### PR TITLE
The great `pylint` cleanup - Part I - `Context.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[tool.pylint.messages_control]
+disable = [
+    "too-many-arguments"
+]
+
 [tool.pylint.format]
 max-line-length = 99
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [tool.pylint.messages_control]
 disable = [
-    "too-many-arguments"
+    "too-many-arguments",
+    # Disable Python 3 improvements:
+    # - We've not definitely ruled 2 out
+    # - Much of this code will move to C++
+    "useless-object-inheritance",
+    "super-with-arguments",
+    "consider-using-f-string"
 ]
 
 [tool.pylint.format]

--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -108,7 +108,7 @@ class Context(object):
 
     def __setManagerOptions(self, options):
 
-        if not isinstance(options, (dict, None)):
+        if options is None or not isinstance(options, dict):
             raise ValueError("The managerOptions must be a dict (not %s)" % type(options))
 
         for key, value in options.items():

--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -187,17 +187,17 @@ class Context(object):
         return self.__retention
 
     def __setRetention(self, retention):
-        r = -1
+        finalVal = -1
         if isinstance(retention, str):
             if retention in self.kRetentionNames:
-                r = self.kRetentionNames.index(retention)
+                finalVal = self.kRetentionNames.index(retention)
         else:
-            r = int(retention)
-        if r < self.kIgnored or r > self.kPermanent:
+            finalVal = int(retention)
+        if finalVal < self.kIgnored or finalVal > self.kPermanent:
             raise ValueError(
                 "%i (%s) is not a valid Retention (%s)"
-                % (r, retention, ", ".join(range(self.kPermanent + 1))))
-        self.__retention = r
+                % (finalVal, retention, ", ".join(range(self.kPermanent + 1))))
+        self.__retention = finalVal
 
     retention = property(__getRetention, __setRetention)
 

--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -90,6 +90,7 @@ class Context(object):
         self.__actionGroupDepth = actionGroupDepth
 
     def __getManagerInterfaceState(self):
+        # pylint: disable=unused-private-member
         """
         The opaque state token owned by the @ref manager, used to
         correlate all API calls made using this context.
@@ -99,6 +100,7 @@ class Context(object):
         return self.__managerState
 
     def __setManagerInterfaceState(self, state):
+        # pylint: disable=unused-private-member
         self.__managerState = state
 
     managerInterfaceState = property(__getManagerInterfaceState, __setManagerInterfaceState)
@@ -113,9 +115,11 @@ class Context(object):
         be generally be done using a @ref
         openassetio-ui.widgets.ManagerOptionsWidget.
         """
+        # pylint: disable=unused-private-member
         return self.__managerOptions
 
     def __setManagerOptions(self, options):
+        # pylint: disable=unused-private-member
 
         if options is None or not isinstance(options, dict):
             raise ValueError("The managerOptions must be a dict (not %s)" % type(options))
@@ -138,9 +142,11 @@ class Context(object):
         openassetio.hostAPI.transactions.TransactionCoordinator "TransactionCoordinator".
         @todo https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/135
         """
+        # pylint: disable=unused-private-member
         return self.__actionGroupDepth
 
     def __setActionGroupDepth(self, depth):
+        # pylint: disable=unused-private-member
         self.__actionGroupDepth = depth
 
     actionGroupDepth = property(__getActionGroupDepth, __setActionGroupDepth)
@@ -154,9 +160,11 @@ class Context(object):
         wanting to choose a new file name to save, or open an existing
         one.
         """
+        # pylint: disable=unused-private-member
         return self.__access
 
     def __setAccess(self, access):
+        # pylint: disable=unused-private-member
         if access not in self.__validAccess:
             raise ValueError(
                 "'%s' is not a valid Access Pattern (%s)"
@@ -184,9 +192,11 @@ class Context(object):
         situations correctly, Hosts are required to set this property to
         reflect their ability to persist this information.
         """
+        # pylint: disable=unused-private-member
         return self.__retention
 
     def __setRetention(self, retention):
+        # pylint: disable=unused-private-member
         finalVal = -1
         if isinstance(retention, str):
             if retention in self.kRetentionNames:
@@ -218,9 +228,11 @@ class Context(object):
         include information such as whether or not multi-selection is
         required.
         """
+        # pylint: disable=unused-private-member
         return self.__locale
 
     def __setLocale(self, locale):
+        # pylint: disable=unused-private-member
         if locale is not None and not isinstance(locale, LocaleSpecification):
             raise ValueError(
                 "Locale must be an instance of %s (not %s)"

--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -91,30 +91,21 @@ class Context(object):
 
     def __getManagerInterfaceState(self):
         # pylint: disable=unused-private-member
-        """
-        The opaque state token owned by the @ref manager, used to
-        correlate all API calls made using this context.
-
-        @see @ref stable_resolution
-        """
         return self.__managerState
 
     def __setManagerInterfaceState(self, state):
         # pylint: disable=unused-private-member
         self.__managerState = state
 
+    ## @property managerInterfaceState
+    ##
+    ## The opaque state token owned by the @ref manager, used to
+    ## correlate all API calls made using this context.
+    ##
+    ## @see @ref stable_resolution
     managerInterfaceState = property(__getManagerInterfaceState, __setManagerInterfaceState)
 
     def __getManagerOptions(self):
-        """
-        The manager options may contain custom locale data specific to
-        your implementation. You should never attempt to set this your
-        self, it will not be preserved in many situations by many hosts.
-        Instead, the host will ask you for this information on occasions
-        that it can be suitable propagated to other API calls. This will
-        be generally be done using a @ref
-        openassetio-ui.widgets.ManagerOptionsWidget.
-        """
         # pylint: disable=unused-private-member
         return self.__managerOptions
 
@@ -133,15 +124,18 @@ class Context(object):
 
         self.__managerOptions = options
 
+    ## @property managerOptions
+    ##
+    ## The manager options may contain custom locale data specific to
+    ## a @ref manager "manager's" implementation. Managers should never
+    ## attempt to set this themselves, it will not be preserved in many
+    ## situations overwritten by many hosts. Instead, the host will
+    ## ask you for this information on occasions that it can be
+    ## suitable propagated to other API calls. This will be generally
+    ## be done using a @needsref openassetio-ui.widgets.ManagerOptionsWidget.
     managerOptions = property(__getManagerOptions, __setManagerOptions)
 
     def __getActionGroupDepth(self):
-        """
-        @protected
-        Defines the number of action groups in the stack managed by the @ref
-        openassetio.hostAPI.transactions.TransactionCoordinator "TransactionCoordinator".
-        @todo https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/135
-        """
         # pylint: disable=unused-private-member
         return self.__actionGroupDepth
 
@@ -149,17 +143,15 @@ class Context(object):
         # pylint: disable=unused-private-member
         self.__actionGroupDepth = depth
 
+    ## @property actionGroupDepth
+    ## @protected
+    ## @todo https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/135
+    ##
+    ## Defines the number of action groups in the stack managed by the @ref
+    ## openassetio.hostAPI.transactions.TransactionCoordinator "TransactionCoordinator".
     actionGroupDepth = property(__getActionGroupDepth, __setActionGroupDepth)
 
     def __getAccess(self):
-        """
-        This covers what the @ref host is intending to do with the data.
-        For example, when passed to resolveEntityReference, it infers if
-        the @ref host is about to read or write. When configuring a
-        BrowserWidget, then it will hint as to whether the Host is
-        wanting to choose a new file name to save, or open an existing
-        one.
-        """
         # pylint: disable=unused-private-member
         return self.__access
 
@@ -171,27 +163,18 @@ class Context(object):
                 % (access, ", ".join(self.__validAccess)))
         self.__access = access
 
+    ## @property access
+    ##
+    ## Describes what the @ref host is intending to do with the data.
+    ##
+    ## For example, when passed to resolveEntityReference, it specifies
+    ## if the @ref host is about to read or write. When configuring a
+    ## BrowserWidget, then it will hint as to whether the Host is
+    ## wanting to choose a new file name to save, or open an existing
+    ## one.
     access = property(__getAccess, __setAccess)
 
     def __getRetention(self):
-        """
-        This is a concession to the fact that it's not always possible
-        to fully implement the spec of this API. For example, @ref
-        openassetio.managerAPI.ManagerInterface.ManagerInterface.register
-        "Manager.register()" can return an @ref entity_reference that
-        points to the newly published @ref entity. This is often not the
-        same as the reference that was passed to the call. The Host is
-        expected to store this new reference for future use. For example
-        in the case of a Scene File added to an 'open recent' menu. A
-        Manager may rely on this to ensure a reference that points to a
-        specific version is used in the future. In some cases - such as
-        batch rendering of an image sequence, it may not be possible to
-        store this final reference, due to constraints of the
-        distributed natured of such a render. Often, it is not actually
-        of consequence. To allow the @ref manager to handle these
-        situations correctly, Hosts are required to set this property to
-        reflect their ability to persist this information.
-        """
         # pylint: disable=unused-private-member
         return self.__retention
 
@@ -209,25 +192,28 @@ class Context(object):
                 % (finalVal, retention, ", ".join(self.kRetentionNames)))
         self.__retention = finalVal
 
+    ## @property retention
+    ## A concession to the fact that it's not always possible to fully
+    ## implement the spec of this API within a @ref host.
+    ##
+    ## For example, @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.register
+    ## "Manager.register()" can return an @ref entity_reference that
+    ## points to the newly published @ref entity. This is often not the
+    ## same as the reference that was passed to the call. The Host is
+    ## expected to store this new reference for future use. For example
+    ## in the case of a Scene File added to an 'open recent' menu. A
+    ## Manager may rely on this to ensure a reference that points to a
+    ## specific version is used in the future.
+    ##
+    ## In some cases - such as batch rendering of an image sequence,
+    ## it may not be possible to store this final reference, due to
+    ## constraints of the distributed natured of such a render.
+    ## Often, it is not actually of consequence. To allow the @ref manager
+    ## to handle these situations correctly, Hosts are required to set
+    ## this property to reflect their ability to persist this information.
     retention = property(__getRetention, __setRetention)
 
     def __getLocale(self):
-        """
-        In many situations, the Specification of the desired @ref entity
-        itself is not entirely sufficient information to realize many
-        functions that a @ref Manager wishes to implement. For example,
-        when determining the final file path for an Image that is about
-        to be published - knowing it came from a render catalog, rather
-        than a 'Write node' from a comp tree could result in different
-        behavior.
-
-        The Locale uses a @ref
-        openassetio.specifications.LocaleSpecification to describe in
-        more detail, what specific part of a @ref host is requesting an
-        action. In the case of a file browser for example, it may also
-        include information such as whether or not multi-selection is
-        required.
-        """
         # pylint: disable=unused-private-member
         return self.__locale
 
@@ -239,6 +225,21 @@ class Context(object):
                 % (LocaleSpecification, type(locale)))
         self.__locale = locale
 
+    ## @property locale
+    ##
+    ## In many situations, the Specification of the desired @ref entity
+    ## itself is not entirely sufficient information to realize many
+    ## functions that a @ref manager wishes to implement. For example,
+    ## when determining the final file path for an Image that is about
+    ## to be published - knowing it came from a render catalog, rather
+    ## than a 'Write node' from a comp tree could result in different
+    ## behavior.
+    ##
+    ## The Locale uses a @ref openassetio.specifications.LocaleSpecification
+    ## to describe in more detail, what specific part of a @ref host
+    ## is requesting an action. In the case of a file browser for example,
+    ## it may also include information such as whether or not multi-selection
+    ## is required.
     locale = property(__getLocale, __setLocale)
 
     def __str__(self):

--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -196,7 +196,7 @@ class Context(object):
         if finalVal < self.kIgnored or finalVal > self.kPermanent:
             raise ValueError(
                 "%i (%s) is not a valid Retention (%s)"
-                % (finalVal, retention, ", ".join(range(self.kPermanent + 1))))
+                % (finalVal, retention, ", ".join(self.kRetentionNames)))
         self.__retention = finalVal
 
     retention = property(__getRetention, __setRetention)

--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -13,6 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+A single-class module, providing the Context class.
+"""
 
 from .specifications import LocaleSpecification
 from .constants import kSupportedAttributeTypes
@@ -87,6 +90,12 @@ class Context(object):
         self.__actionGroupDepth = actionGroupDepth
 
     def __getManagerInterfaceState(self):
+        """
+        The opaque state token owned by the @ref manager, used to
+        correlate all API calls made using this context.
+
+        @see @ref stable_resolution
+        """
         return self.__managerState
 
     def __setManagerInterfaceState(self, state):
@@ -123,6 +132,12 @@ class Context(object):
     managerOptions = property(__getManagerOptions, __setManagerOptions)
 
     def __getActionGroupDepth(self):
+        """
+        @protected
+        Defines the number of action groups in the stack managed by the @ref
+        openassetio.hostAPI.transactions.TransactionCoordinator "TransactionCoordinator".
+        @todo https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/135
+        """
         return self.__actionGroupDepth
 
     def __setActionGroupDepth(self, depth):


### PR DESCRIPTION
Part of #101.

Sets some baseline ignores, and addresses some issues in `Context.py`.

This also fixes up some missing Doxygen documentation for `Context` properties.