### PR TITLE
[CI] Build docs for Pull Requests to catch markup errors

### DIFF
--- a/.github/workflows/problem-matchers/doxygen.json
+++ b/.github/workflows/problem-matchers/doxygen.json
@@ -1,0 +1,20 @@
+{
+  "example": "/src/python/openassetio/hostAPI/Manager.py:614: warning: argument 'bool' of command @param is not found in the argument list of Manager::setEntityMetadata(self, reference, data, context, merge=True)",
+  "notes": [
+    "We don't report line numbers as due to pre-processing, they are usually wrong.",
+    "We don't report severity as we want to treat warnings-as-errors."
+  ],
+
+  "problemMatcher": [
+    {
+      "owner": "doxygen",
+      "pattern": [
+        {
+          "regexp": "^\\/src\\/([^:]+):(\\d+): ?(\\w+): ?(.*)$",
+          "file": 1,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,27 @@ jobs:
       run: |
         pytest
 
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+
+    - name: Test
+      run: |
+        echo "::add-matcher::./.github/workflows/problem-matchers/doxygen.json"
+        # Problem matches don't actually error a step, so we have to
+        # manually check for warnings/errors at the end. Capture the
+        # output so we can parse it later.
+        make -C doc 2>&1 | tee doxygen-log.txt
+        # Remove to prevent the error summary from the grep below from
+        # being matched too.
+        echo "::remove-matcher owner=doxygen::"
+        # Fail the job if we have Doxygen warning/error lines in the
+        # output We don't suppress the output as it forms an easier
+        # to digest error summary.
+        # NB: This is the same regex as doxygen.json, adapted to work
+        # with GNU grep.
+        ! grep -E "^/src/([^:]+):([0-9]+): ?([a-zA-Z]+): ?(.*)$" doxygen-log.txt
+


### PR DESCRIPTION
Part of #21, builds docs as for pull requests, and adds the Doxygen problem matcher. 

This should allow us to catch docs build errors through the status checks. 

For now, this is a known-fail until we fix the remaining Doxygen warnings due to the UI and other sundry parameter errors. #94  and #98 resolve many of the warnings reported on `main`, bar the UI ones.