### PR TITLE
[Build] Use `npm ci` instead of `npm install .` for docs build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -111,7 +111,7 @@ src/styles.css: src/styles.scss $(SASS)
 #
 
 $(SASS):
-	npm install .
+	npm ci
 
 # `pip install wheel` avoids "error: invalid command 'bdist_wheel'"
 $(VENV): requirements.txt


### PR DESCRIPTION
We should be using the pinned versions. `npm install` doesn't respect package-lock.json. In addition, updates picked up during `make deploy` would then cause the deploy to fail as there are un-staged changes to package-lock.json.

`npm ci` (https://docs.npmjs.com/cli/v6/commands/npm-ci) does what we want.