### PR TITLE
[CI] Suppress summary output from grep when checking for build errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,9 @@ jobs:
         # manually check for warnings/errors at the end. Capture the
         # output so we can parse it later.
         make -C doc 2>&1 | tee doxygen-log.txt
-        # Remove to prevent the error summary from the grep below from
-        # being matched too.
         echo "::remove-matcher owner=doxygen::"
         # Fail the job if we have Doxygen warning/error lines in the
-        # output We don't suppress the output as it forms an easier
-        # to digest error summary.
-        # NB: This is the same regex as doxygen.json, adapted to work
-        # with GNU grep.
-        ! grep -E "^/src/([^:]+):([0-9]+): ?([a-zA-Z]+): ?(.*)$" doxygen-log.txt
+        # output. NB: This is the same regex as doxygen.json, adapted
+        # to work with GNU grep.
+        ! grep -qE "^/src/([^:]+):([0-9]+): ?([a-zA-Z]+): ?(.*)$" doxygen-log.txt
 


### PR DESCRIPTION
#104 introduced PR checks for the Doxygen docs build. 

Due to the unique way in which problem matchers work, we require manual effort to actually fail the job.  We'd been using `! grep` for this purpose, and printing its output as a summary of failures. However, some of the Doxygen warnings are multi-line, and so the summary is less helpful. 

 This switches grep to quiet mode. The reader can always click-through from the annotation to the correct line in the log anyway, which makes it easier to see the remaining lines of the message until (if) we figure out a multi-line matcher.
