### PR TITLE
[Core] Rename `metadata` to `attributes`

### DIFF
--- a/doc/src/EntitySpecMeta.dox
+++ b/doc/src/EntitySpecMeta.dox
@@ -1,5 +1,5 @@
 /*!
- * @page entities_specifications_and_metadata Entities, Specifications and Metadata
+ * @page entities_specifications_and_attributes Entities, Specifications and Attributes
  *
  * The concepts discussed on this page are key to understanding how OAIO
  * extends beyond the simple resolution of an @ref entity_reference into
@@ -61,7 +61,7 @@
  * data from the specification's key/value pairs is not persisted beyond
  * the lifetime of the related API calls in any literal form. If a host
  * wishes to persist any other information about an entity, use the @ref
- * metadata mechanism instead.
+ * attributes mechanism instead.
  *
  * @see openassetio.Specification
  *
@@ -144,27 +144,28 @@
  * @warning The library of well-known OAIO base schemas is yet to be
  * ported from `FnAssetAPI`, and will be available soon.
  *
- * @section Metadata
+ * @section Attributes
  *
  * Entities are generally more than just a file on disk, they have
  * additional data that defines their properties or interpretation.
  *
- * In its simplest form, OpenAssetIO's @ref metadata system can be used
+ * In its simplest form, OpenAssetIO's @ref attributes system can be used
  * by a @ref host to store and retrieve additional data about an entity
  * from an @ref asset_management_system without the need for side-car
  * files.
  *
  * An example of this is within a tool that displays image sequences.
  * The @ref primary_string is resolved to provide the path to the images
- * on disk, and the manager-provided metadata queried to control the
- * colorspace and frame range used for playback. This can avoid fragile
- * mechanisms such as extension-based mappings and directory searches.
+ * on disk, and the attributes provided by the manager used to control
+ * the colorspace and frame range used for playback. This can avoid
+ * fragile mechanisms such as extension-based mappings and directory
+ * searches.
  *
  * Extending this further, an entity's primary string does not have to
  * be a file path, or even a URL.
  *
  * If it's possible to break down the description of an entity into a
- * string, and/or set of keys and values, OAIO can be used directly to
+ * string, and/or set of named values, OAIO can be used directly to
  * publish or query entities of this type.
  *
  * A common application of this is its use in a timeline based
@@ -172,18 +173,18 @@
  * a production tracking system.
  *
  * The API contract states that a @ref manager **must** guarantee to
- * store and recall any key/value pairs registered by this
- * mechanism for supported specifications. This allows a host to manage
- * arbitrary data through the asset management system without any
- * special handling by the manager itself.
+ * store and recall any value registered by this mechanism for supported
+ * specifications. This allows a host to manage arbitrary data through
+ * the asset management system without any special handling by the
+ * manager itself.
  *
  * If a Manager holds entities created by means other than OAIO
  * (its own interface, other APIs, etc...) then it is important that it
- * 'bridges' any keys from the well-known OAIO names to its
+ * 'bridges' any attributes from the well-known OAIO names to its
  * corresponding internal name, for both set and get.
  *
- * @warning Metadata in OAIO is limited to simple constants using basic
- * types such as string, float, int and bool. Time-varying data is
+ * @warning In OAIO, attributes are limited to simple constants using
+ * basic types such as string, float, int and bool. Time-varying data is
  * beyond the scope of this API and should be managed through alternate
  * means such as <a href="http://opentimeline.io" target="_blank">OpenTimelineIO</a>
  * or similar.

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -56,13 +56,13 @@
  *   This allows the manager to correctly filter assets or adapt its
  *   behavior as required.
  *
- * - You should query an entity's @ref metadata wherever possible,
- *   and use it as the authoritative source of information about an asset.
- *   For example, to determine the colorspace of an image.
+ * - You should query an entity's @ref attributes wherever possible,
+ *   and use them as the authoritative source of information about an
+ *   asset. For example, to determine the colorspace of an image.
  *
  * @section host_reading Recommended Reading
  *
- * @see @ref entities_specifications_and_metadata
+ * @see @ref entities_specifications_and_attributes
  * @see @ref transactions
  * @see openassetio.hostAPI.Session.Session
  * @see openassetio.hostAPI.Manager.Manager

--- a/doc/src/ForManagers.dox
+++ b/doc/src/ForManagers.dox
@@ -44,16 +44,16 @@
  *   opaque by the host.
  *
  * - The manager is expected to store and recall the
- *   @ref primary_string and @ref metadata
+ *   @ref primary_string and @ref attributes
  *   @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.register
  *   "registered" to any given @ref entity_reference,
  *   grouped by its @ref Specification "specification", and return these
  *   values from the relevant query methods when supplied the
  *   reference returned from the registration.
  *
- * - A @ref host may query other well-known or host-specific @ref
- *   metadata keys to provide additional customization of behavior or the
- *   handling of data referenced by an @ref entity_reference. For example,
+ * - A @ref host may query other well-known or host-specific @ref attributes
+ *   to provide additional customization of behavior or the handling of
+ *   data referenced by an @ref entity_reference. For example,
  *   determining the correct frame range and colorspace of an image
  *   sequence.
  *
@@ -66,7 +66,7 @@
  *   strong hierarchical type mechanism. It is not expected for a manager
  *   to persist any data contained within a specification - but they must
  *   be respected as a filter predicate for browsing/query operations, and
- *   as a type specifier for creation operations. See @ref entities_specifications_and_metadata
+ *   as a type specifier for creation operations. See @ref entities_specifications_and_attributes
  *   for more details on this mechanism.
  *
  * - The @ref ManagerInterface implementation will be passed a
@@ -125,16 +125,16 @@
  * - Implement a @ref ManagerPlugin and install this on
  *   @ref plugin_path_var.
  *
- * @subsection manager_todo_metadata Required for Extended Functionality
+ * @subsection manager_todo_attributes Required for Extended Functionality
  *
- *  Some hosts may make use of an entity's metadata to provide
+ *  Some hosts may make use of an entity's attributes to provide
  *  extended functionality. Such as automating the settings of read
  *  nodes or improving handling of the asset's data.
  *
  * - Implement
- *   @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.getEntityMetadata
- *   "getEntityMetadata" to bridge any internal asset data to the
- *   well-known @ref metadata keys if possible.
+ *   @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.getEntityAttributes
+ *   "getEntityAttributes" to bridge any internal asset data to the
+ *   well-known @ref attributes if possible.
  *
  * @subsection manager_todo_publishing Required for Publishing
  *
@@ -173,16 +173,16 @@
  * registered as appropriate.
  *
  * - In a similar way to @ref primary_string "primary strings", the @ref
- *   metadata set for the entity via @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.setEntityMetadata
- *   "setEntityMetadata" should be stored. This can be freely remapped
+ *   attributes set for the entity via @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.setEntityAttributes
+ *   "setEntityAttributes" should be stored. This can be freely remapped
  *   to internal fields, but should always be returned via the same
- *   source keys. The data should be persisted verbatim unless the
+ *   name used when set. The data should be persisted verbatim unless the
  *   specification is understood.
  *
- * - Bridge any internal asset data to the well-known @ref metadata
- *   keys wherever possible. This will be used by the host as a
- *   preferential source of truth. For example, for the colorspace or
- *   frame range of an image sequence.
+ * - Bridge any internal asset data to the well-known @ref attributes
+ *   wherever possible. This will be used by the host as a preferential
+ *   source of truth. For example, for the colorspace or frame range of
+ *   an image sequence.
  *
  * @subsection manager_todo_related_entities Supporting Relationships
  *
@@ -253,7 +253,7 @@
  *
  * @section manager_reading Recommended Reading
  *
- * @see @ref entities_specifications_and_metadata
+ * @see @ref entities_specifications_and_attributes
  * @see @ref transactions
  * @see openassetio.managerAPI.ManagerInterface
  * @see openassetio.pluginSystem.ManagerPlugin

--- a/doc/src/Glossary.dox
+++ b/doc/src/Glossary.dox
@@ -76,7 +76,7 @@
  *
  * @li name
  * @li @ref primary_string
- * @li @ref metadata
+ * @li @ref attributes
  *
  * This makes it relatively straightforward for an @ref
  * asset_management_system to provide support for any entity that a @ref
@@ -314,42 +314,44 @@
  *   @see openassetio.managerAPI.ManagerInterface.ManagerInterface.thawState
  *
  *
- * @section metadata Metadata
+ * @section attributes Attributes
  *
- * Within the core API, Metadata is used to persist additional properties
- * of an @ref entity. This is particularly useful when there is no
- * meaningful @ref primary_string for any given type of entity.
+ * Within the core API, Attributes are used to persist additional
+ * properties of an @ref entity. This is particularly useful when there
+ * is no meaningful @ref primary_string for any given type of entity.
  *
- * The @ref manager must guarantee to store and recall any metadata set
- * by the @ref host. They may freely re-map any keys to their local
- * names internally, as long as the mapping is reversed for queries.
+ * The @ref manager must guarantee to store and recall any attributes set
+ * by the @ref host. They may freely re-map any attribute names to their
+ * local names internally, as long as the mapping is reversed for
+ * queries.
  *
- * Metadata is limited to **string** keys, and **plain old data** typed values.
+ * Attributes names are strings, and their values are simple **plain
+ * old data** types (ie. int, float, string, bool).
  *
  * > Note: The length of a value is yet to be defined, but ideally it
  * > will be something suitably large - this will only be restricted if
  * > common host applications and/or managers have recurring practical
  * > limits.
  *
- * A simple example of where metadata brings great value is something
- * as humble as an ImageSpecification entity that resolves to an image
- * sequence.
- *  - When a host wishes to read the sequence, if the entity's metadata
- *  has the well-known key for colorspace, then it can ensure the data
- *  is correctly interpreted, without relying on fragile mechanisms such
- *  as the file extension.
- *  - When a host wishes to write image data, if the entity's metadata
- *  has the well-known keys for the file format and associated encoding
- *  options, the data can be reliably written with the correct format,
- *  bit-depth and compression.
+ * A simple example of where entity attributes bring great value is
+ * something as humble as an ImageSpecification entity that resolves to
+ * an image sequence.
+ *  - When a host wishes to read the sequence, if the entity has a
+ *  colorspace attribute then it can ensure the data is correctly
+ *  interpreted, without relying on fragile mechanisms such as the file
+ *  extension.
+ *  - When a host wishes to write image data, the entity's file format
+ *  attribute (along with any associated encoding options) can be used
+ *  to ensure the data is reliably written with the correct format,
+ *  bit-depth and compression, etc.
  *
  * Shots are another type of entity that makes use of this mechanism. As
  * there is no real meaningful @ref primary_string, all relevant data
  * about its frame range, handles, etc. are persisted via the entity's
- * metadata.
+ * attributes.
  *
  * The @ref Specification of any given entity is used to determine the
- * applicable specific set of well-known OAIO metadata keys.
+ * applicable specific set of well-known OAIO attribute names.
  *
  *
  * @section meta_version Meta-version
@@ -377,7 +379,7 @@
  * host and one of these systems in order to query or persist data.
  *
  * Asset managers will generally re-map the well-known OAIO concepts
- * (@ref Specification, @ref metadata) into their own internal
+ * (@ref Specification, @ref attributes) into their own internal
  * structures, and back again when queried.
  *
  * Managers are made available via a @ref ManagerPlugin, that ultimately
@@ -578,7 +580,7 @@
  *
  * The best way to think of a Specification in general use is simply as
  * a glorified 'type string'. The fact that is also can contain
- * key-value metadata is in some ways irrelevant to understanding its
+ * key-value pairs is in some ways irrelevant to understanding its
  * main purpose. A Manager guarantees to be able to 'filter' Entities
  * based on a Specification, and a Host always Registers a new Entity by
  * identifying it with a Specification.

--- a/doc/src/MainPage.dox
+++ b/doc/src/MainPage.dox
@@ -235,7 +235,7 @@
  * rules for the manager:
  *
  * - Store and recall a @ref primary_string
- * - Store and recall @ref metadata
+ * - Store and recall @ref attributes
  * - Allow filtering by @ref Specification
  *
  * If these rules are followed, then arbitrary assets from arbitrary
@@ -243,5 +243,5 @@
  * specific support. However, there is scope to build more advanced and
  * useful functionality by mapping OAIO @ref Specification
  * "specifications" to the manager's native asset types, and well-known
- * @ref metadata to its asset fields.
+ * @ref attributes to its asset fields.
  */

