### PR TITLE
[Docs] Continuous deployment of GitHub Pages from `main`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: "Docs"
+
+concurrency:
+  group: docs
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+      # The checkout action ensures the correct auth tokens
+      # are set in the repo so we can push. We will pass
+      # this path to the deploy stage to use instead of
+      # its own temporary checkout.
+    - name: Checkout docs branch
+      uses: actions/checkout@v2
+      with:
+        path: target
+        ref: docs
+
+    - name: Build
+      run: |
+        # TODO [tc] We should really publish the Docker
+        # image to the GitHub registry
+        make -C src/doc
+
+    - name: Deploy
+      run: |
+        # Global means we don't need hop around the checkouts to set this
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "github-actions@github.com"
+        # Pass the path to the actions/checkout@v2 docs branch checkout
+        OAIO_DOCS_REPO_DIR=`pwd`/target make -C src/doc deploy

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -74,21 +74,10 @@ DOCSREPO_HTML_DIR = docs
 # The `deploy` target takes an existing `html` directory and updates
 # the `docs` branch on `origin` via a temporary checkout.
 deploy: $(OAIO_DOCS_REPO_DIR)
-	# Ensure there are no uncommitted changes
-	git diff --quiet HEAD ||\
-		(echo "Please commit all changes and rebuild documentation before deploying."; exit 1)
-	# Get current source (short) commit hash, for adding to docs commit message.
-	$(eval commit_hash=$(shell git rev-parse --short HEAD))
-	# Remove any previous documentation.
-	rm -rf $(OAIO_DOCS_REPO_DIR)/$(DOCSREPO_HTML_DIR)
-	# Copy in the new documentation.
-	cp -r ./html $(OAIO_DOCS_REPO_DIR)/$(DOCSREPO_HTML_DIR)
-	# Commit and push the new documentation.
-	cd $(OAIO_DOCS_REPO_DIR) && git add . && git commit -s -m "Update docs to $(commit_hash)" && git push
+	# Deploy the local docs build to the target repo
+	./deploy.sh $(OAIO_DOCS_REPO_DIR)
 	# Remove the clone if we made it.
 	$(DOCSREPO_CLEANUP) && rm -rf $(OAIO_DOCS_REPO_DIR) || true
-	# Pull local docs branch, if one exists.
-	git show-branch docs 2>/dev/null && git fetch origin docs:docs || true
 
 
 $(OAIO_DOCS_REPO_DIR):

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -57,33 +57,45 @@ tooling: $(SASS) $(VENV)
 # Deployment to GH Pages
 #
 
+# $OAIO_DOCS_REPO_DIR can be set to point to an existing checkout
+# of the target branch to deploy to.
+# If unset, a temporary checkout will be created.
+ifndef OAIO_DOCS_REPO_DIR
+OAIO_DOCS_REPO_DIR = /tmp/repo
+DOCSREPO_CLEANUP = true
+else
+DOCSREPO_CLEANUP = false
+endif
+
 # Docs repo constants for GitHub Pages branch.
 DOCSREPO_BRANCH = docs
-DOCSREPO_DIR = /tmp/repo
 DOCSREPO_HTML_DIR = docs
 
 # The `deploy` target takes an existing `html` directory and updates
 # the `docs` branch on `origin` via a temporary checkout.
-deploy:
+deploy: $(OAIO_DOCS_REPO_DIR)
 	# Ensure there are no uncommitted changes
 	git diff --quiet HEAD ||\
 		(echo "Please commit all changes and rebuild documentation before deploying."; exit 1)
 	# Get current source (short) commit hash, for adding to docs commit message.
 	$(eval commit_hash=$(shell git rev-parse --short HEAD))
+	# Remove any previous documentation.
+	rm -rf $(OAIO_DOCS_REPO_DIR)/$(DOCSREPO_HTML_DIR)
+	# Copy in the new documentation.
+	cp -r ./html $(OAIO_DOCS_REPO_DIR)/$(DOCSREPO_HTML_DIR)
+	# Commit and push the new documentation.
+	cd $(OAIO_DOCS_REPO_DIR) && git add . && git commit -s -m "Update docs to $(commit_hash)" && git push
+	# Remove the clone if we made it.
+	$(DOCSREPO_CLEANUP) && rm -rf $(OAIO_DOCS_REPO_DIR) || true
+	# Pull local docs branch, if one exists.
+	git show-branch docs 2>/dev/null && git fetch origin docs:docs || true
+
+
+$(OAIO_DOCS_REPO_DIR):
 	# Get origin remote URL for use in pushing updated docs branch.
 	$(eval remote_url=$(shell git remote get-url origin))
 	# Create a clone of this repo with the docs branch checked out.
-	git clone --no-tags --depth 1 --branch $(DOCSREPO_BRANCH) $(remote_url) $(DOCSREPO_DIR)
-	# Remove any previous documentation.
-	rm -rf $(DOCSREPO_DIR)/$(DOCSREPO_HTML_DIR)
-	# Copy in the new documentation.
-	cp -r ./html $(DOCSREPO_DIR)/$(DOCSREPO_HTML_DIR)
-	# Commit and push the new documentation.
-	cd $(DOCSREPO_DIR) && git add . && git commit -s -m "Update docs to $(commit_hash)" && git push
-	# Remove the clone.
-	rm -rf $(DOCSREPO_DIR)
-	# Pull local docs branch, if one exists.
-	git show-branch docs 2>/dev/null && git fetch origin docs:docs || true
+	git clone --no-tags --depth 1 --branch $(DOCSREPO_BRANCH) $(remote_url) $(OAIO_DOCS_REPO_DIR)
 
 #
 # Cleaning

