### PR TITLE
[Docs] Fix broken `@refs` pointing to un-migrated docs

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -238,8 +238,12 @@ TAB_SIZE               = 2
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
+# '@needsref' is aliased to nothing to allow easy tracking of things we need
+# to provide a link for. xrefitem doesn't work too well as it consumes
+# too much of the subsequent text.
 ALIASES                = "envvar=\xrefitem envvar \"Environment Variables\" \"Environment Variable List\"" \
-                         "event=\xrefitem event \"Events\" \"Event List\""
+                         "event=\xrefitem event \"Events\" \"Event List\"" \
+                         "needsref="
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -24,7 +24,7 @@ default: container-build
 ## PHONY TARGETS
 ##
 
-.PHONY: clean clean-html clean-tooling clean-docker container-build deploy docker-image html tooling
+.PHONY: clean clean-html clean-tooling clean-docker container-build deploy docker-image html todo tooling
 
 #
 # Container build - Runs this Makefile via docker
@@ -99,6 +99,12 @@ clean-tooling:
 	rm -rf node_modules
 	rm -rf $(VENV)
 
+#
+# Docs TODO list
+# As annotated by @needsref, outputs a unique file -> ref table.
+#
+todo:
+	@grep -Eor "@needsref [a-zA-Z._-]+" ../ | sort | uniq | sed 's|..//||' | column -s ':' -t
 
 ##
 ## File targets

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -145,13 +145,13 @@
  * - Ensure the use of a correctly configured @ref Context for all
  *   calls to the API.
  *
- * - Allow the @ref ManagerUIDelegate to participate in browsing/etc...
+ * - Allow the @needsref ManagerUIDelegate to participate in browsing/etc...
  *   for any data types they have expressed an interest in managing via
  *   @ref openassetio.hostAPI.Manager.Manager.managementPolicy
  *   "Manager.managementPolicy".
  *
  * - Make the drawing of any parameters that may hold an @ref
- *   entity_reference delegatable to the @ref ManagerUIDeleagate.
+ *   entity_reference delegatable to the @needsref ManagerUIDeleagate.
  *
  * - Derive @ref openassetio.specifications "Specifications" for any
  *   custom 'asset types' you may deal with.
@@ -159,8 +159,8 @@
  * - If you have a document model, implement the entity query methods
  *   in your @ref openassetio.hostAPI.HostInterface class.
  *
- * - You should map any widgets returned by @ref ManagerUIDelegate.widgets
- *   with the @ref ui.widgets.attributes.kCreateApplicationPanel flag set to
+ * - You should map any widgets returned by @needsref ManagerUIDelegate.widgets
+ *   with the @needsref ui.widgets.attributes.kCreateApplicationPanel flag set to
  *   some native panel type, if you have one.
  *
  * @note The UI classes have not yet been migrated from the

--- a/doc/src/ForManagers.dox
+++ b/doc/src/ForManagers.dox
@@ -90,9 +90,9 @@
  *   shared across distributed multi-host renders.
  *
  * - A manager can provide additional UI elements that interact
- *   with the host, by returning them from @ref ManagerUIDelegate.getWidgets.
+ *   with the host, by returning them from @needsref ManagerUIDelegate.getWidgets.
  *   The host will create suitable panels, etc. for them, based on the
- *   flags set in @ref BaseWidget.getAttributes.
+ *   flags set in @needsref BaseWidget.getAttributes.
  *
  * @note The UI classes have not yet been migrated from the
  * `FnAssetAPI` code base.

--- a/python/openassetio/hostAPI/ManagerFactoryInterface.py
+++ b/python/openassetio/hostAPI/ManagerFactoryInterface.py
@@ -25,7 +25,7 @@ __all__ = ['ManagerFactoryInterface']
 class ManagerFactoryInterface(object):
     """
     Manager Factories are responsible for instantiating classes that
-    derive from @ref openassetio.managerAPI.ManagerInterface or @ref
+    derive from @ref openassetio.managerAPI.ManagerInterface or @needsref
     openassetio-ui.implementation.ManagerUIDelegate for use within an
     host.
 
@@ -91,7 +91,7 @@ class ManagerFactoryInterface(object):
     @abc.abstractmethod
     def instantiateUIDelegate(self, managerInterfaceInstance, cache=True):
         """
-        Creates an instance of the @ref ManagerUIDelegate for the
+        Creates an instance of the @needsref ManagerUIDelegate for the
         specified manager interface.
 
         @param the instance of a ManagerInterface to retrieve the UI

--- a/python/openassetio/pluginSystem/ManagerPlugin.py
+++ b/python/openassetio/pluginSystem/ManagerPlugin.py
@@ -40,7 +40,7 @@ class ManagerPlugin(PluginSystemPlugin):
     consequently, it is imperative that no ui libraries (QtCore, QtGui
     etc...) are imported unless @ref uiDelegate() is called, and
     ideally, even then, this should be deferred until something is
-    requested from the @ref
+    requested from the @needsref
     openassetio-ui.implementation.ManagerUIDelegate.
     """
 
@@ -83,11 +83,11 @@ class ManagerPlugin(PluginSystemPlugin):
     @classmethod
     def uiDelegate(cls, interfaceInstance):
         """
-        Constructs an instance of the @ref
+        Constructs an instance of the @needsref
         openassetio-ui.implementation.ManagerUIDelegate
 
         This is an instance of some class derived from ManagerUIDelegate
-        that is used by the @ref UISessionManager to provide widgets to
+        that is used by the @needsref UISessionManager to provide widgets to
         a host that may bind into panels in the application, or to allow
         the application to delegate asset browsing/picking etc...
 
@@ -100,7 +100,7 @@ class ManagerPlugin(PluginSystemPlugin):
         this call*, but generally you may want to deffer this to methods
         in the delegate.
 
-        @return An instance of some class derived from @ref
+        @return An instance of some class derived from @needsref
         ManagerUIDelegate.
         """
         return None

--- a/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
@@ -173,7 +173,7 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
 
     def instantiateUIDelegate(self, managerInterfaceInstance, cache=True):
         """
-        Creates an instance of the @ref ManagerUIDelegate for the
+        Creates an instance of the @needsref ManagerUIDelegate for the
         specified identifier.
 
         @param the instance of a ManagerInterface to retrieve the UI


### PR DESCRIPTION
- Adds a new Doxygen alias so we can get rid of all the failures from #104 due to docs we haven't migrated from `FnAssetAPI` yet. 
- Adds a `doc/Makefile` target to list them.