--- a/doc/src/Transactions.dox
+++ b/doc/src/Transactions.dox
@@ -35,7 +35,7 @@
  *    manager.startTransaction(context)
  *    try:
  *        # Create the shot first, so we can then publish the clips to it
- *        shot_ref = manager.register([shot.name], [shot.metadata],
+ *        shot_ref = manager.register([shot.name], [shot.attributes],
  *                                    [shot.spec], [entity_ref], context)[0]
  *        # Register the clips to the shot's entity reference
  *        register_clips(shot.clips, shot_ref, context)
@@ -82,7 +82,7 @@
  *    """
  *    with coordinator.scopedActionGroup(context):
  *        # Create the shot so we can publish
- *        shot_ref = manager.register([shot.name], [shot.metadata],
+ *        shot_ref = manager.register([shot.name], [shot.attributes],
  *                                    [shot.spec], [entity_ref], context)[0]
  *        # Register the clips to the shots entity reference
  *        register_clips(shot.clips, shot_ref, context)
@@ -164,5 +164,5 @@
  * "preflight" or @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.register "register"
  * performed as part of a transaction must produce valid references that
  * can be used within the same transaction for subsequent registrations.
- * Any registered @ref metadata must also be queryable.
+ * Any registered @ref attributes must also be queryable.
  */

--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -15,7 +15,7 @@
 #
 
 from .specifications import LocaleSpecification
-from .constants import kSupportedMetadataTypes
+from .constants import kSupportedAttributeTypes
 
 
 __all__ = ['Context']
@@ -27,7 +27,7 @@ class Context(object):
     environment to a @ref manager. It encapsulates several key access
     properties, as well as providing additional information about the
     @ref host that may be useful to the @ref manager to decorate or
-    extend the metadata associated with the stored @ref entity.
+    extend the attributes associated with the stored @ref entity.
 
     A Manager will also use this information to ensure it presents the
     correct UI, or behavior.
@@ -112,11 +112,11 @@ class Context(object):
             raise ValueError("The managerOptions must be a dict (not %s)" % type(options))
 
         for key, value in options.items():
-            if type(value) not in kSupportedMetadataTypes:
+            if type(value) not in kSupportedAttributeTypes:
                 raise ValueError(
                     ("Manager Options '%s' is not of a " +
                      "supported type '%s' must be %s")
-                    % (key, type(value), kSupportedMetadataTypes))
+                    % (key, type(value), kSupportedAttributeTypes))
 
         self.__managerOptions = options
 

--- a/python/openassetio/constants.py
+++ b/python/openassetio/constants.py
@@ -15,7 +15,7 @@
 #
 
 
-kSupportedMetadataTypes = (str, int, float, bool, type(None))
+kSupportedAttributeTypes = (str, int, float, bool, type(None))
 
 ## @name Management States
 ## @see @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.managementPolicy
@@ -66,7 +66,7 @@ kField_ItemType = 'fnItemType'
 # General
 
 kField_DisplayName = 'displayName'
-kField_Metadata = 'metadata'
+kField_Attributes = 'attributes'
 kField_SmallIcon = 'smallIcon'
 kField_Icon = 'icon'
 kField_ThumbnailPath = 'thumbnailPath'

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -258,8 +258,8 @@ class Manager(Debuggable):
         a chance to retrieve information in advance.
 
         The prefetch calls instructs the manager to retrieve any
-        information needed to either resolve, or fetch metadata for the
-        supplied list of entities.
+        information needed to either resolve, or populate attributes for
+        the supplied list of entities.
 
         The lifetime of the data is managed by the manager, as it may
         have mechanisms to auto-dirty any caches. It is *highly*
@@ -321,7 +321,7 @@ class Manager(Debuggable):
         @warning The @ref openassetio.Context.Context.access "access"
         of the supplied context will be considered by the manager. If
         it is set to read, then it's response applies to resolution
-        and @ref metadata queries. If write, then it applies to
+        and @ref attributes queries. If write, then it applies to
         publishing. Ignored reads can allow optimisations in a host as
         there is no longer a need to test/resolve applicable strings.
 
@@ -500,7 +500,7 @@ class Manager(Debuggable):
     # This suite of methods query information for a supplied @ref
     # entity_reference.
     #
-    # @see @ref metadata
+    # @see @ref attributes
     #
     # @{
 
@@ -556,105 +556,106 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def getEntityMetadata(self, entityRefs, context):
+    def getEntityAttributes(self, entityRefs, context):
         """
-        Retrieve @ref metadata for each given entity. This may contain
-        well-known keys that you can then use to further customize your
-        handling of the entity. Some types of entity may only have
-        metadata, and no meaningful @ref primary_string.
+        Retrieve @ref attributes for each given entity. This may contain
+        well-known attributes that you can then use to further customize
+        your handling of the entity. Some types of entity may only have
+        attributes, and no meaningful @ref primary_string.
 
-        There are some well-known keys defined in the core API - @see
-        openassetio.constants. These have universally agreed meaning.
+        There are some well-known attribute names defined in the core
+        API - @see openassetio.constants. These have universally agreed
+        meaning.
 
-        As a host, you can also advertize well-known keys of your own as
-        part of any first-class asset based workflows you may have. For
-        example, a compositor may choose to consume the `colorspace`
-        key (if present) and adjust the input space of an image reader
-        node accordingly.
+        As a host, you can also advertize well-known attribute names of
+        your own as part of any first-class asset based workflows you
+        may have. For example, a compositor may choose to consume the
+        `colorspace` attribute (if present) and adjust the input space
+        of an image reader node accordingly.
 
-        These new keys should be clearly explained in your
+        These new attribute names should be clearly explained in your
         documentation. A manager may then be able to provide this
         information, based on introspection of your identifier (@see
         Host.identifier).
 
-        @warning See @ref setEntityMetadata for important notes on
-        metadata and its role in the system.
+        @warning See @ref setEntityAttributes for important notes on
+        attributes and their role in the system.
 
         @param entityRefs `List[str]` Entity references to query.
 
         @param context Context The calling context.
 
-        @return `List[Dict[str, primitive]]` Metadata for each entity.
+        @return `List[Dict[str, primitive]]` Attributes for each entity.
         Values will be singular plain-old-data types (ie. string,
         int, float, bool), keys will be strings.
         """
-        return self.__impl.getEntityMetadata(entityRefs, context, self.__hostSession)
+        return self.__impl.getEntityAttributes(entityRefs, context, self.__hostSession)
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def setEntityMetadata(self, entityRefs, data, context, merge=True):
+    def setEntityAttributes(self, entityRefs, data, context, merge=True):
         """
-        Sets metadata on each given entity.
+        Sets the supplied attributes for each given entity.
 
-        A Manager guarantees that it will round-trip metadata, such that
-        the return of @ref getEntityMetadata for those keys will be the same.
-        Managers may remap keys internally to their own native names,
-        but a set/get should be transparent.
+        A Manager guarantees that it will round-trip attributes, such that
+        the return of @ref getEntityAttributes for attributes with those names
+        will be the same as set. Managers may remap attributes internally to
+        their own native names, but a set/get should be transparent.
 
-        If any value is 'None' it should be assumed that that key should
+        If any value is 'None' it should be assumed that that attribute should
         be un-set on the object.
 
         @param entityRefs List[str] Entity references to update.
 
-        @param data List[dict] The metadata to set for each referenced
+        @param data List[dict] The attributes to set for each referenced
         entity.
 
         @param context Context The calling context.
 
-        @param merge bool If true, then each entity's existing metadata
+        @param merge bool If true, then each entity's existing attributes
         will be merged with the new data (the new data taking
-        precedence). If false, its metadata will entirely replaced by
+        precedence). If false, its attributes will entirely replaced by
         the new data.
 
