### PR TITLE
[Core] Fix cyclic dependencies in module imports

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -14,7 +14,6 @@
 #   limitations under the License.
 #
 
-from ..managerAPI.HostSession import HostSession
 from ..managerAPI.ManagerInterface import ManagerInterface
 
 from .._core.debug import debugApiCall, Debuggable

--- a/python/openassetio/managerAPI/Host.py
+++ b/python/openassetio/managerAPI/Host.py
@@ -17,8 +17,6 @@
 from .._core.debug import debugApiCall, Debuggable
 from .._core.audit import auditApiCall
 
-from ..hostAPI import HostInterface
-
 
 __all__ = ['Host']
 

--- a/python/openassetio/managerAPI/HostSession.py
+++ b/python/openassetio/managerAPI/HostSession.py
@@ -16,8 +16,6 @@
 
 from ..logging import LoggerInterface
 
-from .Host import Host
-
 
 class HostSession(object):
     """

--- a/tests/openassetio/test_imports.py
+++ b/tests/openassetio/test_imports.py
@@ -1,0 +1,128 @@
+#
+#   Copyright 2013-2021 [The Foundry Visionmongers Ltd]
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""
+These test ensure that all modules are importable. This can help catch
+dependencies between packages due to the hoisting required to hide
+duplicate namespaces to match the future C++ implementation appearance.
+"""
+
+import sys
+import pytest
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name
+# pylint: disable=unused-import,import-outside-toplevel
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+
+@pytest.fixture(autouse=True)
+def unload_openassetio_modules():
+    """
+    Removes openassetio modules from the sys.modules cache that
+    otherwise mask cyclic dependencies.
+    """
+    to_delete = [
+        name for name in sys.modules if name.startswith("openassetio")]
+    for name in to_delete:
+        del sys.modules[name]
+
+
+class Test_package_imports:
+
+    def test_importing_openassetui_succeeds(self):
+        import openassetio
+
+    def test_importing_constants_succeeds(self):
+        from openassetio import constants
+
+    def test_importing_Context_succeeds(self):
+        from openassetio import Context
+
+    def test_importing_exceptions_succeeds(self):
+        from openassetio import exceptions
+
+    def test_importing_logging_succeeds(self):
+        from openassetio import logging
+
+    def test_importing_Specification_succeeds(self):
+        from openassetio import Specification
+
+    def test_importing_SpecificationFactory_succeeds(self):
+        from openassetio import SpecificationFactory
+
+    def test_importing_specifications_succeeds(self):
+        from openassetio import specifications
+
+
+class Test_core_imports:
+
+    def test_importing_audit_succeeds(self):
+        from openassetio._core import audit
+
+    def test_importing_debug_succeeds(self):
+        from openassetio._core import debug
+
+    def test_importing_objects_succeeds(self):
+        from openassetio._core import objects
+
+
+class Test_hostAPI_imports:
+
+    def test_importing_HostInterface_succeeds(self):
+        from openassetio.hostAPI import HostInterface
+
+    def test_importing_Manager_succeeds(self):
+        from openassetio.hostAPI import Manager
+
+    def test_importing_ManagerFactoryInterface_succeeds(self):
+        from openassetio.hostAPI import ManagerFactoryInterface
+
+    def test_importing_Session_succeeds(self):
+        from openassetio.hostAPI import Session
+
+    def test_importing_terminology_succeeds(self):
+        from openassetio.hostAPI import terminology
+
+    def test_importing_transactions_succeeds(self):
+        from openassetio.hostAPI import transactions
+
+
+class Test_managerAPI_imports:
+
+    def test_importing_Host_succeeds(self):
+        from openassetio.managerAPI import Host
+
+    def test_importing_HostSession_succeeds(self):
+        from openassetio.managerAPI import HostSession
+
+    def test_importing_ManagerInterface_succeeds(self):
+        from openassetio.managerAPI import ManagerInterface
+
+
+class Test_pluginSystem_imports:
+
+    def test_importing_ManagerPlugin_succeeds(self):
+        from openassetio.pluginSystem import ManagerPlugin
+
+    def test_importing_PluginSystem_succeeds(self):
+        from openassetio.pluginSystem import PluginSystem
+
+    def test_importing_PluginSystemManagerFactory_succeeds(self):
+        from openassetio.pluginSystem import PluginSystemManagerFactory
+
+    def test_importing_PluginSystemPlugin_succeeds(self):
+        from openassetio.pluginSystem import PluginSystemPlugin


### PR DESCRIPTION
`managerAPI.Host` was importing `HostInterface`, which meant the `hostAPI` package was initialized, which hoists `Manager`, this in turn was importing `HostSession` which was importing `Host`...

...all in the aid of previously removed Python 3 type hints (#64), which meant they were unused imports anyway!

Definitely looking forward to this all being back in C++ and getting rid of all these hoists.

Adds test coverage to keep an eye on this.