### PR TITLE
[CI] Add yml section in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -57,6 +57,9 @@ indent_size = 2
 # ij_json_spaces_within_brackets = false
 # ij_json_wrap_long_lines = false
 
+[*.yml]
+indent_size = 2
+
 [*.dox]
 max_line_length = 72
 


### PR DESCRIPTION
Set the indent size to 2 to match current YAML files in the repo.