-        @exception ValueError if any of the metadata values are of an
+        @exception ValueError if any of the attributes values are of an
         un-storable type. Presently it is only required to store str,
         float, int, bool
 
-        @exception KeyError if any of the metadata keys are non-strings.
+        @exception KeyError if any of the data keys are non-strings.
         """
-        return self.__impl.setEntityMetadata(
+        return self.__impl.setEntityAttributes(
             entityRefs, data, context, self.__hostSession, merge=merge)
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def getEntityMetadataEntry(self, entityRefs, key, context, defaultValue=None):
+    def getEntityAttribute(self, entityRefs, name, context, defaultValue=None):
         """
-        Retrieve the value of the given metadata key for each given
-        entity.
+        Retrieve the value of the given attribute for each given entity.
 
-        @see getEntityMetadata
+        @see getEntityAttributes
 
         @param entityRefs `List[str]` Entity references to query.
 
-        @param key `str` The key to look up
+        @param name `str` The attribute name to look up
 
         @param defaultValue `primitive` If not `None`, this value will
-        be returned in the case of the specified key not being set for
+        be returned in the case of the specified name not being set for
         an entity.
 
         @param context Context The calling context.
 
         @return `Union[primitive, KeyError]` The value for the specific
-        key, or `KeyError` if not found and no defaultValue is supplied.
+        attribute, or `KeyError` if not found and no defaultValue is
+        supplied.
         """
-        return self.__impl.getEntityMetadataEntry(
-            entityRefs, key, context, self.__hostSession, defaultValue=defaultValue)
+        return self.__impl.getEntityAttribute(
+            entityRefs, name, context, self.__hostSession, defaultValue=defaultValue)
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def setEntityMetadataEntry(self, entityRefs, key, value, context):
-        return self.__impl.setEntityMetadataEntry(
-            entityRefs, key, value, context, self.__hostSession)
+    def setEntityAttribute(self, entityRefs, name, value, context):
+        return self.__impl.setEntityAttribute(
+            entityRefs, name, value, context, self.__hostSession)
 
     ## @}
 
@@ -914,7 +915,7 @@ class Manager(Debuggable):
     # Some kinds of entity - for example, a 'Shot' - may not have a meaningful
     # @ref primary_string, and so an empty string will be returned.
     # In these cases, it is more likely that the information required (eg.
-    # a working frame range) is obtained through calling @ref getEntityMetadata.
+    # a working frame range) is obtained through calling @ref getEntityAttributes.
     # The dictionary returned from this method should then contain well-known
     # keys for this information.
     #
@@ -999,16 +1000,16 @@ class Manager(Debuggable):
     # accompanied by with an spec, that details the file type, color space,
     # resolution etc...
     #
-    # @note The Specification should *not* be confused with @ref metadata.  The
+    # @note The Specification should *not* be confused with @ref attributes.  The
     # manager will not directly store any information contained within the
     # Specification, though it may be used to better define the type of entity.
     # If you wish to persist other properties of the published entity, you must
-    # call @ref setEntityMetadata() directly instead, and as described in the
-    # metadata section, this is assumed that this is the channel for information
+    # call @ref setEntityAttributes() directly instead, and as described in the
+    # attributes section, this is assumed that this is the channel for information
     # that needs to be stored by the manager.
     #
     # For more on the relationship between Entities, Specifications and
-    # metadata, please see @ref entities_specifications_and_metadata
+    # attributes, please see @ref entities_specifications_and_attributes
     # "this" page.
     #
     # The action of 'publishing' itself, is split into two parts, depending on
@@ -1119,7 +1120,7 @@ class Manager(Debuggable):
 
         @warning The working @ref entity_reference returned by this
         method should *always* be used in place of the original
-        reference supplied to `preflight` for resolves or metadata
+        reference supplied to `preflight` for resolves or attributes
         queries prior to registration, and for the final call to @ref
         register itself. See @ref example_publishing_a_file.
 
@@ -1161,7 +1162,7 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def register(self, primaryStrings, targetEntityRefs, entitySpecs, context, metadata=None):
+    def register(self, primaryStrings, targetEntityRefs, entitySpecs, context, attributes=None):
         """
         Register should be used to register new entities either when
         originating new data within the application process, or