--- a/doc/README.md
+++ b/doc/README.md
@@ -55,28 +55,28 @@ index page via `html/index.html`.
 ## Deploying the docs
 
 Public facing documentation is served via GitHub Pages from the `docs`
-branch of https://github.com/TheFoundryVisionmongers/OpenAssetIO. This 
+branch of https://github.com/TheFoundryVisionmongers/OpenAssetIO. This
 branch should be updated using the standard Pull Request process.
 
 Specifically,
 1. Check out the latest `main` branch.
-2. Generate the documentation (see above), resulting in a `html` 
+2. Generate the documentation (see above), resulting in a `html`
    directory.
 3. Check out the latest `docs` branch.
-4. Replace the `docs` directory in the `docs` branch checkout with 
+4. Replace the `docs` directory in the `docs` branch checkout with
    the generated `html` directory (i.e. renamed to `docs`).
-5. Commit and push the updated `docs` branch to your fork of the 
-   repository, placing the (short) commit hash that the documentation 
+5. Commit and push the updated `docs` branch to your fork of the
+   repository, placing the (short) commit hash that the documentation
    was generated from in the commit message.
-6. Create a Pull Request against the `docs` branch in the main 
+6. Create a Pull Request against the `docs` branch in the main
    repository.
 
-For convenience, much of this can be automated using the `deploy` 
+For convenience, much of this can be automated using the `deploy`
 target of the included `Makefile`, i.e.
 ```shell
 make deploy
 ```
-which will commit a previously generated `html` directory to a `docs` 
+which will commit a previously generated `html` directory to a `docs`
 directory in the `docs` branch, then push that branch to `origin`.
 
 ## Tidying up

--- a/doc/README.md
+++ b/doc/README.md
@@ -55,8 +55,14 @@ index page via `html/index.html`.
 ## Deploying the docs
 
 Public facing documentation is served via GitHub Pages from the `docs`
-branch of https://github.com/TheFoundryVisionmongers/OpenAssetIO. This
-branch should be updated using the standard Pull Request process.
+branch of [TheFoundryVisionmongers/OpenAssetIO](https://github.com/TheFoundryVisionmongers/OpenAssetIO).
+This is automatically deployed whenever the `main` branch of the repository
+is pushed via GitHub Actions (see [workflows/docs.yml](../.github/workflows/docs.yml)).
+
+### Manual deployment
+
+Should GitHub Actions be unavailable, the deployment can be updated
+manually, using the standard Pull Request process.
 
 Specifically,
 1. Check out the latest `main` branch.

--- a/doc/deploy.sh
+++ b/doc/deploy.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Copyright 2013-2021 [The Foundry Visionmongers Ltd]
+# SPDX-License-Identifier: Apache-2.0
+
+# A script to deploy an existing documentation build in
+# the current working directory to the target branch of
+# the specifed local repository clone.
+#
+# The script expects the build to exist at `./html`,
+# and the target repo to have a writable `docs` branch.
+
+set -e
+
+#
+# Constants
+#
+
+# The target branch to be updated with the new build
+target_branch=docs
+# The path to store the docs under in the target branch
+html_dir=docs
+
+#
+# Args
+#
+
+script_name=$0
+repo_dir=$1
+
+usage()
+{
+    echo "usage: $script_name <target-repo-path>"
+}
+
+if [[ -z "${repo_dir}" ]]; then
+    echo "ERROR: No target repository path specified"
+    usage
+    exit 1
+fi
+
+#
+# Deployment
+#
+
+# Ensure the checkout has no uncommited changes so we
+# only deploy a commited version with an identifiable hash.
+if ! git diff --quiet HEAD
+then
+    echo "ERROR: Please commit all changes and rebuild documentation before deploying"
+    git status -s
+    exit 1
+fi
+
+commit_hash=`git rev-parse --short HEAD`
+target_dir="${repo_dir}/${html_dir}"
+
+echo "Copying local build (commit ${commit_hash}) to ${target_dir}"
+
+# Clean up any existing build in the target should files
+# have been removed in the new build.
+rm -rf "${target_dir}"
+# Copy in the new build
+cp -r ./html "${target_dir}"
+
+# See if there are any resulting changes in the target
+# branch, commit and push if so.
+
+cd "${repo_dir}"
+
+if git diff --quiet HEAD
+then
+    echo "WARNING: No changes to commit, skipping deployment"
+    exit 0
+fi
+
+echo "Updated files:"
+git status -s
+
+git add .
+git commit -s -m "Update docs to ${commit_hash}"
+git push
+
+cd -
+
+# Pull the local docs branch, if one exists so it is up to date
+git show-branch docs 2>/dev/null && git fetch origin docs:docs || true


### PR DESCRIPTION
For #21, sets up CD that continually deploys `main` to GitHub pages.

This required a little refactoring of the `Makefile` to split out the deployment logic. It was getting a bit complex for single line shell foo.

There are runs for a deployment [here](https://github.com/foundrytom/OpenAssetIO/runs/4326630988?check_suite_focus=true), and one where there is no change to the built docs [here](https://github.com/foundrytom/OpenAssetIO/runs/4326658874?check_suite_focus=true).