### PR TITLE
[CI] Run `pytest` for Pull Requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+# A simple workflow to run tests using pytest against supported Python versions
+
+name: Tests
+on:
+  pull_request:
+    branches-ignore:
+      - docs
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r tests/requirements.txt
+
+    - name: Build
+      run: |
+        python -m pip install .
+
+    - name: Test
+      run: |
+        pytest
+


### PR DESCRIPTION
Part of #21, ensures `pytest` is run for all PRs, preventing merges on failures.

There is a [mirror PR](https://github.com/foundrytom/OpenAssetIO/pull/2) that shows the action running. 