@@ -1221,8 +1222,8 @@ class Manager(Debuggable):
 
         @param context Context The calling context.
 
-        @param metadata `List[Union[Dict[str, primitive], None]`
-        Optional metadata to set during publish.
+        @param attributes `List[Union[Dict[str, primitive], None]`
+        Optional attributes to set during publish.
 
         @return `List[Union[str,`
             exceptions.RegistrationError, exceptions.RetryableError `]]`
@@ -1240,26 +1241,26 @@ class Manager(Debuggable):
 
         @see openassetio.specifications
         @see preflight
-        @see setMetadata
+        @see setAttributes
         """
-        ## At the mo, metadata is deliberately not passed to register in the
+        ## At the mo, attributes are deliberately not passed to register in the
         ## ManagerInterface. This helps ensure that no Manager ever places a
-        ## requirement that metadata is known on creation. This is a bad state to
+        ## requirement that attributes is known on creation. This is a bad state to
         ## be in, as it places severe limitations on a host so its worth leaving it
         ## this way so people will moan at us if its a problem.
-        ## @todo ... but conversely, setMetadata doesn't allow that data to be versioned
-        ## This needs revisiting, as its not even really 'metadata' as we encourage
+        ## @todo ... but conversely, setAttributes doesn't allow that data to be versioned
+        ## This needs revisiting, as its not even really 'attributes' as we encourage
         ## hosts to treat it as first-class asset data.
         if (len(primaryStrings) != len(targetEntityRefs) or
                 len(primaryStrings) != len(entitySpecs) or
-                metadata is not None and len(primaryStrings) != len(metadata)):
+                attributes is not None and len(primaryStrings) != len(attributes)):
             raise IndexError("Parameter lists must be of the same length")
 
         entityRefs = self.__impl.register(
             primaryStrings, targetEntityRefs, entitySpecs, context, self.__hostSession)
-        if metadata and entityRefs:
-            self.__impl.setEntityMetadata(
-                entityRefs, metadata, context, self.__hostSession, merge=True)
+        if attributes and entityRefs:
+            self.__impl.setEntityAttributes(
+                entityRefs, attributes, context, self.__hostSession, merge=True)
         return entityRefs
 
     ## @}

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -336,7 +336,7 @@ class ManagerInterface(object):
         entity_reference list. This usually means that the host is about
         to make multiple queries to the same references.  This can be
         left unimplemented, but it is advisable to batch request the
-        data for resolveEntityReference, getEntityMetadata here if
+        data for resolveEntityReference, getEntityAttributes here if
         possible.
 
         The implementation should ignore any entities to which no action
@@ -639,7 +639,7 @@ class ManagerInterface(object):
     # This suite of methods query information for a supplied @ref
     # entity_reference.
     #
-    # @see @ref metadata
+    # @see @ref attributes
     #
     # @{
 
@@ -702,20 +702,19 @@ class ManagerInterface(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def getEntityMetadata(self, entityRefs, context, hostSession):
+    def getEntityAttributes(self, entityRefs, context, hostSession):
         """
