### PR TITLE
[Core] Batch manager methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,38 @@ _should_ be prefixed with `get` and `set`, respectively.
 
 This makes it easier to determine the API surface at a glance.
 
+### Test cases
+
+Where feasible, Python unit test cases should use a class for each unit,
+where the methods of the test class are the test cases for that unit. In
+addition, test cases should ideally be written using `when` and `then`
+to delineate action/input and postcondition. The name of the test class
+itself should begin with `Test_`. For example,
+
+```python
+class Test_UnitName:
+    def test_when_action_then_postcondition(self, ...):
+        ...
+```
+
+Often the unit under test is a class method, in which case the test
+class name should include the method under test preceded by its class, 
+separated by an underscore. For example,
+
+```python
+class Test_ManagerInterface_entityVersionName:
+    ...
+```
+
+Don't be afraid of long test case names (up to the 99 character line 
+length limit).
+
+Sometimes the test is trivial, in that the unit is small and only has 
+one code path. In that case shoehorning a test case description into a 
+`when`/`then` style may be less readable than a simpler ad-hoc 
+alternative. Best judgement should be used, bearing in mind readability
+and consistency tradeoffs.
+
 ### IDE configuration
 
 To aid in conforming to our coding style a [`.editorconfig`](https://editorconfig.org/)

--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -125,7 +125,7 @@
  *
  * # We must **ALWAYS** validate that a string is an entity reference
  * # before passing it to any other manager API call.
- * if not manager.isEntityReference(some_string):
+ * if not manager.isEntityReference([some_string])[0]:
  *    raise ValueError(f'"{some_string}" isn't an entity reference.')
  *
  * # All calls to the manager must have a Context, these should always
@@ -144,7 +144,7 @@
  * context.retention = context.kTransient
  *
  * # We can now resolve a token we may have if it is a reference.
- * resolved_asset = manager.resolveEntityReference(some_string, context)
+ * resolved_asset = manager.resolveEntityReference([some_string], context)[0]
  * @endcode
  *
  * @section example_publishing_a_file Publishing a File
@@ -168,7 +168,7 @@
  * context.locale = APIDocumentationExampleLocale()
  *
  * # The first step is to see if the manager wants to manage text files
- * policy = manager.managementPolicy(file_spec, context)
+ * policy = manager.managementPolicy([file_spec], context)[0]
  *
  * if not policy & constants.kManaged:
  *   # The manager doesn't care about this type of asset
@@ -182,11 +182,11 @@
  * # Whenever we make new data, we always tell the manager first,
  * # This allows it to create a placeholder version or similar.
  * # NOTE: It is critical to always use the working_ref from now on.
- * working_ref = manager.preflight(entity_ref, file_spec, context)
+ * working_ref = manager.preflight([entity_ref], [file_spec], context)[0]
  *
  * # We then check if the manager can tell us where to save the file
  * if policy & constants.kWillManagePath:
- *     save_path = manager.resolveEntityReference(working_ref, context)
+ *     save_path = manager.resolveEntityReference([working_ref], context)[0]
  *
  * # Now we can write the file
  * with open(save_path, 'w') as f:
@@ -196,7 +196,7 @@
  * # is complete. Update the context retention to denote that we're going
  * # to save a reference to this entity in our user's history.
  * context.retention = context.kPermanent
- * final_ref = manager.register(save_path, working_ref, file_spec, context)
+ * final_ref = manager.register([save_path], [working_ref], [file_spec], context)[0]
  *
  * # We can persist this reference as we used the kPermanent retention
  * with open(os.path.join(os.path.expanduser('~'), 'history', 'a') as f:

--- a/doc/src/ManagerState.dox
+++ b/doc/src/ManagerState.dox
@@ -89,7 +89,7 @@
  * worker -> Session : createContext()
  * Session --> worker : context
  * worker -> worker : context.access = context.kWrite
- * worker -> Manager : working_reference = preflight("ref://asset", context)
+ * worker -> Manager : working_reference = preflight(["ref://asset"], context)[0]
  * Manager --> worker : "ref://asset=v4&state=inflight"
  * worker -> TransactionCoordinator : freezeManagerState(context)
  * activate TransactionCoordinator
@@ -114,7 +114,7 @@
  *     deactivate TransactionCoordinator
  *     worker -> worker : context.access = context.kWrite
  *     worker -> worker : working_reference = ref_map["ref://asset"]
- *     worker -> Manager : path = resolveEntityReference(working_reference, context)
+ *     worker -> Manager : path = resolveEntityReference([working_reference], context)[0]
  *     Manager --> worker : "file://out.####.exr"
  *     worker -> worker : write_data(path)
  *     worker --> scheduler
@@ -135,9 +135,9 @@
  * deactivate TransactionCoordinator
  * worker -> worker : context.access = context.kWrite
  * worker -> worker : working_reference = ref_map["ref://asset"]
- * worker -> Manager : path = resolveEntityReference(working_reference, context)
+ * worker -> Manager : path = resolveEntityReference([working_reference], context)[0]
  * Manager --> worker : "file://out.####.exr"
- * worker -> Manager : final_reference = register(path, {}, spec, context)
+ * worker -> Manager : final_reference = register([path], [working_reference], [spec], context)[0]
  * Manager --> worker : "ref://asset=v4"
  * worker -> worker : update_state_file({"ref://asset": final_reference})
  * worker --> scheduler

--- a/doc/src/Transactions.dox
+++ b/doc/src/Transactions.dox
@@ -35,8 +35,8 @@
  *    manager.startTransaction(context)
  *    try:
  *        # Create the shot first, so we can then publish the clips to it
- *        shot_ref = manager.register(shot.name, shot.metadata,
- *                                    shot.spec, entity_ref, context)
+ *        shot_ref = manager.register([shot.name], [shot.metadata],
+ *                                    [shot.spec], [entity_ref], context)[0]
  *        # Register the clips to the shot's entity reference
  *        register_clips(shot.clips, shot_ref, context)
  *    except Exception as e:
@@ -82,8 +82,8 @@
  *    """
  *    with coordinator.scopedActionGroup(context):
  *        # Create the shot so we can publish
- *        shot_ref = manager.register(shot.name, shot.metadata,
- *                                    shot.spec, entity_ref, context)
+ *        shot_ref = manager.register([shot.name], [shot.metadata],
+ *                                    [shot.spec], [entity_ref], context)[0]
  *        # Register the clips to the shots entity reference
  *        register_clips(shot.clips, shot_ref, context)
  *

--- a/python/openassetio/constants.py
+++ b/python/openassetio/constants.py
@@ -51,17 +51,6 @@ kWillManagePath = 8
 ## @}
 
 
-## @name Batch Processing
-## @see openassetio.managerAPI.ManagerInterface.ManagerInterface.preflightMultiple
-## @see openassetio.managerAPI.ManagerInterface.ManagerInterface.registerMultiple
-## @{
-
-## Some Managers may implement the 'batched' API methods, this flag should be
-## set to indicate that the Manage prefers batch operations where possible.
-kSupportsBatchOperations = 16
-
-## @}
-
 ## @name Field Names
 ## Field names are to be used whenever data is get or set from a dictionary by
 ## key, rather than through an accessor in some wrapper class (eg:

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -109,7 +109,7 @@ class Manager(Debuggable):
 
             "org.openassetio.manager.test"
 
-        @return str
+        @return `str`
         """
         return self.__impl.identifier()
 
@@ -123,7 +123,7 @@ class Manager(Debuggable):
 
             "OpenAssetIO Test Manager"
 
-        @return str
+        @return `str`
         """
         return self.__impl.displayName()
 
@@ -174,8 +174,9 @@ class Manager(Debuggable):
         openassetio.hostAPI.terminology.Mapper.replaceTerms
         @see @ref openassetio.hostAPI.terminology.defaultTerminology
 
-        @param stringDict Dict[str, str] this will be modified in-place
-        by the manager if it has any alternate terminology.
+        @param[out] stringDict `Dict[str, str]` Dictionary that is
+        modified in-place by the manager if it has any alternate
+        terminology.
         """
         self.__impl.updateTerminology(stringDict, self.__hostSession)
         # This is purely so we can see it in the debug log, the
@@ -268,12 +269,12 @@ class Manager(Debuggable):
         lifetime is inherently well-managed by your persistence (or not)
         of the context.
 
-        @param references List[@ref entity_reference] A list of
+        @param references `List[` @ref entity_reference `]` A list of
         references to prefetch data for.
 
-        @param context openassetio.Context
+        @param context Context
 
-        @return None
+        @return `None`
         """
         if not isinstance(references, (list, tuple)):
             references = [references, ]

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -1069,6 +1069,9 @@ class Manager(Debuggable):
 
         @return bool, If True, a Thumbnail is desired by the manager, if
         False, the host should not waste time making one.
+
+        @todo Remove this method in favour of using the
+        `preflight`/`register` procedure as with any other entity.
         """
         return self.__impl.thumbnailSpecification(
             specification, context, options, self.__hostSession)

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -1128,6 +1128,9 @@ class ManagerInterface(object):
 
         @return bool, If True, a Thumbnail is desired by the manager, if
         False, the host should not waste time making one.
+
+        @todo Remove this method in favour of using the
+        `preflight`/`register` procedure as with any other entity.
         """
         return False
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -367,20 +367,21 @@ class ManagerInterface(object):
     # @{
 
     @abc.abstractmethod
-    def managementPolicy(self, specification, context, hostSession, entityRef=None):
+    def managementPolicy(self, specifications, context, hostSession, entityRef=None):
         """
         Determines if the asset manager is interested in participating
-        in interactions with the specified specification of @ref entity.
+        in interactions with the specified specifications of @ref
+        entity.
 
         For example, a host may call this in order to see if the manager
         would like to manage the path of a scene file whilst choosing a
         destination to save to.
 
-        This information is then used to determine which options should
-        be presented to the user. For example, if kIgnored was returned
-        for a query as to the management of scene files, a Host will
-        hide or disable menu items that relate to publish or loading of
-        assetised scene files.
+        This information is then used to determine which options
+        should be presented to the user. For example, if `kIgnored`
+        was returned for a query as to the management of scene files,
+        a Host will hide or disable menu items that relate to publish
+        or loading of assetized scene files.
 
         @warning The @ref openassetio.Context.Context.access "access"
         specified in the supplied context should be carefully considered.
@@ -405,19 +406,22 @@ class ManagerInterface(object):
         asset becomes a partially manual task, rather than one that can
         be fully automated for new assets.
 
-        Additionally, the @ref
-        openassetio.constants.kSupportsBatchOperations bit is important
-        if you want hosts to call the *Multiple variants of the @ref
-        preflight and @ref register methods.
+        @param specifications `List[Specification]` Specifications to
+        query.
 
-        @param entityRef str, If supplied, then the call should be
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @param entityRef `str` If supplied, then the call should be
         interpreted as a query as to the applicability of the given
-        specification if registered to the supplied entity. For example,
-        attempts to register an ImageSpecification to an entity
-        reference that refers to the top level project may be
-        meaningless, so in this case kIgnored should be returned.
+        specifications if registered to the supplied entity. For
+        example, attempts to register an ImageSpecification to an
+        entity reference that refers to the top level project may be
+        meaningless, so in this case `kIgnored` should be returned.
 
-        @return int, a bitfield, see @ref openassetio.constants
+        @return `List[int]` Bitfields, one for each element in
+        `specifications`. See @ref openassetio.constants.
         """
         raise NotImplementedError
 
@@ -433,32 +437,35 @@ class ManagerInterface(object):
     # @{
 
     @abc.abstractmethod
-    def isEntityReference(self, token, context, hostSession):
+    def isEntityReference(self, tokens, context, hostSession):
         """
-        Determines if a supplied token (in its entirety) matches the
+        Determines if each supplied token (in its entirety) matches the
         pattern of a valid @ref entity_reference in your system.  It
         does not need to verify that it points to a valid entity in the
         system, simply that the pattern of the token is recognised by
         this implementation.
 
-        If this returns True, the token is an @ref entity_reference and
-        should be considered usable with the other methods of this
+        If this returns `True`, the token is an @ref entity_reference
+        and should be considered usable with the other methods of this
         interface.
 
-        If false, this manager should no longer be involved in actions
+        If `False`, this manager should no longer be involved in actions
         relating to the token.
 
         @warning The result of this call should not depend on the
         context Locale.
 
-        @param token The string to be inspected.
+        @param tokens `List[str]` The strings to be inspected.
 
-        @param context openassetio.Context, The calling context.
+        @param context Context The calling context.
 
-        @return bool, True if the supplied token should be considered as
-        an @ref entity_reference, False if the pattern is not recognised.
+        @param hostSession HostSession The API session.
 
-        @note This call should not verify the entity exits, just that
+        @return `List[bool]` `True` if the supplied token should be
+        considered as an @ref entity_reference, `False` if the pattern is
+        not recognised.
+
+        @note This call should not verify an entity exits, just that
         the format of the string is recognised.
 
         @see entityExists()
@@ -467,12 +474,12 @@ class ManagerInterface(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def entityExists(self, entityRef, context, hostSession):
+    def entityExists(self, entityRefs, context, hostSession):
         """
-        Called to determine if the supplied @ref entity_reference points
-        to an entity that does exist in the @ref
-        asset_management_system, and that it can be resolved into a
-        meaningful string or otherwise queried.
+        Called to determine if each @ref entity_reference supplied
+        points to an entity that exists in the @ref
+        asset_management_system, and that they can be resolved into
+        a meaningful string or otherwise queried.
 
         By 'exist' we mean 'is ready to be read'. For example,
         entityExists may be called before attempting to read from a
@@ -483,15 +490,22 @@ class ManagerInterface(object):
         complex definition of 'existence' (for example, known to the
         system, but not yet finalized). For now however, it should be
         assumed to simply mean, 'ready to be consumed', and if only a
-        placeholder or un-finalized asset is available, False should be
-        returned.
+        placeholder or un-finalized asset is available, `False` should
+        be returned.
 
         The supplied context's locale may contain information pertinent
         to disambiguating this subtle definition of 'exists' in some
         cases too, as it better explains the use-case of the call.
 
-        @return bool, True if it points to an existing entity, False if
-        the entity is not known or ready yet.
+        @param entityRefs `List[str]` Entity references to query.
+
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @return `List[bool]` `True` if the corresponding element in
+        entityRefs points to an existing entity, `False` if the entity
+        is not known or ready yet.
         """
         raise NotImplementedError
 
@@ -512,18 +526,18 @@ class ManagerInterface(object):
     # @{
 
     @abc.abstractmethod
-    def resolveEntityReference(self, entityRef, context, hostSession):
+    def resolveEntityReference(self, entityRefs, context, hostSession):
         """
-        Returns the 'finalized' string represented by the @ref
+        Returns the @ref primary_string represented by each given @ref
         entity_reference.
 
-        If the string points to some data, then it should always be in
-        the form of a valid URL. File paths should be returned as a
-        `file` scheme URL.
+        If a primary string points to some data, then it should
+        always be in the form of a valid URL. File paths should be
+        returned as a `file` scheme URL.
 
-        When the @ref entity_reference points to a sequence of files,
-        the frame token should be preserved, and in the sprintf
-        compatible syntax.
+        When an @ref entity_reference points to a sequence of files,
+        the frame, view, etc substitution tokens should be preserved,
+        and in the sprintf compatible syntax.
 
         This function should attempt to take into account the current
         host/Context to ensure that any other substitution tokens are
@@ -533,70 +547,65 @@ class ManagerInterface(object):
         entity reference for write.
 
         The caller will have first called isEntityReference() on the
-        supplied string.
+        supplied strings.
 
         @note You may need to call finalizedEntityVersion() within
         this function to ensure any @ref meta_version "meta-versions"
         are resolved prior to resolution.
 
-        @return str, The string that that is represented by the
-        reference.
+        @param entityRefs `List[str]` Entity references to query.
 
-        @exception openassetio.exceptions.EntityResolutionError If the
-        supplied @ref entity_reference does not have a meaningful string
-        representation, or it is a valid reference format, that doesn't
-        exist.
-        @exception openassetio.exceptions.InvalidEntityReference if the
-        supplied entity_reference should not be resolved for that
-        context, for example, if the context access is kWrite and the
-        entity is an existing version - raising will ensure that a Host
-        will not attempt to write to that location.
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @return `List[Union[str,`
+            exceptions.EntityResolutionError,
+            exceptions.InvalidEntityReference `]]`
+        A list containing either the primary string for each
+        reference; `EntityResolutionError` if a supplied entity
+        reference does not have a meaningful string representation,
+        or it is a valid reference format that doesn't exist; or
+        `InvalidEntityReference` if a supplied entity reference should
+        not be resolved for that context, for example, if the context
+        access is `kWrite` and the entity is an existing version.
 
         @see entityExists()
         @see isEntityReference()
-        @see resolveEntityReferences()
         """
         raise NotImplementedError
 
-    def resolveEntityReferences(self, references, context, hostSession):
-        """
-        Batch-resolves a list of @ref entity_reference
-        "entity references", following the same pattern as @ref
-        resolveEntityReference.
-
-        @return List[str], A list of strings, corresponding to the
-        source reference with the same index.
-
-        This will be called by hosts when they wish to batch-resolve
-        many references with an eye to performance, or server hits, and
-        so should be re-implemented to minimize the number of queries
-        over a standard 'for' loop.
-
-        The base class implementation simply calls
-        resolveEntityReference repeatedly for each supplied reference.
-        """
-        resolved = []
-        for r in references:
-            resolved.append(self.resolveEntityReference(r, context, hostSession))
-        return resolved
-
-    def defaultEntityReference(self, specification, context, hostSession):
+    def defaultEntityReference(self, specifications, context, hostSession):
         """
         Returns an @ref entity_reference considered to be a sensible
-        default for the given specification and Context. This is often
-        used in a host to ensure dialogs, prompts or publish locations
-        default to some sensible value, avoiding the need for a user to
-        re-enter such information when a Host is being run in some known
-        environment.
+        default for each of the given specifications and Context. This
+        is often used in a host to ensure dialogs, prompts or publish
+        locations default to some sensible value, avoiding the need for
+        a user to re-enter such information when a Host is being run in
+        some known environment.
 
         For example, a host may request the default ref for
         'ShotSpecification/kWriteMultiple'. If the Manager has some
         concept of the 'current sequence' it may wish to return this so
         that a 'Create Shots' starts somewhere meaningful.
 
-        @return str, A valid @ref entity_reference, or empty string.
+        @param specifications `List[`
+            specifications.EntitySpecification `]`
+        The relevant specifications for the type of entities a host is
+        about to work with. These should be interpreted in conjunction
+        with the context to determine the most sensible default.
+
+        @param context Context The context the resulting reference
+        will be used in. When determining a suitable reference to
+        return, it is important to pay particular attention to the
+        access pattern. It differentiates between a reference that
+        will be used for reading or writing, and critically single or
+        multiple entities.
+
+        @return `List[str]` An @ref entity_reference or empty string for
+        each given specification.
         """
-        return ''
+        return ["" for _ in specifications]
 
     ## @}
 
@@ -614,9 +623,9 @@ class ManagerInterface(object):
     # @{
 
     @abc.abstractmethod
-    def entityName(self, entityRef, context, hostSession):
+    def entityName(self, entityRefs, context, hostSession):
         """
-        Returns the name of the entity itself, not including any
+        Returns the name of each entity itself, not including any
         hierarchy or classification.
 
         For example:
@@ -624,15 +633,21 @@ class ManagerInterface(object):
          @li `"Cuttlefish v1"` - for a version of an asset
          @li `"seq003"` - for a sequence in a hierarchy
 
-        @return str, A string containing any valid characters for the
-        manager's implementation.
+        @param entityRefs `List[str]` Entity references to query.
+
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @return `List[str]` Strings containing any valid characters for
+        the manager's implementation.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def entityDisplayName(self, entityRef, context, hostSession):
+    def entityDisplayName(self, entityRefs, context, hostSession):
         """
-        Returns an unambiguous, humanised display name for the entity.
+        Returns an unambiguous, humanised display name for each entity.
 
         The display name may want to consider the host, and any other
         relevant Context information to form a display name for an
@@ -645,19 +660,24 @@ class ManagerInterface(object):
          @li `"Sequence 003 [ Dive / Episode 1 ]"` - for a sequence in
          an hierarchy as a window title.
 
-        @return str, A string containing any valid characters for the
-        @ref asset_management_system's implementation.
+        @param entityRefs `List[str]` Entity references to query.
 
-        @exception openassetio.exceptions.InvalidEntityReference If any
-        supplied reference is not recognised by the asset management
-        system.
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @return `List[Union[str,` exceptions.InvalidEntityReference `]]`
+        For each given entity, either a string containing any valid
+        characters for the @ref asset_management_system's
+        implementation; or an `InvalidEntityReference` if the supplied
+        reference is not recognised by the asset management system.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def getEntityMetadata(self, entityRef, context, hostSession):
+    def getEntityMetadata(self, entityRefs, context, hostSession):
         """
-        Retrieve @ref metadata for an entity.
+        Retrieve @ref metadata for each given entity.
 
         It may be required to bridge between certain 'first-class'
         properties of your asset management system and the well-known
@@ -670,20 +690,21 @@ class ManagerInterface(object):
         @warning See @ref setEntityMetadata for important notes on
         metadata and its role in the system.
 
-        @return Dict[str,primitive], with the entity's metadata. Values
-        must be singular plain-old-data types (ie. string, int, float,
-        bool), keys must be strings.
+        @param entityRefs `List[str]` Entity references to query.
+
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @return `List[Dict[str, primitive]]` Metadata for each entity.
+        Values must be singular plain-old-data types (ie. string,
+        int, float, bool), keys must be strings.
         """
         raise NotImplementedError
 
-    def setEntityMetadata(self, entityRef, data, context, hostSession, merge=True):
+    def setEntityMetadata(self, entityRefs, data, context, hostSession, merge=True):
         """
-        Sets an entities metadata.
-
-        @param merge, bool If true, then the entity's existing metadata
-        will be merged with the new data (the new data taking
-        precedence). If false, its metadata will entirely replaced by
-        the new data.
+        Sets metadata on each given entity.
 
         @note It is a vital that the implementation faithfully stores
         and recalls metadata. It is the underlying mechanism by which
@@ -694,41 +715,58 @@ class ManagerInterface(object):
         If any value is 'None' it should be assumed that that key should
         be un-set on the object.
 
+        @param entityRefs List[str] Entity references to update.
+
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @param merge bool If true, then each entity's existing metadata
+        will be merged with the new data (the new data taking
+        precedence). If false, its metadata will entirely replaced by
+        the new data.
+
         @exception ValueError if any of the metadata values are of an
         un-storable type. Presently it is only required to store str,
         float, int, bool
         """
         raise NotImplementedError
 
-    def getEntityMetadataEntry(self, entityRef, key, context, hostSession, defaultValue=None):
+    def getEntityMetadataEntry(self, entityRefs, key, context, hostSession, defaultValue=None):
         """
-        Returns the value for the specified metadata key.
+        Retrieve the value of the given metadata key for each given
+        entity.
+
+        The default implementation retrieves all metadata for each
+        entity and extracts the requested key.
 
         @see getEntityMetadata
 
-        @param key str, The key to look up
-        @param defaultValue primitive, If not None, this value will be
-        returned in the case of the specified key not being set for the
-        entity.
+        @param entityRefs `List[str]` Entity references to query.
 
-        @return primitive, The value for the specific key.
+        @param key `str` The key to look up
 
-        @exception KeyError If no defaultValue is supplied, and the
-        entity has no metadata for the specified key.
+        @param defaultValue `primitive` If not None, this value should
+        be returned in the case of the specified key not being set for
+        an entity.
 
-        The default implementation retrieves all metadata for an entity
-        and extracts the requested key.
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @return `Union[primitive, KeyError]` The value for the specific
+        key, or `KeyError` if not found and no defaultValue is supplied.
         """
         value = defaultValue
         try:
-            value = self.getEntityMetadata(entityRef, context, hostSession)[key]
+            value = self.getEntityMetadata(entityRefs, context, hostSession)[key]
         except KeyError:
             if defaultValue is None:
                 raise
         return value
 
-    def setEntityMetadataEntry(self, entityRef, key, value, context, hostSession):
-        self.setEntityMetadata(entityRef, {key: value}, context, hostSession, merge=True)
+    def setEntityMetadataEntry(self, entityRefs, key, value, context, hostSession):
+        self.setEntityMetadata(entityRefs, {key: value}, context, hostSession, merge=True)
 
     ## @}
 
@@ -743,86 +781,98 @@ class ManagerInterface(object):
     #
     # @{
 
-    def entityVersionName(self, entityRef, context, hostSession):
+    def entityVersionName(self, entityRefs, context, hostSession):
         """
-        Retrieves the name of the version pointed to by the supplied
+        Retrieves the name of the version pointed to by each supplied
         @ref entity_reference.
 
-        @return str, A string representing the version or an empty
-        string if the entity was not versioned.
+        @param entityRefs `List[str]` Entity references to query.
+
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @return `List[str]` A string for each entity representing its
+        version, or an empty string if the entity was not versioned.
 
         @note It is not necessarily a requirement that the entity
         exists, if, for example, the version name can be determined from
         the reference itself (in systems that implement a human-readable
-        url, for example)
+        URL, for example)
 
         @see entityVersions()
         @see finalizedEntityVersion()
         """
-        return ""
+        return ["" for _ in entityRefs]
 
     def entityVersions(
-            self, entityRef, context, hostSession, includeMetaVersions=False, maxResults=-1):
+            self, entityRefs, context, hostSession, includeMetaVersions=False, maxNumVersions=-1):
         """
-        Retrieves all available versions of the supplied @ref
+        Retrieves all available versions of each supplied @ref
         entity_reference (including the supplied ref, if it points to a
         specific version).
 
-        @param includeMetaVersions bool, if true, @ref meta_version
+        @param entityRefs `List[str]` Entity references to query.
+
+        @param context Context The calling context.
+
+        @param hostSession HostSession The API session.
+
+        @param includeMetaVersions `bool` If `True`, @ref meta_version
         "meta-versions" such as 'latest', etc... should be included,
         otherwise, only concrete versions need to be returned.
 
-        @param maxResults int, Limits the number of results collected,
-        if more results are available than the limit, then the newest
-        versions should be returned. If a value of -1 is used, then all
-        results should be returned.
+        @param maxNumVersions `int` Limits the number of versions
+        collected for each entity. If more results are available than
+        the limit, then the newest versions should be returned. If a
+        value of -1 is used, then all results should be returned.
 
-        @return Dict[str,str], Where the keys are string versions, and
-        the values are an @ref entity_reference that points to that
-        versions entity. Additionally the
-        openassetio.constants.kVersionDict_OrderKey can be set to a list
-        of the version names (ie: dict keys) in their natural ascending
-        order, that may be used by UI elements, etc...
+        @return `List[Dict[str, str]]` A dictionary for each entity,
+        where the keys are string versions, and the values are an
+        @ref entity_reference that points to its entity. Additionally
+        the openassetio.constants.kVersionDict_OrderKey can be set to
+        a list of the version names (ie: dict keys) in their natural
+        ascending order, that may be used by UI elements, etc.
 
         @see entityVersionName()
         @see finalizedEntityVersion()
         """
-        return {}
+        return [{} for _ in entityRefs]
 
-    def finalizedEntityVersion(self, entityRef, context, hostSession, overrideVersionName=None):
+    def finalizedEntityVersion(self, entityRefs, context, hostSession, overrideVersionName=None):
         """
-        Retrieves an @ref entity_reference that points to the concrete
-        version of a @ref meta_version or otherwise unstable @ref
-        entity_reference.
+        Retrieves an @ref entity_reference that points to the
+        concrete version for each given @ref meta_version or
+        otherwise unstable @ref entity_reference.
 
-        If the supplied entity reference is not versioned, or already
+        If a supplied entity reference is not versioned, or already
         has a concrete version, the input reference should be
         passed-through.
 
-        If versioning is unsupported for the given @ref
+        If versioning is unsupported for a given @ref
         entity_reference, then the input reference should be returned.
 
-        @param overrideVersionName str If supplied, then the call should
-        return the entity reference for the version of the referenced
-        asset that matches the name specified here, ignoring any version
-        inferred by the input reference.
+        @param overrideVersionName `str` If supplied, then the call
+        should return entity references for the version of the
+        referenced assets that match the name specified here, ignoring
+        any version inferred by the input reference.
 
-        @return str
-
-        @exception openassetio.exceptions.EntityResolutionError should
-        be thrown if the entityReference is ambiguously versioned (for
-        example if the version is missing from a reference to a
-        versioned entity, and that behavior is undefined in the system
-        managers model. It may be that it makes sense in the specific
-        asset manager to fall back on 'latest' in this case...)
-
-        @exception openassetio.exceptions.EntityResolutionError if the
-        supplied overrideVersionName does not exist for that entity.
+        @return `List[Union[str,` exceptions.EntityResolutionError `]]`
+        A list where each element is either the concretely versioned
+        reference, or `EntityResolutionError`. An
+        `EntityResolutionError` should be returned if the entity
+        reference is ambiguously versioned or if the supplied
+        `overrideVersionName` does not exist for that entity. For
+        example, if the version is missing from a reference to a
+        versioned entity, and that behavior is undefined in the
+        manager's model, then an `EntityResolutionError` should be
+        returned. It may be that it makes sense in the specific asset
+        manager to fall back on 'latest' in this case.
 
         @see entityVersionName()
         @see entityVersions()
         """
-        return entityRef
+        return entityRefs
 
     ## @}
 
@@ -1073,7 +1123,7 @@ class ManagerInterface(object):
         """
         return False
 
-    def preflight(self, targetEntityRef, entitySpec, context, hostSession):
+    def preflight(self, targetEntityRefs, entitySpecs, context, hostSession):
         """
         Prepares for some work to be done to create data for the
         referenced entity. The entity may not yet exist (@ref
@@ -1083,66 +1133,55 @@ class ManagerInterface(object):
 
         Generally, this will be called before register() in any host
         that creates media, where the return to @ref managementPolicy
-        has the @ref openassetio.constants.kWillManagePath bit set.
+        has the constants.kWillManagePath bit set.
 
-        @param targetEntityRef str, a @ref entity_reference that it is
-        desired to publish the forthcoming data to. See the notes in the
-        API documentation for the specifics of this.
+        @param targetEntityRefs `List[str]` An @ref entity_reference
+        for each entity that it is desired to publish the forthcoming
+        data to. See the notes in the API documentation for the
+        specifics of this.
 
-        @note it is important for the implementation to pay attention to
-        @ref openassetio.Context.Context.retention "Context.retention",
-        as not all hosts will support the reference changing at this point.
+        @param entitySpecs `List[`
+            specifications.EntitySpecification `]`
+        A description of each entity that is being published.
 
-        @return str, An @ref entity_reference, that the host should
-        resolve to determine the path to write media too. This may or
-        may not be the same as the input reference. A host will resolve
-        this reference to get the working URL before writing any files
-        or other data.
+        @param context Context The calling context. This is not
+        replaced with an array in order to simplify implementation.
+        Otherwise, transactional handling has the potential to be
+        extremely complex if different contexts are allowed.
 
-        @exception openassetio.exceptions.PreflightError if some fatal
-        exception happens during preflight, indicating the process
-        should be aborted.
+        @param hostSession HostSession The API session.
 
-        @exception openassetio.exceptions.RetryableError If any
-        non-fatal error occurs that means the host should re-try from
-        the beginning of any given process.
+        @return `List[Union[str,`
+            exceptions.PreflightError, exceptions.RetryableError `]]`
+        The preflight result for each corresponding entity. If
+        successful, this should be an @ref entity_reference that the
+        host should resolve to determine the path to write media to.
+        This may or may not be the same as the input reference. A host
+        will resolve this reference to get the working URL before
+        writing any files or other data. If preflight was
+        unsuccessful, the result for an entity should be either a
+        `PreflightError` if some fatal exception happens during
+        preflight, indicating the process should be aborted; or
+        `RetryableError` if any non-fatal error occurs that means the
+        host should retry from the beginning of any given process.
+
+        @note it is important for the implementation to pay attention
+        to @ref openassetio.Context.Context.retention
+        "Context.retention", as not all hosts will support the
+        reference changing at this point.
 
         @see register()
         """
-        return targetEntityRef
+        return targetEntityRefs
 
-    def preflightMultiple(self, targetEntityRefs, entitySpecs, context, hostSession):
+    def register(self, primaryStrings, targetEntityRefs, entitySpecs, context, hostSession):
         """
-        A batch version of @ref preflight, where most arguments are
-        replaced by arrays of equal length. Exception behavior, etc...
-        is the same as per preflight, and should be thrown mid way
-        though preflight if necessary.
-
-        This will be used in preference to calling preflight many times
-        in succession to allow the implementation to optimise
-        communication with the back end asset management system.
-
-        @param context Context, is not replaced with an array in order
-        to simplify implementation. Otherwise, transactional handling
-        has the potential to be extremely complex if different contexts
-        are allowed.
-
-
-        @return List[str], A list of working entity references.
-        """
-        result = []
-        for t, s in zip(targetEntityRefs, entitySpecs):
-            result.append(self.preflight(t, s, context, hostSession))
-        return result
-
-    def register(self, stringData, targetEntityRef, entitySpec, context, hostSession):
-        """
-        Publish an entity to the @ref asset_management_system.
+        Publish entities to the @ref asset_management_system.
 
         This instructs the implementation to ensure a valid entity
-        exists for the given reference and spec. This will be called
+        exists for each given reference and spec. This will be called
         either in isolation or after calling preflight, depending on the
-        nature of the data being published and the kWillManagePath bit
+        nature of the data being published and the `kWillManagePath` bit
         of the returned @ref managementPolicy.
 
         This is an opportunity to do other things in the host as part of
@@ -1153,77 +1192,62 @@ class ManagerInterface(object):
         information or schedule additional processes to produce
         derivative data.
 
-        @param stringData str, The string that the entity should resolve
-        to if passed to a call to resolveEntityReference(). This may be
-        left blank, if there is no meaningful string representation of
-        that entity (eg: a 'sequence' in a hierarchy). This must be
-        stored by the manager and a logically equivalent value returned
-        by @ref resolveEntityReference for the same reference. The
-        meaning of 'logical' here, is that in the case of an URL, that
-        it points to the same data. The manager is free to relocate data
-        as required. If stringData is not an URL, then it should be
+        @param primaryStrings `List[str]` The @ref primary_string that
+        each entity should resolve to if passed to a call to
+        resolveEntityReference(). This may be left blank if there is
+        no meaningful string representation of that entity (eg: a
+        'sequence' in a hierarchy). This must be stored by the
+        manager and a logically equivalent value returned by @ref
+        resolveEntityReference for the same reference. The meaning of
+        'logical' here, in the case of a URL, is that it points to
+        the same data. The manager is free to relocate data as
+        required. If a primary string is not a URL, then it should be
         returned verbatim.
 
-        @param targetReference The @ref entity_reference to publish to.
-        It is up to the manager to ensure that this is meaningful, as it
-        is most likely implementation specific. For example, if a 'Shot'
-        specification is requested to be published to a reference that
-        points to a 'Sequence' it makes sense to interpret this as a
-        'add a shot of this spec to the sequence'. For other types of
-        entity, there may be different constraints on what makes sense.
+        @param targetEntityRefs `List[str]` The @ref entity_reference
+        of each entity to publish. It is up to the manager to ensure
+        that this is meaningful, as it is most likely implementation
+        specific. For example, if a 'Shot' specification is requested
+        to be published to a reference that points to a 'Sequence' it
+        makes sense to interpret this as a 'add a shot of this spec
+        to the sequence'. For other types of entity, there may be
+        different constraints on what makes sense.
 
-        @param entitySpec openassetio.specifications.EntitySpecification
-        A description of the Entity (or 'asset') that is being
-        published. It is *not* required for the implementation to store
-        any information contained in the specification, though it may
-        choose to use it if it is meaningful. The host will separately
-        call setEntityMetadata() if it wishes to persist any other
-        information in the entity.
+        @param entitySpecs `List[`
+            specifications.EntitySpecification `]`
+        A description of each entity (or 'asset') that is being
+        published. It is *not* required for the implementation to
+        store any information contained in the specification, though
+        it may choose to use it if it is meaningful. The host will
+        separately call setEntityMetadata() if it wishes to persist
+        any other information in an entity.
 
-        @return str, An @ref entity_reference to the 'final' entity
-        created by the publish action. It does not need to be the same
-        as targetReference.
+        @param context Context The calling context. This is not
+        replaced with an array in order to simplify implementation.
+        Otherwise, transactional handling has the potential to be
+        extremely complex if different contexts are allowed.
+
+        @param hostSession HostSession The API session.
+
+        @return `List[Union[str,`
+            exceptions.RegistrationError, exceptions.RetryableError `]]`
+        The publish result for each corresponding entity. This is
+        either an @ref entity_reference to the 'final' entity created
+        by the publish action (which does not need to be the same as
+        the corresponding entry in `targetEntityRefs`); a
+        `RegistrationError` if some fatal exception happens during
+        publishing, indicating the process should be aborted; or
+        `RetryableError` if any non-fatal error occurs that means the
+        host should retry from the beginning of any given process.
 
         @note it is important for the implementation to pay attention to
         openassetio.Context.Context.retention, as not all Hosts will
         support the reference changing at this point.
 
-        @exception openassetio.exceptions.RegistrationError if some
-        fatal exception happens during publishing, indicating the
-        process should be aborted.
-
-        @exception openassetio.exceptions.RetryableError If any
-        non-fatal error occurs that means the host should re-try from
-        the beginning of any given process.
-
         @see preflight()
         @see resolveEntityReference()
         """
         raise NotImplementedError
-
-    def registerMultiple(self, strings, targetEntityRefs, entitySpecs, context, hostSession):
-        """
-        A batch version of @ref register, where most arguments are
-        replaced by arrays of equal length. Exception behavior, etc...
-        is the same as per register, and should be thrown mid way though
-        registration if necessary.
-
-        This will be used in preference to calling register many times
-        in succession to allow the implementation to optimise
-        communication with the back end asset management system.
-
-        @param context Context, is not replaced with an array in order
-        to simplify implementation. Otherwise, transactional handling
-        has the potential to be extremely complex if different contexts
-        are allowed.
-
-
-        @return List[str], A list of finalized entity references.
-        """
-        result = []
-        for d, t, s in zip(strings, targetEntityRefs, entitySpecs):
-            result.append(self.register(d, t, s, context, hostSession))
-        return result
 
     ## @}
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -34,6 +34,14 @@ class ManagerInterface(object):
       entity_reference. objects should not be used to represent an @ref
       entity or its properties.
 
+      @li The manager plugin is expected to be batch-first. That is,
+      where relevant, methods expect lists as their primary input
+      parameters, and return a list as the result. This means a host
+      can batch together multiple items and execute the same command
+      on every item in the list in a single call, saving on
+      potentially expensive round-trips and allowing the manager to
+      use other back-end optimisations.
+
       @li The interface is stateless as far as the host-facing API is
       concerned. The result of any method should solely depend on its
       inputs. This class could be static. In practice though, in a

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -77,8 +77,8 @@ class ManagerInterface(object):
 
     Exceptions should be thrown to handle any in-flight errors that
     occur.  The error should be mapped to a derived class of
-    openassetio.exceptions.OAIOException, and thrown.  All exceptions of
-    this kind, will be correctly passed across the plug-in C boundary,
+    exceptions.OAIOException, and thrown.  All exceptions of this
+    kind, will be correctly passed across the plug-in C boundary,
     and re-thrown. Other exceptions should not be used.
 
      @see openassetio.exceptions
@@ -201,7 +201,7 @@ class ManagerInterface(object):
 
             "org.openassetio.manager.test"
 
-        @return str
+        @return `str`
         """
         raise NotImplementedError
 
@@ -262,7 +262,7 @@ class ManagerInterface(object):
         read "Release Clip", so you would set the @ref openassetio.hostAPI.terminology.kTerm_Publish
         value to "Release".
 
-        @return None
+        @return `None`
 
         @see @ref openassetio.constants
         @see @ref openassetio.hostAPI.terminology.defaultTerminology
@@ -346,14 +346,14 @@ class ManagerInterface(object):
         designated thread safe, it is important to implement any
         pre-fetch mechanism with suitable locks/etc... if required.
 
-        @param context openassetio.Context, You may wish to make use of
+        @param context openassetio.Context You may wish to make use of
         the managerInterfaceState object (if you supplied one on
         construction of the context), to simplify scoping any caching of
         data. Otherwise, it's up to you how to manage the lifetime of
         the data to avoid inconsistencies, but the @ref flushCaches
         method should clear any otherwise sorted data for this call.
 
-        @return None
+        @return `None`
         """
         pass
 
@@ -1320,13 +1320,13 @@ class ManagerInterface(object):
         that is open in the parent state. So the returned state should
         have any open transactions.
 
-        @return object, Some object that represents self-contained state
-        of the ManagerInterface. This will be passed to future calls and
-        to the transactional methods. Presently this can be any hashable
-        object.
+        @return `object` Some object that represents self-contained
+        state of the ManagerInterface. This will be passed to future
+        calls and to the transactional methods. Presently this can be
+        any hashable object.
 
-        @exception openassetio.exceptions.StateError If for some reason
-        creation fails.
+        @exception exceptions.StateError If for some reason creation
+        fails.
 
         @see startTransaction()
         @see finishTransaction()
@@ -1357,10 +1357,10 @@ class ManagerInterface(object):
         any state relating to the transaction within the
         ManagerInterface instance itself.
 
-        @return None
+        @return `None`
 
-        @exception openassetio.exceptions.StateError If for some reason
-        the action fails.
+        @exception exceptions.StateError If for some reason the action
+        fails.
 
         @see createState()
         @see finishTransaction()
@@ -1384,10 +1384,10 @@ class ManagerInterface(object):
         This method **must** only use or store any persistent state from
         the supplied state object to ensure the API is stateless.
 
-        @return None
+        @return `None`
 
-        @exception openassetio.exceptions.StateError If for some reason
-        the action fails, or finish is called before start.
+        @exception exceptions.StateError If for some reason the action
+        fails, or finish is called before start.
 
         @see createState()
         @see startTransaction()
@@ -1452,12 +1452,11 @@ class ManagerInterface(object):
         object,(created by @ref createState) so that can be restored
         later, or in another process.
 
-        After calling this, the state should be considered frozen, and
-        any further cancel/finish calls should throw a @ref
-        openassetio.exceptions.StateError if made without first thawing
-        the stack.
+        After calling this, the state should be considered frozen,
+        and any further cancel/finish calls should throw a @ref
+        exceptions.StateError if made without first thawing the stack.
 
-        @return A string that can be used to restore the stack.
+        @return `str` A string that can be used to restore the stack.
 
         @see thawState()
         @see The @ref transactions page.
@@ -1468,13 +1467,12 @@ class ManagerInterface(object):
         """
         Restores the supplied state object to a previously frozen state.
 
-        @return object A state object, as per createState(), except
+        @return `object` A state object, as per createState(), except
         restored to the previous state encapsulated in the token, which
         is the same string as returned by freezeState.
 
-        @exception openassetio.exceptions.StateError If the supplied
-        token is not meaningful, or that a state has already been
-        thawed.
+        @exception exceptions.StateError If the supplied token is not
+        meaningful, or that a state has already been thawed.
         """
         return None
 

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+import inspect
 
 import pytest
 from unittest import mock
@@ -25,9 +26,154 @@ from openassetio.managerAPI import HostSession, ManagerInterface
 
 ## @todo Remove comments regarding Entity methods when splitting them from core API
 
+
+class ValidatingMockManagerInterface(ManagerInterface):
+    """
+    `ManagerInterface` implementation that asserts parameter types.
+
+    Using this (wrapped in a mock) then allows us to update the API
+    test-first, i.e. provide a failing test that gives a starting point
+    for TDD.
+
+    @see mock_manager_interface
+    """
+
+    def info(self):
+        return mock.DEFAULT
+
+    def updateTerminology(self, stringDict, hostSession):
+        return mock.DEFAULT
+
+    def getSettings(self, hostSession):
+        return mock.DEFAULT
+
+    def setSettings(self, settings, hostSession):
+        return mock.DEFAULT
+
+    def prefetch(self, entitRefs, context, hostSession):
+        return mock.DEFAULT
+
+    def flushCaches(self, hostSession):
+        return mock.DEFAULT
+
+    def resolveEntityReferences(self, references, context, hostSession):
+        return mock.DEFAULT
+
+    def defaultEntityReference(self, specification, context, hostSession):
+        return mock.DEFAULT
+
+    def getEntityMetadataEntry(self, entityRef, key, context, hostSession, defaultValue=None):
+        return mock.DEFAULT
+
+    def setEntityMetadataEntry(self, entityRef, key, value, context, hostSession):
+        return mock.DEFAULT
+
+    def entityVersionName(self, entityRef, context, hostSession):
+        return mock.DEFAULT
+
+    def entityVersions(
+            self, entityRef, context, hostSession, includeMetaVersions=False, maxResults=-1):
+        return mock.DEFAULT
+
+    def finalizedEntityVersion(self, entityRef, context, hostSession, overrideVersionName=None):
+        return mock.DEFAULT
+
+    def setRelatedReferences(
+            self, entityRef, relationshipSpec, relatedRefs, context, hostSession, append=True):
+        return mock.DEFAULT
+
+    def thumbnailSpecification(self, specification, context, options, hostSession):
+        return mock.DEFAULT
+
+    def preflight(self, targetEntityRef, entitySpec, context, hostSession):
+        return mock.DEFAULT
+
+    def preflightMultiple(self, targetEntityRefs, entitySpecs, context, hostSession):
+        return mock.DEFAULT
+
+    def registerMultiple(self, strings, targetEntityRefs, entitySpecs, context, hostSession):
+        return mock.DEFAULT
+
+    def createState(self, hostSession, parentState=None):
+        return mock.DEFAULT
+
+    def startTransaction(self, state, hostSession):
+        return mock.DEFAULT
+
+    def finishTransaction(self, state, hostSession):
+        return mock.DEFAULT
+
+    def cancelTransaction(self, state, hostSession):
+        return mock.DEFAULT
+
+    def freezeState(self, state, hostSession):
+        return mock.DEFAULT
+
+    def thawState(self, token, hostSession):
+        return mock.DEFAULT
+
+    def identifier(self):
+        return mock.DEFAULT
+
+    def displayName(self):
+        return mock.DEFAULT
+
+    def initialize(self, hostSession):
+        return mock.DEFAULT
+
+    def managementPolicy(self, specification, context, hostSession, entityRef=None):
+        return mock.DEFAULT
+
+    def isEntityReference(self, token, context, hostSession):
+        return mock.DEFAULT
+
+    def entityExists(self, entityRef, context, hostSession):
+        return mock.DEFAULT
+
+    def resolveEntityReference(self, entityRef, context, hostSession):
+        return mock.DEFAULT
+
+    def entityName(self, entityRef, context, hostSession):
+        return mock.DEFAULT
+
+    def entityDisplayName(self, entityRef, context, hostSession):
+        return mock.DEFAULT
+
+    def getEntityMetadata(self, entityRef, context, hostSession):
+        return mock.DEFAULT
+
+    def setEntityMetadata(self, entityRef, data, context, hostSession, merge=True):
+        return mock.DEFAULT
+
+    def getRelatedReferences(
+            self, entityRefs, relationshipSpecs, context, hostSession, resultSpec=None):
+        return mock.DEFAULT
+
+    def register(self, stringData, targetEntityRef, entitySpec, context, hostSession):
+        return mock.DEFAULT
+
+
 @pytest.fixture
 def mock_manager_interface():
-    return mock.create_autospec(spec=ManagerInterface)
+    """
+    Fixture for a mock `ManagerInterface` that asserts parameter types.
+
+    Return a mock `autospec`ed to the `ManagerInterface`, with each
+    mocked method set up to `side_effect` to the corresponding
+    method in `ValidatingMockManagerInterface`.
+
+    This then means method parameter types will be `assert`ed, whilst
+    still providing full `MagicMock` functionality.
+    """
+    interface = ValidatingMockManagerInterface()
+    mockInterface = mock.create_autospec(spec=interface, spec_set=True)
+    # Set the `side_effect` of each mocked method to call through to
+    # the concrete instance.
+    methods = inspect.getmembers(interface, predicate=inspect.ismethod)
+    for name, method in methods:
+        getattr(mockInterface, name).side_effect = method
+
+    return mockInterface
 
 
 @pytest.fixture

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -56,26 +56,42 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def flushCaches(self, hostSession):
         return mock.DEFAULT
 
-    def resolveEntityReferences(self, references, context, hostSession):
+    def defaultEntityReference(self, specifications, context, hostSession):
+        self.__assertIsIterableOf(specifications, EntitySpecification)
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def defaultEntityReference(self, specification, context, hostSession):
+    def getEntityMetadataEntry(self, entityRefs, key, context, hostSession, defaultValue=None):
+        self.__assertIsIterableOf(entityRefs, str)
+        assert isinstance(key, str)
+        self.__assertCallingContext(context, hostSession)
+        assert isinstance(defaultValue, (str, int, float, bool)) or defaultValue is None
         return mock.DEFAULT
 
-    def getEntityMetadataEntry(self, entityRef, key, context, hostSession, defaultValue=None):
+    def setEntityMetadataEntry(self, entityRefs, key, value, context, hostSession):
+        self.__assertIsIterableOf(entityRefs, str)
+        assert isinstance(key, str)
+        assert isinstance(value, (str, bool, int, float))
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def setEntityMetadataEntry(self, entityRef, key, value, context, hostSession):
-        return mock.DEFAULT
-
-    def entityVersionName(self, entityRef, context, hostSession):
+    def entityVersionName(self, entityRefs, context, hostSession):
+        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
     def entityVersions(
-            self, entityRef, context, hostSession, includeMetaVersions=False, maxResults=-1):
+            self, entityRefs, context, hostSession, includeMetaVersions=False, maxNumVersions=-1):
+        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertCallingContext(context, hostSession)
+        assert isinstance(includeMetaVersions, bool)
+        assert isinstance(maxNumVersions, int)
         return mock.DEFAULT
 
-    def finalizedEntityVersion(self, entityRef, context, hostSession, overrideVersionName=None):
+    def finalizedEntityVersion(self, entityRefs, context, hostSession, overrideVersionName=None):
+        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertCallingContext(context, hostSession)
+        assert isinstance(overrideVersionName, str) or overrideVersionName is None
         return mock.DEFAULT
 
     def setRelatedReferences(
@@ -85,13 +101,11 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def thumbnailSpecification(self, specification, context, options, hostSession):
         return mock.DEFAULT
 
-    def preflight(self, targetEntityRef, entitySpec, context, hostSession):
-        return mock.DEFAULT
-
-    def preflightMultiple(self, targetEntityRefs, entitySpecs, context, hostSession):
-        return mock.DEFAULT
-
-    def registerMultiple(self, strings, targetEntityRefs, entitySpecs, context, hostSession):
+    def preflight(self, targetEntityRefs, entitySpecs, context, hostSession):
+        self.__assertIsIterableOf(targetEntityRefs, str)
+        self.__assertIsIterableOf(entitySpecs, EntitySpecification)
+        self.__assertCallingContext(context, hostSession)
+        assert len(targetEntityRefs) == len(entitySpecs)
         return mock.DEFAULT
 
     def createState(self, hostSession, parentState=None):
@@ -121,36 +135,81 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def initialize(self, hostSession):
         return mock.DEFAULT
 
-    def managementPolicy(self, specification, context, hostSession, entityRef=None):
+    def managementPolicy(self, specifications, context, hostSession, entityRef=None):
+        self.__assertIsIterableOf(specifications, EntitySpecification)
+        self.__assertCallingContext(context, hostSession)
+        assert isinstance(entityRef, str) or entityRef is None
+
         return mock.DEFAULT
 
-    def isEntityReference(self, token, context, hostSession):
+    def isEntityReference(self, tokens, context, hostSession):
+        self.__assertIsIterableOf(tokens, str)
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def entityExists(self, entityRef, context, hostSession):
+    def entityExists(self, entityRefs, context, hostSession):
+        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def resolveEntityReference(self, entityRef, context, hostSession):
+    def resolveEntityReference(self, entityRefs, context, hostSession):
+        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def entityName(self, entityRef, context, hostSession):
+    def entityName(self, entityRefs, context, hostSession):
+        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def entityDisplayName(self, entityRef, context, hostSession):
+    def entityDisplayName(self, entityRefs, context, hostSession):
+        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def getEntityMetadata(self, entityRef, context, hostSession):
+    def getEntityMetadata(self, entityRefs, context, hostSession):
+        self.__assertIsIterableOf(entityRefs, str)
+        self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def setEntityMetadata(self, entityRef, data, context, hostSession, merge=True):
+    def setEntityMetadata(self, entityRefs, data, context, hostSession, merge=True):
+        self.__assertIsIterableOf(entityRefs, str)
+        # TODO(DF): The following fails for `register` since it passes a
+        #   list of dicts.
+        # assert isinstance(data, dict)
+        self.__assertCallingContext(context, hostSession)
+        assert isinstance(merge, bool)
         return mock.DEFAULT
 
     def getRelatedReferences(
             self, entityRefs, relationshipSpecs, context, hostSession, resultSpec=None):
         return mock.DEFAULT
 
-    def register(self, stringData, targetEntityRef, entitySpec, context, hostSession):
+    def register(self, primaryStrings, targetEntityRefs, entitySpecs, context, hostSession):
+        self.__assertIsIterableOf(primaryStrings, str)
+        self.__assertIsIterableOf(targetEntityRefs, str)
+        self.__assertIsIterableOf(entitySpecs, EntitySpecification)
+        self.__assertCallingContext(context, hostSession)
+        assert len(primaryStrings) == len(targetEntityRefs)
+        assert len(primaryStrings) == len(entitySpecs)
         return mock.DEFAULT
+
+    @staticmethod
+    def __assertIsIterableOf(iterable, expectedElemType):
+        # We want to assert that `iterable` is any reasonable container.
+        # Unfortunately there doesn't seem to be a catch-all for this.
+        # E.g. if we expect a collection containing str elements, then a
+        # str itself fits this criteria since we could iterate over it
+        # and each element (character) would be a str. So just be
+        # explicit on the types that we accept.
+        assert isinstance(iterable, (list, tuple, set))
+        for elem in iterable:
+            assert isinstance(elem, expectedElemType)
+
+    @staticmethod
+    def __assertCallingContext(context, hostSession):
+        assert isinstance(context, Context)
+        assert isinstance(hostSession, HostSession)
 
 
 @pytest.fixture
@@ -189,6 +248,11 @@ def manager(mock_manager_interface, host_session):
 @pytest.fixture
 def an_entity_spec():
     return EntitySpecification()
+
+
+@pytest.fixture
+def some_entity_specs():
+    return [EntitySpecification(), EntitySpecification()]
 
 
 @pytest.fixture
@@ -254,125 +318,140 @@ class TestManager():
         method.assert_called_once_with(host_session)
 
     def test_isEntityReference(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
         method = mock_manager_interface.isEntityReference
-        assert manager.isEntityReference(a_ref, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_context, host_session)
+        assert manager.isEntityReference(some_refs, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_entityExists(self, manager, mock_manager_interface, host_session, a_ref, a_context):
+    def test_entityExists(
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
         method = mock_manager_interface.entityExists
-        assert manager.entityExists(a_ref, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_context, host_session)
+        assert manager.entityExists(some_refs, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, a_context, host_session)
 
     # Not testing getEntity as it will be removed
 
     def test_defaultEntityReference(
-            self, manager, mock_manager_interface, host_session, an_entity_spec):
+            self, manager, mock_manager_interface, host_session, a_context, some_entity_specs):
         method = mock_manager_interface.defaultEntityReference
-        assert manager.defaultEntityReference(an_entity_spec, a_context) == method.return_value
-        method.assert_called_once_with(an_entity_spec, a_context, host_session)
+        assert manager.defaultEntityReference(some_entity_specs, a_context) == method.return_value
+        method.assert_called_once_with(some_entity_specs, a_context, host_session)
 
-    def test_entityName(self, manager, mock_manager_interface, host_session, a_ref, a_context):
+    def test_entityName(self, manager, mock_manager_interface, host_session, some_refs, a_context):
         method = mock_manager_interface.entityName
-        assert manager.entityName(a_ref, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_context, host_session)
+        assert manager.entityName(some_refs, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, a_context, host_session)
 
     def test_entityDisplayName(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
         method = mock_manager_interface.entityDisplayName
-        assert manager.entityDisplayName(a_ref, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_context, host_session)
+        assert manager.entityDisplayName(some_refs, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, a_context, host_session)
 
     def test_getEntityMetadata(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
         method = mock_manager_interface.getEntityMetadata
-        assert manager.getEntityMetadata(a_ref, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_context, host_session)
+        assert manager.getEntityMetadata(some_refs, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, a_context, host_session)
 
     def test_setEntityMetadata(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
         method = mock_manager_interface.setEntityMetadata
-        some_data = {"k": "v"}
+        some_data = [{"k1": "v1"}, {"k2": "v2"}]
 
-        assert manager.setEntityMetadata(a_ref, some_data, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, some_data, a_context, host_session, merge=True)
+        assert manager.setEntityMetadata(some_refs, some_data, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, some_data, a_context, host_session, merge=True)
         method.reset_mock()
 
         assert manager.setEntityMetadata(
-            a_ref, some_data, a_context, merge=False) == method.return_value
-        method.assert_called_once_with(a_ref, some_data, a_context, host_session, merge=False)
+            some_refs, some_data, a_context, merge=False) == method.return_value
+        method.assert_called_once_with(some_refs, some_data, a_context, host_session, merge=False)
 
     def test_getEntityMetadataEntry(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
+        # TODO(DF): This test doesn't cover the default implementation
+        #   in ManagerInterface. We will redesign the metadata mechanism
+        #   soon (including removing this method), so deliberately
+        #   leaving untested.
 
         method = mock_manager_interface.getEntityMetadataEntry
         a_key = "key"
         a_default = 2
 
-        assert manager.getEntityMetadataEntry(a_ref, a_key, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_key, a_context, host_session, defaultValue=None)
+        assert manager.getEntityMetadataEntry(some_refs, a_key, a_context) == method.return_value
+        method.assert_called_once_with(
+            some_refs, a_key, a_context, host_session, defaultValue=None)
         method.reset_mock()
 
         assert manager.getEntityMetadataEntry(
-            a_ref, a_key, a_context, defaultValue=a_default) == method.return_value
+            some_refs, a_key, a_context, defaultValue=a_default) == method.return_value
         method.assert_called_once_with(
-            a_ref, a_key, a_context, host_session, defaultValue=a_default)
+            some_refs, a_key, a_context, host_session, defaultValue=a_default)
 
     def test_setEntityMetadataEntry(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
+        # TODO(DF): This test doesn't cover the default implementation
+        #   in ManagerInterface. We will redesign the metadata mechanism
+        #   soon (including removing this method), so deliberately
+        #   leaving untested.
+
         a_key = "key"
         a_value = "value"
         method = mock_manager_interface.setEntityMetadataEntry
         assert manager.setEntityMetadataEntry(
-            a_ref, a_key, a_value, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_key, a_value, a_context, host_session)
+            some_refs, a_key, a_value, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, a_key, a_value, a_context, host_session)
 
     def test_entityVersionName(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
         method = mock_manager_interface.entityVersionName
-        assert manager.entityVersionName(a_ref, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_context, host_session)
+        assert manager.entityVersionName(some_refs, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, a_context, host_session)
 
     def test_entityVersions(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
         method = mock_manager_interface.entityVersions
 
-        assert manager.entityVersions(a_ref, a_context) == method.return_value
+        assert manager.entityVersions(some_refs, a_context) == method.return_value
         method.assert_called_once_with(
-            a_ref, a_context, host_session, includeMetaVersions=False, maxResults=-1)
+            some_refs, a_context, host_session, includeMetaVersions=False, maxNumVersions=-1)
         method.reset_mock()
 
         max_results = 5
         assert manager.entityVersions(
-            a_ref, a_context, maxResults=max_results) == method.return_value
+            some_refs, a_context, maxNumVersions=max_results) == method.return_value
         method.assert_called_once_with(
-            a_ref, a_context, host_session, includeMetaVersions=False, maxResults=max_results)
+            some_refs, a_context, host_session,
+            includeMetaVersions=False, maxNumVersions=max_results)
         method.reset_mock()
 
         include_meta = True
         assert manager.entityVersions(
-            a_ref, a_context, maxResults=max_results,
+            some_refs, a_context, maxNumVersions=max_results,
             includeMetaVersions=include_meta) == method.return_value
         method.assert_called_once_with(
-            a_ref, a_context, host_session, includeMetaVersions=include_meta,
-            maxResults=max_results)
+            some_refs, a_context, host_session, includeMetaVersions=include_meta,
+            maxNumVersions=max_results)
         method.reset_mock()
 
     def test_finalizedEntityVersion(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
         method = mock_manager_interface.finalizedEntityVersion
-        assert manager.finalizedEntityVersion(a_ref, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_context, host_session, overrideVersionName=None)
+        assert manager.finalizedEntityVersion(some_refs, a_context) == method.return_value
+        method.assert_called_once_with(
+            some_refs, a_context, host_session, overrideVersionName=None)
         method.reset_mock()
 
         a_version_name = "aVersion"
         method = mock_manager_interface.finalizedEntityVersion
         assert manager.finalizedEntityVersion(
-            a_ref, a_context, overrideVersionName=a_version_name) == method.return_value
+            some_refs, a_context, overrideVersionName=a_version_name) == method.return_value
         method.assert_called_once_with(
-            a_ref, a_context, host_session, overrideVersionName=a_version_name)
+            some_refs, a_context, host_session, overrideVersionName=a_version_name)
 
     def test_getRelatedReferences(
             self, manager, mock_manager_interface, host_session, a_ref, an_entity_spec, a_context):
@@ -415,29 +494,24 @@ class TestManager():
             [one_ref], [one_spec], a_context, host_session, resultSpec=an_entity_spec)
 
     def test_resolveEntityReference(
-            self, manager, mock_manager_interface, host_session, a_ref, a_context):
-        method = mock_manager_interface.resolveEntityReference
-        assert manager.resolveEntityReference(a_ref, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, a_context, host_session)
-
-    def test_resolveEntityReferences(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
-        method = mock_manager_interface.resolveEntityReferences
-        assert manager.resolveEntityReferences(some_refs, a_context) == method.return_value
+        method = mock_manager_interface.resolveEntityReference
+        assert manager.resolveEntityReference(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
     def test_managementPolicy(
-            self, manager, mock_manager_interface, host_session, an_entity_spec, a_context, a_ref):
+            self, manager, mock_manager_interface, host_session, some_entity_specs, a_context,
+            a_ref):
 
         method = mock_manager_interface.managementPolicy
-        assert manager.managementPolicy(an_entity_spec, a_context) == method.return_value
-        method.assert_called_once_with(an_entity_spec, a_context, host_session, entityRef=None)
+        assert manager.managementPolicy(some_entity_specs, a_context) == method.return_value
+        method.assert_called_once_with(some_entity_specs, a_context, host_session, entityRef=None)
         method.reset_mock()
 
         method = mock_manager_interface.managementPolicy
         assert manager.managementPolicy(
-            an_entity_spec, a_context, entityRef=a_ref) == method.return_value
-        method.assert_called_once_with(an_entity_spec, a_context, host_session, entityRef=a_ref)
+            some_entity_specs, a_context, entityRef=a_ref) == method.return_value
+        method.assert_called_once_with(some_entity_specs, a_context, host_session, entityRef=a_ref)
 
     def test_thumbnailSpecification(
             self, manager, mock_manager_interface, host_session, an_entity_spec, a_context):
@@ -448,39 +522,37 @@ class TestManager():
         method.assert_called_once_with(an_entity_spec, a_context, some_options, host_session)
 
     def test_preflight(
-            self, manager, mock_manager_interface, host_session, a_ref, an_entity_spec, a_context):
-        method = mock_manager_interface.preflight
-        assert manager.preflight(a_ref, an_entity_spec, a_context) == method.return_value
-        method.assert_called_once_with(a_ref, an_entity_spec, a_context, host_session)
-
-    def test_preflightMultiple(
-            self, manager, mock_manager_interface, host_session, some_refs, an_entity_spec,
+            self, manager, mock_manager_interface, host_session, some_refs, some_entity_specs,
             a_context):
-        method = mock_manager_interface.preflightMultiple
-        assert manager.preflightMultiple(
-            some_refs, an_entity_spec, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, an_entity_spec, a_context, host_session)
+        method = mock_manager_interface.preflight
+        assert manager.preflight(some_refs, some_entity_specs, a_context) == method.return_value
+        method.assert_called_once_with(some_refs, some_entity_specs, a_context, host_session)
+
+        # Check IndexError is raised if list lengths mismatch
+        with pytest.raises(IndexError):
+            manager.preflight(some_refs, some_entity_specs[1:], a_context)
 
     def test_register(
-            self, manager, mock_manager_interface, host_session, a_ref, an_entity_spec, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs, some_entity_specs,
+            a_context):
 
         register_method = mock_manager_interface.register
         setmeta_method = mock_manager_interface.setEntityMetadata
 
-        some_string = "primary string"
-        some_meta = {"k": "v"}
+        some_strings = ["primary string 1", "primary string 2"]
+        some_meta = [{"k1": "v1"}, {"k2": "v2"}]
 
         # the return value is used in the setEntityMetadata call so we
         # need it to provide an actual ref we know
-        mutated_ref = f"{a_ref}-registered"
-        register_method.return_value = mutated_ref
+        mutated_refs = [f"{some_refs[0]}-registered", f"{some_refs[1]}-registered"]
+        register_method.return_value = mutated_refs
 
         # Test without metadata
 
         assert manager.register(
-            some_string, a_ref, an_entity_spec, a_context) == register_method.return_value
+            some_strings, some_refs, some_entity_specs, a_context) == register_method.return_value
         register_method.assert_called_once_with(
-            some_string, a_ref, an_entity_spec, a_context, host_session)
+            some_strings, some_refs, some_entity_specs, a_context, host_session)
         setmeta_method.assert_not_called()
 
         mock_manager_interface.reset_mock()
@@ -488,19 +560,27 @@ class TestManager():
         # Test with metadata
 
         assert manager.register(
-            some_string, a_ref, an_entity_spec, a_context,
+            some_strings, some_refs, some_entity_specs, a_context,
             metadata=some_meta) == register_method.return_value
         register_method.assert_called_once_with(
-            some_string, a_ref, an_entity_spec, a_context, host_session)
+            some_strings, some_refs, some_entity_specs, a_context, host_session)
         setmeta_method.assert_called_once_with(
-            mutated_ref, some_meta, a_context, host_session, merge=True)
+            mutated_refs, some_meta, a_context, host_session, merge=True)
 
-    def test_registerMultiple(
-            self, manager, mock_manager_interface, host_session, a_ref, an_entity_spec, a_context):
-        two_strings = ("a", "b")
-        two_refs = (a_ref, a_ref)
-        two_specs = (an_entity_spec, an_entity_spec)
-        method = mock_manager_interface.registerMultiple
-        assert manager.registerMultiple(
-            two_strings, two_refs, two_specs, a_context) == method.return_value
-        method.assert_called_once_with(two_strings, two_refs, two_specs, a_context, host_session)
+        # Check IndexError is raised if list lengths mismatch
+
+        with pytest.raises(IndexError):
+            manager.register(
+                some_strings[1:], some_refs, some_entity_specs, a_context, metadata=some_meta)
+
+        with pytest.raises(IndexError):
+            manager.register(
+                some_strings, some_refs[1:], some_entity_specs, a_context, metadata=some_meta)
+
+        with pytest.raises(IndexError):
+            manager.register(
+                some_strings, some_refs, some_entity_specs[1:], a_context, metadata=some_meta)
+
+        with pytest.raises(IndexError):
+            manager.register(
+                some_strings, some_refs, some_entity_specs, a_context, metadata=some_meta[1:])

--- a/tests/openassetio/managerAPI/test_managerinterface.py
+++ b/tests/openassetio/managerAPI/test_managerinterface.py
@@ -1,0 +1,72 @@
+#
+#   Copyright 2013-2021 [The Foundry Visionmongers Ltd]
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Tests for the default implementations of ManagerInterface methods.
+"""
+from unittest.mock import Mock
+
+import pytest
+
+from openassetio.managerAPI import ManagerInterface
+
+
+@pytest.fixture
+def manager_interface():
+    return ManagerInterface()
+
+
+class Test_ManagerInterface_defaultEntityReference:
+    def test_when_given_single_spec_then_returns_single_empty_ref(self, manager_interface):
+        refs = manager_interface.defaultEntityReference([Mock()], Mock(), Mock())
+        assert refs == [""]
+
+    def test_when_given_multiple_specs_then_returns_corresponding_number_of_empty_refs(
+            self, manager_interface):
+        refs = manager_interface.defaultEntityReference([Mock(), Mock(), Mock()], Mock(), Mock())
+        assert refs == ["", "", ""]
+
+
+class Test_ManagerInterface_entityVersionName:
+    def test_when_given_single_ref_then_returns_single_empty_name(self, manager_interface):
+        names = manager_interface.entityVersionName([Mock()], Mock(), Mock())
+        assert names == [""]
+
+    def test_when_given_multiple_refs_then_returns_corresponding_number_of_empty_names(
+            self, manager_interface):
+        names = manager_interface.entityVersionName([Mock(), Mock(), Mock()], Mock(), Mock())
+        assert names == ["", "", ""]
+
+
+class Test_ManagerInterface_entityVersions:
+    def test_when_given_single_ref_then_returns_single_empty_version_dicts(
+            self, manager_interface):
+        versions = manager_interface.entityVersions([Mock()], Mock(), Mock())
+        assert versions == [{}]
+
+    def test_when_given_multiple_refs_then_returns_corresponding_number_of_empty_version_dicts(
+            self, manager_interface):
+        versions = manager_interface.entityVersions([Mock(), Mock(), Mock()], Mock(), Mock())
+        assert versions == [{}, {}, {}]
+
+
+class Test_ManagerInterface_finalizedEntityVersion:
+
+    def test_when_given_refs_then_returns_refs_unaltered(self, manager_interface):
+        refs = Mock()
+
+        finalized_refs = manager_interface.finalizedEntityVersion(refs, Mock(), Mock())
+
+        assert finalized_refs == refs


### PR DESCRIPTION
Addressing the bulk of #43 by rewriting `Manager` and `ManagerInterface` methods to take/return lists.

The `setMetadata*` methods are deliberately left with minimal changes, since we expect to remove them (see #3 and #4).  Similarly `thumbnailSpecification` is left untouched since we expect to remove it in #86.