### PR TITLE
[Core] Make `ManagerInterface.identifier` static

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -31,7 +31,8 @@
  *     """
  *     A minimal host implementation with no document model.
  *     """
- *     def identifier(self):
+ *     @staticmethod
+ *     def identifier():
  *         return "org.openassetio.example.host"
  *
  *

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -186,8 +186,8 @@ class ManagerInterface(object):
     #
     # @{
 
-    @abc.abstractmethod
-    def identifier(self):
+    @staticmethod
+    def identifier():
         """
         Returns an identifier to uniquely identify a specific asset
         manager. This may be used by a host to persist the users

--- a/python/openassetio/pluginSystem/ManagerPlugin.py
+++ b/python/openassetio/pluginSystem/ManagerPlugin.py
@@ -44,8 +44,8 @@ class ManagerPlugin(PluginSystemPlugin):
     openassetio-ui.implementation.ManagerUIDelegate.
     """
 
-    @classmethod
-    def identifier(cls):
+    @staticmethod
+    def identifier():
         """
         Returns an identifier to uniquely identify the plug-in.
         Generally, this should be the identifier used by the manager.

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -126,7 +126,8 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def thawState(self, token, hostSession):
         return mock.DEFAULT
 
-    def identifier(self):
+    @staticmethod
+    def identifier():
         return mock.DEFAULT
 
     def displayName(self):


### PR DESCRIPTION
It doesn't make much sense to allow the manager's identifier to vary. It has to be consistent with the one reported by the ManagerPlugin. Having this be an instance method makes having a single source of truth a little ugly to no tangible benefit.

Leaving the host side, as it makes more sense to be an instance method, as an application may have different modes served from the same binary (eg: PLE).

Considered making this a read-only property, but keeping it as a method for symmetry with `HostInterface` (which has to be a method in c++).