-        Retrieve @ref metadata for each given entity.
+        Retrieve @ref attributes for each given entity.
 
         It may be required to bridge between certain 'first-class'
         properties of your asset management system and the well-known
-        keys in the metadata dictionary. For example, if the asset
-        system represents a 'Shot' with 'cutIn' and 'cutOut' properties
-        or accessors, these should be remapped to the @ref
-        openassetio.constants.kField_FrameIn and Out metadata keys as
-        appropriate.
+        OAIO attributes. For example, if the asset system represents a
+        'Shot' with 'cutIn' and 'cutOut' properties or accessors, these
+        should be remapped to the @ref openassetio.constants.kField_FrameIn
+        and Out attributes as appropriate.
 
-        @warning See @ref setEntityMetadata for important notes on
-        metadata and its role in the system.
+        @warning See @ref setEntityAttributes for important notes on
+        attributes and its role in the system.
 
         @param entityRefs `List[str]` Entity references to query.
 
@@ -726,24 +725,24 @@ class ManagerInterface(object):
         logging and provides access to the openassetio.managerAPI.Host
         object representing the process that initiated the API session.
 
-        @return `List[Dict[str, primitive]]` Metadata for each entity.
+        @return `List[Dict[str, primitive]]` Attributes for each entity.
         Values must be singular plain-old-data types (ie. string,
         int, float, bool), keys must be strings.
         """
         raise NotImplementedError
 
-    def setEntityMetadata(self, entityRefs, data, context, hostSession, merge=True):
+    def setEntityAttributes(self, entityRefs, data, context, hostSession, merge=True):
         """
-        Sets metadata on each given entity.
+        Sets attributes on each given entity.
 
         @note It is a vital that the implementation faithfully stores
-        and recalls metadata. It is the underlying mechanism by which
+        and recalls attributes. It is the underlying mechanism by which
         hosts may round-trip non file-based entities within this API.
-        Specific key names and value types should be maintained, even if
-        they are re-mapped to an internal name for persistence.
+        Specific attribute names and value types should be maintained,
+        even if they are re-mapped to an internal name for persistence.
 
-        If any value is 'None' it should be assumed that that key should
-        be un-set on the object.
+        If any value is 'None' it should be assumed that that attribute
+        should be un-set on the object.
 
         @param entityRefs List[str] Entity references to update.
 
@@ -756,30 +755,30 @@ class ManagerInterface(object):
         logging and provides access to the openassetio.managerAPI.Host
         object representing the process that initiated the API session.
 
-        @param merge bool If true, then each entity's existing metadata
+        @param merge bool If true, then each entity's existing attributes
         will be merged with the new data (the new data taking
-        precedence). If false, its metadata will entirely replaced by
+        precedence). If false, its attributes will entirely replaced by
         the new data.
 
-        @exception ValueError if any of the metadata values are of an
+        @exception ValueError if any of the attributes values are of an
         un-storable type. Presently it is only required to store str,
         float, int, bool
         """
         raise NotImplementedError
 
-    def getEntityMetadataEntry(self, entityRefs, key, context, hostSession, defaultValue=None):
+    def getEntityAttribute(self, entityRefs, name, context, hostSession, defaultValue=None):
         """
-        Retrieve the value of the given metadata key for each given
+        Retrieve the value of the given attribute for each given
         entity.
 
-        The default implementation retrieves all metadata for each
-        entity and extracts the requested key.
+        The default implementation retrieves all attributes for each
+        entity and extracts the requested name.
 
-        @see getEntityMetadata
+        @see getEntityAttributes
 
         @param entityRefs `List[str]` Entity references to query.
 
-        @param key `str` The key to look up
+        @param name `str` The attribute to look up
 
         @param context Context The calling context.
 
@@ -789,22 +788,23 @@ class ManagerInterface(object):
         object representing the process that initiated the API session.
 
         @param defaultValue `primitive` If not None, this value should
-        be returned in the case of the specified key not being set for
-        an entity.
+        be returned in the case of the specified attribute not being
+        set for an entity.
 
         @return `Union[primitive, KeyError]` The value for the specific
-        key, or `KeyError` if not found and no defaultValue is supplied.
+        attribute, or `KeyError` if not found and no defaultValue is
+        supplied.
         """
         value = defaultValue
         try:
-            value = self.getEntityMetadata(entityRefs, context, hostSession)[key]
+            value = self.getEntityAttributes(entityRefs, context, hostSession)[name]
         except KeyError:
             if defaultValue is None:
                 raise
         return value
 
-    def setEntityMetadataEntry(self, entityRefs, key, value, context, hostSession):
-        self.setEntityMetadata(entityRefs, {key: value}, context, hostSession, merge=True)
+    def setEntityAttribute(self, entityRefs, name, value, context, hostSession):
+        self.setEntityAttributes(entityRefs, {name: value}, context, hostSession, merge=True)
 
     ## @}
 
@@ -1135,16 +1135,16 @@ class ManagerInterface(object):
     # accompanied by with an spec, that details the file type, color space,
     # resolution etc...
     #
-    # @note The Specification should *not* be confused with @ref metadata.  The
+    # @note The Specification should *not* be confused with @ref attributes.  The
     # implementation must not directly store any information contained within the
     # Specification, though it may be used to better define the type of entity.
     # Hosts that wish to persist other properties of the published entity, will
-    # call @ref setEntityMetadata() directly instead, and as described in the
-    # metadata section, it is assumed that this is the channel for information
+    # call @ref setEntityAttributes() directly instead, and as described in the
+    # attributes section, it is assumed that this is the channel for information
     # that needs to persist.
     #
     # For more on the relationship between Entities, Specifications and
-    # metadata, please see @ref entities_specifications_and_metadata
+    # attributes, please see @ref entities_specifications_and_attributes
     # "this" page.
     #
     # The action of 'publishing' itself, is split into two parts, depending on
@@ -1304,7 +1304,7 @@ class ManagerInterface(object):
         published. It is *not* required for the implementation to
         store any information contained in the specification, though
         it may choose to use it if it is meaningful. The host will
-        separately call setEntityMetadata() if it wishes to persist
+        separately call setEntityAttributes() if it wishes to persist
         any other information in an entity.
 
         @param context Context The calling context. This is not

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -61,16 +61,16 @@ class ValidatingMockManagerInterface(ManagerInterface):
         self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def getEntityMetadataEntry(self, entityRefs, key, context, hostSession, defaultValue=None):
+    def getEntityAttribute(self, entityRefs, name, context, hostSession, defaultValue=None):
         self.__assertIsIterableOf(entityRefs, str)
-        assert isinstance(key, str)
+        assert isinstance(name, str)
         self.__assertCallingContext(context, hostSession)
         assert isinstance(defaultValue, (str, int, float, bool)) or defaultValue is None
         return mock.DEFAULT
 
-    def setEntityMetadataEntry(self, entityRefs, key, value, context, hostSession):
+    def setEntityAttribute(self, entityRefs, name, value, context, hostSession):
         self.__assertIsIterableOf(entityRefs, str)
-        assert isinstance(key, str)
+        assert isinstance(name, str)
         assert isinstance(value, (str, bool, int, float))
         self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
@@ -168,12 +168,12 @@ class ValidatingMockManagerInterface(ManagerInterface):
         self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def getEntityMetadata(self, entityRefs, context, hostSession):
+    def getEntityAttributes(self, entityRefs, context, hostSession):
         self.__assertIsIterableOf(entityRefs, str)
         self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def setEntityMetadata(self, entityRefs, data, context, hostSession, merge=True):
+    def setEntityAttributes(self, entityRefs, data, context, hostSession, merge=True):
         self.__assertIsIterableOf(entityRefs, str)
         # TODO(DF): The following fails for `register` since it passes a
         #   list of dicts.
@@ -349,60 +349,60 @@ class TestManager():
         assert manager.entityDisplayName(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_getEntityMetadata(
+    def test_getEntityAttributes(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
-        method = mock_manager_interface.getEntityMetadata
-        assert manager.getEntityMetadata(some_refs, a_context) == method.return_value
+        method = mock_manager_interface.getEntityAttributes
+        assert manager.getEntityAttributes(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_setEntityMetadata(
+    def test_setEntityAttributes(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.setEntityMetadata
+        method = mock_manager_interface.setEntityAttributes
         some_data = [{"k1": "v1"}, {"k2": "v2"}]
 
-        assert manager.setEntityMetadata(some_refs, some_data, a_context) == method.return_value
+        assert manager.setEntityAttributes(some_refs, some_data, a_context) == method.return_value
         method.assert_called_once_with(some_refs, some_data, a_context, host_session, merge=True)
         method.reset_mock()
 
-        assert manager.setEntityMetadata(
+        assert manager.setEntityAttributes(
             some_refs, some_data, a_context, merge=False) == method.return_value
         method.assert_called_once_with(some_refs, some_data, a_context, host_session, merge=False)
 
-    def test_getEntityMetadataEntry(
+    def test_getEntityAttribute(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
         # TODO(DF): This test doesn't cover the default implementation
-        #   in ManagerInterface. We will redesign the metadata mechanism
+        #   in ManagerInterface. We will redesign the attributes mechanism
         #   soon (including removing this method), so deliberately
         #   leaving untested.
 
-        method = mock_manager_interface.getEntityMetadataEntry
+        method = mock_manager_interface.getEntityAttribute
         a_key = "key"
         a_default = 2
 
-        assert manager.getEntityMetadataEntry(some_refs, a_key, a_context) == method.return_value
+        assert manager.getEntityAttribute(some_refs, a_key, a_context) == method.return_value
         method.assert_called_once_with(
             some_refs, a_key, a_context, host_session, defaultValue=None)
         method.reset_mock()
 
-        assert manager.getEntityMetadataEntry(
+        assert manager.getEntityAttribute(
             some_refs, a_key, a_context, defaultValue=a_default) == method.return_value
         method.assert_called_once_with(
             some_refs, a_key, a_context, host_session, defaultValue=a_default)
 
-    def test_setEntityMetadataEntry(
+    def test_setEntityAttribute(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
         # TODO(DF): This test doesn't cover the default implementation
-        #   in ManagerInterface. We will redesign the metadata mechanism
+        #   in ManagerInterface. We will redesign the attributes mechanism
         #   soon (including removing this method), so deliberately
         #   leaving untested.
 
         a_key = "key"
         a_value = "value"
-        method = mock_manager_interface.setEntityMetadataEntry
-        assert manager.setEntityMetadataEntry(
+        method = mock_manager_interface.setEntityAttribute
+        assert manager.setEntityAttribute(
             some_refs, a_key, a_value, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_key, a_value, a_context, host_session)
 
@@ -538,17 +538,17 @@ class TestManager():
             a_context):
 
         register_method = mock_manager_interface.register
-        setmeta_method = mock_manager_interface.setEntityMetadata
+        setmeta_method = mock_manager_interface.setEntityAttributes
 
         some_strings = ["primary string 1", "primary string 2"]
-        some_meta = [{"k1": "v1"}, {"k2": "v2"}]
+        some_attr = [{"k1": "v1"}, {"k2": "v2"}]
 
-        # the return value is used in the setEntityMetadata call so we
+        # the return value is used in the setEntityAttributes call so we
         # need it to provide an actual ref we know
         mutated_refs = [f"{some_refs[0]}-registered", f"{some_refs[1]}-registered"]
         register_method.return_value = mutated_refs
 
-        # Test without metadata
+        # Test without attributes
 
         assert manager.register(
             some_strings, some_refs, some_entity_specs, a_context) == register_method.return_value
@@ -558,30 +558,30 @@ class TestManager():
 
         mock_manager_interface.reset_mock()
 
-        # Test with metadata
+        # Test with attributes
 
         assert manager.register(
             some_strings, some_refs, some_entity_specs, a_context,
-            metadata=some_meta) == register_method.return_value
+            attributes=some_attr) == register_method.return_value
         register_method.assert_called_once_with(
             some_strings, some_refs, some_entity_specs, a_context, host_session)
         setmeta_method.assert_called_once_with(
-            mutated_refs, some_meta, a_context, host_session, merge=True)
+            mutated_refs, some_attr, a_context, host_session, merge=True)
 
         # Check IndexError is raised if list lengths mismatch
 
         with pytest.raises(IndexError):
             manager.register(
-                some_strings[1:], some_refs, some_entity_specs, a_context, metadata=some_meta)
+                some_strings[1:], some_refs, some_entity_specs, a_context, attributes=some_attr)
 
         with pytest.raises(IndexError):
             manager.register(
-                some_strings, some_refs[1:], some_entity_specs, a_context, metadata=some_meta)
+                some_strings, some_refs[1:], some_entity_specs, a_context, attributes=some_attr)
 
         with pytest.raises(IndexError):
             manager.register(
-                some_strings, some_refs, some_entity_specs[1:], a_context, metadata=some_meta)
+                some_strings, some_refs, some_entity_specs[1:], a_context, attributes=some_attr)
 
         with pytest.raises(IndexError):
             manager.register(
-                some_strings, some_refs, some_entity_specs, a_context, metadata=some_meta[1:])
+                some_strings, some_refs, some_entity_specs, a_context, attributes=some_attr[1:])


### PR DESCRIPTION
Closes #3. Using the term "metadata" was fundamentally misleading. There
is nothing "meta" about the data held in an entity's associated key/value
pairs. It is considered part of the entity itself - as a companion to
the primary string.

Metadata also conjured up thoughts around timestamps, permissions etc. when raised in discussions around the purpose of the API.

We considered 'data', but it was too ambiguous with the 'data' that may be referenced by the primary string when it is an URL.

We considered 'properties', and enjoyed a journey down a philosophical rabbit hole reading Wikipedia articles on the philosphy of attributes and properties and ended up coming up none the wiser.

We settled on attributes, probably for no specific reason. The computing version of the attributes wikipedia entry says this:
 
> "In computing, an attribute is a specification that defines a property of an object"

So attributes felt more fitting as within OAIO we desire to anchor concrete meaning and usage to this data. I'm sure it'll be the wrong way around which ever one we pick. 🙃

## Review notes

- The first commit adjusts method names, but doesn't update documentation or docstrings.
- The other commits update docs/etc.