### PR TITLE
[Test] Add Manager plugin test harness

### DIFF
--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -221,9 +221,12 @@ class ManagerInterface(object):
         """
         Returns other information that may be useful about this @ref
         asset_management_system. This can contain arbitrary key/value
-        pairs.For example:
+        pairs. For example:
 
             { 'version' : '1.1v3', 'server' : 'assets.openassetio.org' }
+
+        @note Keys should always be strings, and values must be
+        plain-old-data types (ie: str, int, float, bool).
 
         There are certain optional keys that may be used by a host or
         the API:
@@ -244,9 +247,6 @@ class ManagerInterface(object):
 
           @li openassetio.constants.kField_EntityReferencesMatchPrefix
           @li openassetio.constants.kField_EntityReferencesMatchRegex
-
-        @note Keys should always be strings, and values must be
-        plain-old-data types (ie: str, int, float, bool).
         """
         return {}
 

--- a/python/openassetio/test/managerValidator/__init__.py
+++ b/python/openassetio/test/managerValidator/__init__.py
@@ -1,0 +1,19 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+This package contains a test harness that exercises a manager plugin
+implementation.
+"""

--- a/python/openassetio/test/managerValidator/__main__.py
+++ b/python/openassetio/test/managerValidator/__main__.py
@@ -1,0 +1,30 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Entry point for command-line execution of the manager plugin test
+harness.
+"""
+
+# pylint: disable=invalid-name
+
+import sys
+
+from openassetio.test.managerValidator import commandLine, validatorSuite
+
+
+isSuccessful = commandLine.execute(sys.argv, validatorSuite)
+
+sys.exit(int(isSuccessful))

--- a/python/openassetio/test/managerValidator/commandLine.py
+++ b/python/openassetio/test/managerValidator/commandLine.py
@@ -1,0 +1,183 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Utilities for executing the manager test harness from the command line.
+"""
+import argparse
+import collections
+import importlib.util
+import inspect
+import unittest
+
+from . import validatorHarness
+
+
+__all__ = ["execute", "Parser", "ParsedArgs", "PyFixtureLoader"]
+
+
+def execute(argv, testModule, parser=None, harnessFactory=None):
+    """
+    Command-line execution of the manager test harness.
+
+    @param argv `List[str]` Command-line arguments as per `sys.argv`,
+    including the executable name.  See @ref Parser for details of usage
+    and supported arguments.
+
+    @param testModule `types.ModuleType` Python module containing the
+    test harness test case suite.
+
+    @param parser Parser Utility to parse the command-line arguments
+    and load fixtures. If `None` then the default parser will be used.
+
+    @param harnessFactory validatorHarness.ValidatorHarnessFactory
+    Factory for constructing dependencies required for execution of
+    the test cases. If `None` then the default factory will be used.
+
+    @return `bool` `True` if tests executed with no failures, `False`
+    otherwise.
+    """
+    if parser is None:
+        parser = Parser(PyFixtureLoader())
+    if harnessFactory is None:
+        harnessFactory = validatorHarness.ValidatorHarnessFactory()
+
+    parsedArgs = parser.parse(argv)
+    logger = harnessFactory.createLogger()
+    hostInterface = harnessFactory.createHostInterface()
+    managerFactory = harnessFactory.createManagerFactory(logger)
+    session = harnessFactory.createSessionWithManager(
+        parsedArgs.fixtures["identifier"], hostInterface, logger, managerFactory)
+    unittestLoader = harnessFactory.createLoader(parsedArgs.fixtures, session)
+    harness = harnessFactory.createHarness(unittest.main, unittestLoader)
+    return harness.executeTests(parsedArgs.extraArgs, testModule)
+
+
+ParsedArgs = collections.namedtuple("ParsedArgs", ("fixtures", "extraArgs"))
+
+
+class Parser:
+    """
+    Parser for command-line arguments.
+
+    Wraps `argparse` to parse command-line invocation flags and load the
+    provided fixtures file.
+    """
+    # TODO(DF): @pylint-disable Should we update pylint rules to allow
+    #  classes with a single public method?
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, fixtureLoader):
+        """
+        Initialises an instance of this class.
+
+        @param fixtureLoader PyFixtureLoader Utility for loading
+        the test case fixture dict.
+        """
+        self.__fixtureLoader = fixtureLoader
+
+    def parse(self, argv):
+        """
+        Process the given command-line arguments and load fixtures.
+
+        Uses `argparse` to present a nice command-line interface,
+        including help text.
+
+        @param argv Arguments passed on the command-line, as in
+        `sys.argv`.
+
+        @return ParsedArgs A `namedtuple` wrapping the result of parsing
+        the command-line arguments.
+        """
+        cmdline = argparse.ArgumentParser(
+            prog="managerValidator", formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=inspect.cleandoc("""
+                The OAIO Manager test harness - A tool to validate a given manager
+                correctly implements the API interface.
+
+                When executed with a manager-supplied fixtures file, the harness will
+                load the specified manager plugin from OAIO_PLUGIN_PATH and run a
+                series of tests that validate:
+
+                - Input handling
+                - Return types and values
+
+                Because OAIO places no constraints on the nature of an entity
+                reference, it is necessary for any given manager to provide the test
+                suite with valid input data that can be used to test entity related
+                methods. In addition, as the result of many methods is also specific to
+                the manager, in many cases, the test suite requires expected output to
+                be specified too.
+
+                This data is provided via a fixtures file. This is a python script that
+                defines a top-level 'fixtures' variable containing this data. This
+                variable should be a dict with the following structure:
+
+                fixtures = {
+                    "identifier" : "<identifier of target plugin>",
+                    "<Test_ClassName>" : {
+                        "<test_case_name>" : {
+                            "<fixture_name>" : <value>,
+                            ...
+                        },
+                        ...
+                    },
+                    ...
+                }
+
+                Test classes, case names, and fixture names are available in
+                openassetio.test.managerValidator.validatorSuite.
+                 """))
+        cmdline.add_argument(
+            "-f", "--fixtures", metavar="FILE", required=True, help="Path to Python fixtures file")
+        # The following "argument" is just a dummy for the help text. If
+        # additional arguments are provided, `args.extraArgs` will be
+        # `True`, yet those arguments will still go in the
+        # "unrecognized" list (i.e. `extraArgs`).
+        cmdline.add_argument(
+            "extraArgs", action="store_true", help="Arguments to pass to the test runner")
+
+        args, extraArgs = cmdline.parse_known_args(argv[1:])
+
+        return ParsedArgs(
+            fixtures=self.__fixtureLoader.load(args.fixtures),
+            extraArgs=extraArgs)
+
+
+class PyFixtureLoader:
+    """
+    Utility that loads a Python module and extracts the `fixtures`
+    top-level variable within.
+    """
+    # TODO(DF): @pylint-disable
+    # pylint: disable=too-few-public-methods
+
+    @staticmethod
+    def load(filePath):
+        """
+        Execute the given Python file and extract its `fixtures`
+        top-level variable.
+
+        See `resources/examples/SampleAssetManager/test/fixtures.py` for
+        a reference fixtures file.
+
+        @param filePath `str` Python file to load.
+
+        @return `dict` Dictionary of test case fixtures.
+        """
+        spec = importlib.util.spec_from_file_location("oaioTestFixtures", filePath)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.fixtures

--- a/python/openassetio/test/managerValidator/validatorHarness.py
+++ b/python/openassetio/test/managerValidator/validatorHarness.py
@@ -1,0 +1,272 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Boilerplate classes for initialisation and execution of test cases.
+"""
+import unittest
+
+from openassetio import hostAPI, pluginSystem, logging, managerAPI
+
+
+__all__ = [
+    "ValidatorHarnessFactory", "ValidatorHarness", "ValidatorTestLoader",
+    "ValidatorHarnessHostInterface", "FixtureAugmentedTestCase"]
+
+
+class ValidatorHarnessFactory:
+    """
+    Factory encapsulating the construction of dependencies required to
+    run the manager validator test harness.
+    """
+
+    @staticmethod
+    def createHarness(runner, loader):
+        """
+        Create the test harness used begin test case execution.
+
+        @param runner `unittest.main` A unittest-compatible test runner.
+
+        @param loader ValidatorTestLoader A unittest-compatible test
+        case loader that injects test fixtures into test case instances.
+
+        @return ValidatorHarness Test harness.
+        """
+        return ValidatorHarness(runner, loader)
+
+    @staticmethod
+    def createLoader(fixtures, session):
+        """
+        Create the test case loader that injects fixtures into test case
+        instances as they are discovered and instantiated.
+
+        @param fixtures `Dict[Any, Any]` Dictionary of test case
+        fixtures.
+
+        @param session hostAPI.Session.Session The OAIO session to
+        inject into test cases.
+
+        @return ValidatorTestLoader Test case loader.
+        """
+        return ValidatorTestLoader(fixtures, session)
+
+    @staticmethod
+    def createHostInterface():
+        """
+        Create the hostAPI.HostInterface.HostInterface to be used by the
+        test harness @ref session.
+
+        @return ValidatorHarnessHostInterface The
+        hostAPI.HostInterface.HostInterface implementation used by the
+        test harness.
+        """
+        return ValidatorHarnessHostInterface()
+
+    @staticmethod
+    def createSessionWithManager(identifier, hostInterface, logger, managerFactory):
+        """
+        Create a hostAPI.Session.Session instance and load the given
+        manager plugin into it via the given `identifier`.
+
+        @param identifier `str` Identifier of the manager plugin to
+        load.
+
+        @param hostInterface hostAPI.HostInterface.HostInterface The
+        `HostInterface` implementation used by the test harness session.
+
+        @param logger logging.LoggerInterface Logger to be used by the
+        test harness session.
+
+        @param managerFactory
+        hostAPI.ManagerFactoryInterface.ManagerFactoryInterface
+        Manager factory to be used by the test harness session.
+
+        @return hostAPI.Session.Session Test harness session.
+        """
+        session = hostAPI.Session(hostInterface, logger, managerFactory)
+        session.useManager(identifier)
+        return session
+
+    @staticmethod
+    def createManagerFactory(logger):
+        """
+        Create the @ref manager factory to be used by the test harness
+        session.
+
+        @param logger logging.LoggerInterface Logger to be used by the
+        manager factory.
+        """
+        return pluginSystem.PluginSystemManagerFactory(logger)
+
+    @staticmethod
+    def createLogger():
+        """
+        Create the logger to be used by the test harness OAIO @ref
+        session.
+
+        @return logging.SeverityFilter A logging.ConsoleLogger wrapped
+        in a `SeverityFilter`.
+        """
+        return logging.SeverityFilter(logging.ConsoleLogger())
+
+
+class ValidatorHarness:
+    """
+    Facade wrapping the unittest runner.
+
+    Injects a custom testcase loader and acts as an anti-corruption
+    layer around a unittest-compatible test runner.
+    """
+    # pylint: disable=too-few-public-methods
+
+    _kValidatorHarnessProgramName = "managerValidator"
+
+    def __init__(self, runner, loader):
+        """
+        Initializes an instance of this class.
+
+        @param runner `unittest.main` A unittest-compatible test runner.
+
+        @param loader ValidatorTestLoader A unittest-compatible test
+        case loader that injects test fixtures into test case instances.
+        """
+        self.__runner = runner
+        self.__loader = loader
+
+    def executeTests(self, extraArgs, module):
+        """
+        Run the tests harness test cases in the provided `module`,
+        passing any `extraArgs` to the test runner.
+
+        @param extraArgs `List[str]` Arguments to pass to the unittest
+        runner.
+
+        @param module `types.ModuleType` Python module containing the
+        test cases to execute.
+
+        @return `bool` `True` if all tests succeeded, `False` otherwise.
+        """
+        # Prepend the "program name" to simulate full argv for unittest.
+        argv = [self._kValidatorHarnessProgramName] + extraArgs
+        runnerInstance = self.__runner(
+            testLoader=self.__loader, argv=argv, module=module, exit=False)
+        return runnerInstance.result.wasSuccessful()
+
+
+class ValidatorTestLoader(unittest.loader.TestLoader):
+    """
+    Custom test case loader that injects test harness fixtures into
+    test cases for use in querying and assertions.
+    """
+    def __init__(self, fixtures, session):
+        """
+        Initializes an instance of this class.
+
+        @param fixtures `Dict[Any, Any]` Dictionary of test case
+        fixtures.
+
+        @param session hostAPI.Session.Session Test harness OAIO @ref
+        session
+        """
+        self.__fixtures = fixtures
+        self.__session = session
+        super(ValidatorTestLoader, self).__init__()
+
+    def loadTestsFromTestCase(self, testCaseClass):
+        """
+        Override of base class to additionally inject fixtures and OAIO
+        @ref session into test cases.
+
+        Injects the child dict of the `fixtures` dict that corresponds
+        to the test case class and method. If no such dict is available
+        then the injected fixtures for the test case will be `None`.
+
+        @param testCaseClass FixtureAugmentedTestCase Test case class
+        that supports injection of fixtures.
+
+        @return `unittest.suite.TestSuite` The unittest suite to
+        execute.
+        """
+        testCaseNames = self.getTestCaseNames(testCaseClass)
+        loadedSuite = self.suiteClass(
+            testCaseClass(
+                self.__fixtures.get(testCaseClass.__name__, {}).get(testCaseName),
+                self.__session, testCaseName
+            )
+            for testCaseName in testCaseNames)
+        return loadedSuite
+
+
+class ValidatorHarnessHostInterface(hostAPI.HostInterface):
+    """
+    Minimal required OAIO hostAPI.HostInterface.HostInterface
+    implementation.
+    """
+    def identifier(self):
+        return "org.openassetio.test.managerValidator"
+
+    def displayName(self):
+        return "OAIO Manager Validator"
+
+
+class FixtureAugmentedTestCase(unittest.TestCase):
+    """
+    Base test case class that all test classes must inherit from.
+
+    Expects test harness fixtures and an OAIO session to be provided,
+    hence requires that `unittest` is provided with the custom
+    ValidatorTestLoader test case loader.
+
+    Fixtures, session and manager interface are then provided to
+    subclasses via protected members.
+    """
+    def __init__(self, fixtures, session, *args, **kwargs):
+        """
+        Initializes an instance of this class.
+
+        Makes available `_fixtures`, `_session` and `_manager` to
+        subclasses.
+
+        @param fixtures `Dict[Any, Any]` Dictionary of fixtures specific
+        to the current test case.
+
+        @param session hostAPI.Session.Session The OAIO @ref session
+        to be used by test cases.
+
+        @param args `List[Any]` Additional args passed along to the
+        base class.
+
+        @param kwargs: `Dict[str, Any]` Additional keyword args passed
+        along to the base class.
+        """
+        self._fixtures = fixtures  # type: dict
+        self._session = session  # type: hostAPI.Session
+        self._manager = session.currentManager()  # type: managerAPI.ManagerInterface
+        super(FixtureAugmentedTestCase, self).__init__(*args, **kwargs)
+
+    def assertIsStringKeyPrimitiveValueDict(self, dictionary):
+        """
+        Assert that given `dictionary` is `str`-keyed with all primitive
+        values.
+
+        @param dictionary `Dict[Any, Any]` Dictionary to check.
+
+        @exception `AssertionError` On failure.
+        """
+        self.assertIsInstance(dictionary, dict)
+
+        for key, value in dictionary.items():
+            self.assertIsInstance(key, str)
+            self.assertIsInstance(value, (str, int, float, bool))

--- a/python/openassetio/test/managerValidator/validatorSuite.py
+++ b/python/openassetio/test/managerValidator/validatorSuite.py
@@ -1,0 +1,71 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Manager test harness test case suite.
+
+Test cases in this module are executed against the provided plugin,
+parametrised by the provided fixtures.
+"""
+
+# pylint: disable=invalid-name, missing-function-docstring
+
+from .validatorHarness import FixtureAugmentedTestCase
+
+
+__all__ = []
+
+
+class Test_identifier(FixtureAugmentedTestCase):
+    """
+    Check plugin's implementation of
+    managerAPI.ManagerInterface.identifier.
+    """
+    def test_is_correct_type(self):
+        self.assertIsInstance(self._manager.identifier(), str)
+
+    def test_is_non_empty(self):
+        self.assertIsNot(self._manager.identifier(), "")
+
+    def test_matches_fixture(self):
+        self.assertEqual(self._fixtures["identifier"], self._manager.identifier())
+
+
+class Test_displayName(FixtureAugmentedTestCase):
+    """
+    Check plugin's implementation of
+    managerAPI.ManagerInterface.displayName.
+    """
+    def test_is_correct_type(self):
+        self.assertIsInstance(self._manager.displayName(), str)
+
+    def test_is_non_empty(self):
+        self.assertIsNot(self._manager.displayName(), "")
+
+    def test_matches_fixture(self):
+        self.assertEqual(self._fixtures["displayName"], self._manager.displayName())
+
+
+class Test_info(FixtureAugmentedTestCase):
+    """
+    Check plugin's implementation of managerAPI.ManagerInterface.info.
+    """
+    # TODO(DF): Once `isEntityReference` tests are added, check that
+    #   `kField_EntityReferencesMatchPrefix` in info dict is used.
+    def test_is_correct_type(self):
+        self.assertIsStringKeyPrimitiveValueDict(self._manager.info())
+
+    def test_matches_fixture(self):
+        self.assertEqual(self._fixtures["info"], self._manager.info())

--- a/resources/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
+++ b/resources/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
@@ -21,7 +21,7 @@ A single-class module, providing the SampleAssetManagerInterface class.
 # the this class. See the notes under the "Initialization" section of:
 #   https://thefoundryvisionmongers.github.io/OpenAssetIO/classopenassetio_1_1manager_a_p_i_1_1_manager_interface_1_1_manager_interface.html#details (pylint: disable=line-too-long)
 # As such, any expensive module imports should be deferred.
-
+from openassetio.constants import kField_EntityReferencesMatchPrefix
 from openassetio.managerAPI import ManagerInterface
 
 __all__ = ['SampleAssetManagerInterface', ]
@@ -43,5 +43,17 @@ class SampleAssetManagerInterface(ManagerInterface):
     def identifier():
         return "org.openassetio.examples.manager.sam"
 
+    def initialize(self, hostSession):
+        pass
+
     def displayName(self):
         return "Sample Asset Manager (SAM)"
+
+    def info(self):
+        # This hint allows the API middleware to short-circuit calls to `isEntityReference`
+        # using string prefix comparisons. If your implementation's entity reference format
+        # supports this kind of matching, you should set this key. It allows for multi-threaded
+        # reference testing in C++ as it avoids the need to acquire the GIL and enter Python.
+        return {
+            kField_EntityReferencesMatchPrefix: "sam://"
+        }

--- a/resources/examples/manager/SampleAssetManager/test/fixtures.py
+++ b/resources/examples/manager/SampleAssetManager/test/fixtures.py
@@ -1,0 +1,42 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Manager test harness test case fixtures for Sample Asset Manager (SAM).
+"""
+from openassetio.constants import kField_EntityReferencesMatchPrefix
+
+kIdentifier = "org.openassetio.examples.manager.sam"
+
+fixtures = {
+    "identifier": kIdentifier,
+    "Test_identifier": {
+        "test_matches_fixture": {
+            "identifier": kIdentifier
+        }
+    },
+    "Test_displayName": {
+        "test_matches_fixture": {
+            "displayName": "Sample Asset Manager (SAM)"
+        }
+    },
+    "Test_info": {
+        "test_matches_fixture": {
+            "info" : {
+                kField_EntityReferencesMatchPrefix: "sam://"
+            }
+        }
+    },
+}

--- a/tests/openassetio/test/managerValidator/__init__.py
+++ b/tests/openassetio/test/managerValidator/__init__.py
@@ -1,0 +1,15 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#

--- a/tests/openassetio/test/managerValidator/conftest.py
+++ b/tests/openassetio/test/managerValidator/conftest.py
@@ -1,0 +1,62 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Common pytest fixtures available to all tests in this package.
+"""
+
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-function-docstring
+from unittest import mock
+
+import pytest
+
+from openassetio import hostAPI, logging
+from openassetio.test.managerValidator import validatorHarness
+
+
+@pytest.fixture
+def mock_host_interface():
+    return mock.create_autospec(
+        validatorHarness.ValidatorHarnessHostInterface, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def mock_manager_factory():
+    return mock.create_autospec(hostAPI.ManagerFactoryInterface, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def mock_session(mock_manager):
+    sess = mock.create_autospec(hostAPI.Session, instance=True, spec_set=True)
+    sess.currentManager.return_value = mock_manager
+    return sess
+
+
+@pytest.fixture
+def mock_manager():
+    return mock.create_autospec(hostAPI.Manager, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def mock_logger():
+    return mock.create_autospec(logging.LoggerInterface, instance=True, spec_set=False)
+
+
+@pytest.fixture
+def a_fixture_dict():
+    return {
+        "identifier": "org.some.manager"
+    }

--- a/tests/openassetio/test/managerValidator/test_commandLine.py
+++ b/tests/openassetio/test/managerValidator/test_commandLine.py
@@ -1,0 +1,139 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Unit tests for the commandLine module of the manager test harness.
+"""
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=too-many-arguments,too-few-public-methods
+
+import tempfile
+import textwrap
+import types
+import unittest
+from unittest import mock
+from unittest.mock import Mock
+
+import pytest
+
+from openassetio.test.managerValidator import commandLine, validatorHarness
+
+
+class Test_execute:
+    def test_constructs_dependencies_and_runs_tests(
+            self, mock_parser, mock_module, mock_host_interface, mock_session,
+            mock_manager_factory, mock_logger, mock_harness_factory, mock_case_loader,
+            mock_harness):
+        # setup
+
+        argv = Mock()
+        parsed = mock_parser.parse.return_value
+
+        # action
+
+        result = commandLine.execute(
+            argv, mock_module, parser=mock_parser, harnessFactory=mock_harness_factory)
+
+        # confirm
+
+        mock_parser.parse.assert_called_once_with(argv)
+        mock_harness_factory.createHostInterface.assert_called_once_with()
+        mock_harness_factory.createLogger.assert_called_once_with()
+        mock_harness_factory.createManagerFactory.assert_called_once_with(mock_logger)
+        mock_harness_factory.createSessionWithManager.assert_called_once_with(
+            parsed.fixtures["identifier"], mock_host_interface, mock_logger, mock_manager_factory)
+        mock_harness_factory.createLoader.assert_called_once_with(parsed.fixtures, mock_session)
+        mock_harness_factory.createHarness.assert_called_once_with(unittest.main, mock_case_loader)
+        mock_harness.executeTests.assert_called_once_with(parsed.extraArgs, mock_module)
+        assert result is mock_harness.executeTests.return_value
+
+
+class Test_Parser_parse:
+    def test_loads_fixtures_and_returns_with_extra_args(self, mock_fixture_loader):
+        parser = commandLine.Parser(mock_fixture_loader)
+
+        parsed = parser.parse([
+            "managerValidator", "--fixtures", "/some/fixtures.json", "-v", "extra", "arg"])
+
+        mock_fixture_loader.load.assert_called_once_with("/some/fixtures.json")
+        assert parsed.fixtures is mock_fixture_loader.load.return_value
+        assert parsed.extraArgs == ["-v", "extra", "arg"]
+
+
+class Test_FixtureLoader_load:
+    def test_retrieves_dict_from_python_file(self, a_fixture_dict, a_fixture_file):
+        fixture_loader = commandLine.PyFixtureLoader()
+
+        actual_dict = fixture_loader.load(a_fixture_file)
+
+        assert a_fixture_dict == actual_dict
+
+
+@pytest.fixture
+def mock_parser():
+    parser = mock.create_autospec(commandLine.Parser)
+    parsed = mock.create_autospec(commandLine.ParsedArgs)
+    parser.parse.return_value = parsed
+    return parser
+
+
+@pytest.fixture
+def mock_module():
+    return mock.create_autospec(types.ModuleType)
+
+
+@pytest.fixture
+def mock_harness_factory(
+        mock_harness, mock_case_loader, mock_host_interface, mock_session, mock_manager_factory,
+        mock_logger):
+    factory = mock.create_autospec(
+        validatorHarness.ValidatorHarnessFactory, instance=True, spec_set=True)
+    factory.createHarness.return_value = mock_harness
+    factory.createLoader.return_value = mock_case_loader
+    factory.createHostInterface.return_value = mock_host_interface
+    factory.createSessionWithManager.return_value = mock_session
+    factory.createManagerFactory.return_value = mock_manager_factory
+    factory.createLogger.return_value = mock_logger
+    return factory
+
+
+@pytest.fixture
+def mock_harness():
+    return mock.create_autospec(validatorHarness.ValidatorHarness, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def mock_case_loader():
+    return mock.create_autospec(validatorHarness.ValidatorTestLoader, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def mock_fixture_loader():
+    return mock.create_autospec(commandLine.PyFixtureLoader, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def a_fixture_file(a_fixture_dict):
+    with tempfile.NamedTemporaryFile(suffix=".py") as fixture_file:
+        fixture_file.write(textwrap.dedent(f"""
+            fixtures = {a_fixture_dict}
+        """).encode())
+
+        fixture_file.flush()
+
+        yield fixture_file.name

--- a/tests/openassetio/test/managerValidator/test_validatorHarness.py
+++ b/tests/openassetio/test/managerValidator/test_validatorHarness.py
@@ -1,0 +1,301 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Unit tests for the validatorHarness module of the manager test harness.
+"""
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=too-many-arguments,too-few-public-methods
+# pylint: disable=protected-access
+
+import unittest
+from unittest import mock
+from unittest.mock import Mock, call
+
+import pytest
+
+from openassetio import logging, pluginSystem, hostAPI
+from openassetio.test.managerValidator import validatorHarness
+
+
+class Test_ValidatorHarnessFactory_createHarness:
+    def test_constructs_harness(self, monkeypatch, mock_runner, mock_test_loader):
+        StubHarness = mock.create_autospec(
+            validatorHarness.ValidatorHarness, instance=False, spec_set=True)
+        monkeypatch.setattr(validatorHarness, "ValidatorHarness", StubHarness)
+
+        harness = validatorHarness.ValidatorHarnessFactory().createHarness(
+            mock_runner, mock_test_loader)
+
+        assert harness is StubHarness.return_value
+
+
+class Test_ValidatorHarnessFactory_createLoader:
+    def test_constructs_loader(self, monkeypatch, a_fixture_dict, mock_session):
+        StubLoader = mock.create_autospec(
+            validatorHarness.ValidatorTestLoader, instance=False, spec_set=True)
+        monkeypatch.setattr(validatorHarness, "ValidatorTestLoader", StubLoader)
+
+        loader = validatorHarness.ValidatorHarnessFactory().createLoader(
+            a_fixture_dict, mock_session)
+
+        assert loader is StubLoader.return_value
+
+
+class Test_ValidatorHarnessFactory_createHostInterface:
+    def test_constructs_interface(self, monkeypatch):
+        StubHostInterface = mock.create_autospec(
+            validatorHarness.ValidatorHarnessHostInterface, instance=False, spec_set=True)
+        monkeypatch.setattr(validatorHarness, "ValidatorHarnessHostInterface", StubHostInterface)
+
+        interface = validatorHarness.ValidatorHarnessFactory().createHostInterface()
+
+        assert interface is StubHostInterface.return_value
+
+
+class Test_ValidatorHarnessFactory_createSession:
+    def test_constructs_session(self, monkeypatch, mock_host_interface, mock_logger):
+        manager_factory = mock.create_autospec(hostAPI.ManagerFactoryInterface)
+        StubSession = mock.create_autospec(hostAPI.Session, instance=False, spec_set=True)
+        monkeypatch.setattr(hostAPI, "Session", StubSession)
+
+        session = validatorHarness.ValidatorHarnessFactory().createSessionWithManager(
+            "org.some.id", mock_host_interface, mock_logger, manager_factory)
+
+        StubSession.assert_called_once_with(mock_host_interface, mock_logger, manager_factory)
+        session.useManager.assert_called_once_with("org.some.id")  # pylint: disable=no-member
+        assert session is StubSession.return_value
+
+
+class Test_ValidatorHarnessFactory_createManagerFactory:
+    def test_constructs_factory(self, monkeypatch, mock_logger):
+        StubManagerFactory = mock.create_autospec(
+            pluginSystem.PluginSystemManagerFactory, instance=False, spec_set=True)
+        monkeypatch.setattr(pluginSystem, "PluginSystemManagerFactory", StubManagerFactory)
+
+        manager_factory = validatorHarness.ValidatorHarnessFactory().createManagerFactory(
+            mock_logger)
+
+        StubManagerFactory.assert_called_once_with(mock_logger)
+        assert manager_factory is StubManagerFactory.return_value
+
+
+class Test_ValidatorHarnessFactory_createLogger:
+    def test_constructs_logger(self, monkeypatch):
+        StubFilter = mock.create_autospec(logging.SeverityFilter, instance=False, spec_set=True)
+        monkeypatch.setattr(logging, "SeverityFilter", StubFilter)
+        StubLogger = mock.create_autospec(logging.ConsoleLogger, instance=False, spec_set=True)
+        monkeypatch.setattr(logging, "ConsoleLogger", StubLogger)
+
+        manager_factory = validatorHarness.ValidatorHarnessFactory().createLogger()
+
+        StubFilter.assert_called_once_with(StubLogger.return_value)
+        assert manager_factory is StubFilter.return_value
+
+
+class Test_Harness_executeTests:
+    def test_executes_runner_and_returns_runner_result(self, mock_runner, mock_test_loader):
+        module = Mock()
+        harness = validatorHarness.ValidatorHarness(mock_runner, mock_test_loader)
+
+        result = harness.executeTests(["some", "args"], module)
+
+        mock_runner.assert_called_once_with(
+            testLoader=mock_test_loader, argv=["managerValidator", "some", "args"],
+            module=module, exit=False)
+        assert result is mock_runner.return_value.result.wasSuccessful.return_value
+
+
+class Test_Loader_loadTestsFromTestCase:
+    def test_when_class_of_cases_has_no_fixtures_then_initialises_test_cases_with_no_fixtures(
+            self, a_fixture_dict, mock_session, mock_test_case_class, mock_test_case_one,
+            mock_test_case_two):
+        # setup
+
+        loader = validatorHarness.ValidatorTestLoader(a_fixture_dict, mock_session)
+
+        # action
+
+        suite = loader.loadTestsFromTestCase(mock_test_case_class)
+
+        # confirm
+
+        # Assert that the instances of the TestCase class are given the
+        # Host instance in their constructors.
+        mock_test_case_class.assert_has_calls([
+            call(None, mock_session, "test_one"),
+            call(None, mock_session, "test_two")])
+        assert set(suite._tests) == {mock_test_case_one, mock_test_case_two}
+
+    def test_when_cases_have_fixtures_then_initialises_test_cases_with_fixtures(
+            self, a_fixture_dict, mock_session, mock_test_case_class, mock_test_case_one,
+            mock_test_case_two):
+        # setup
+
+        # Include fixtures for both test cases
+        case_one_fixtures = Mock()
+        case_two_fixtures = Mock()
+        a_fixture_dict["Test_MockTest"] = {
+            "test_one": case_one_fixtures,
+            "test_two": case_two_fixtures
+        }
+        loader = validatorHarness.ValidatorTestLoader(a_fixture_dict, mock_session)
+
+        # action
+
+        suite = loader.loadTestsFromTestCase(mock_test_case_class)
+
+        # confirm
+
+        # Assert that the instances of the TestCase class are given the
+        # Host instance in their constructors.
+        mock_test_case_class.assert_has_calls([
+            call(case_one_fixtures, mock_session, "test_one"),
+            call(case_two_fixtures, mock_session, "test_two")])
+        assert set(suite._tests) == {mock_test_case_one, mock_test_case_two}
+
+    def test_when_case_has_no_fixtures_then_initialises_test_case_with_no_fixtures(
+            self, a_fixture_dict, mock_session, mock_test_case_class, mock_test_case_one,
+            mock_test_case_two):
+        # setup
+
+        # Only include fixtures for one test case
+        case_two_fixtures = Mock()
+        a_fixture_dict["Test_MockTest"] = {
+            "test_two": case_two_fixtures
+        }
+        loader = validatorHarness.ValidatorTestLoader(a_fixture_dict, mock_session)
+
+        # action
+
+        suite = loader.loadTestsFromTestCase(mock_test_case_class)
+
+        # confirm
+
+        # Assert that the instances of the TestCase class are given the
+        # Host instance in their constructors.
+        mock_test_case_class.assert_has_calls([
+            call(None, mock_session, "test_one"),
+            call(case_two_fixtures, mock_session, "test_two")])
+        assert set(suite._tests) == {mock_test_case_one, mock_test_case_two}
+
+
+class Test_ValidatorHostInterface_identifier:
+    def test_returns_expected_id(self):
+        interface = validatorHarness.ValidatorHarnessHostInterface()
+        assert interface.identifier() == "org.openassetio.test.managerValidator"
+
+
+class Test_ValidatorHostInterface_displayName:
+    def test_returns_expected_name(self):
+        interface = validatorHarness.ValidatorHarnessHostInterface()
+        assert interface.displayName() == "OAIO Manager Validator"
+
+
+class Test_FixtureAugmentedTestCase_init:
+    def test_has_fixtures_session_and_manager(
+            self, mock_test_case, a_fixture_dict, mock_session, mock_manager):
+        assert mock_test_case._fixtures is a_fixture_dict
+        assert mock_test_case._session is mock_session
+        assert mock_test_case._manager is mock_manager
+
+
+class Test_FixtureAugmentedTestCase_assertIsStringKeyPrimitiveValueDict:
+    def test_when_not_dict_then_fails(self, mock_test_case):
+        with pytest.raises(AssertionError):
+            mock_test_case.assertIsStringKeyPrimitiveValueDict("something")
+
+    def test_when_dict_empty_then_passes(self, mock_test_case):
+        mock_test_case.assertIsStringKeyPrimitiveValueDict({})
+
+    def test_when_dict_ok_then_passes(self, mock_test_case):
+        mock_test_case.assertIsStringKeyPrimitiveValueDict({
+            "k1": 1, "k2": 1.1, "k3": "v", "k4": True
+        })
+
+    def test_when_dict_has_non_string_key_then_fails(self, mock_test_case):
+        with pytest.raises(AssertionError):
+            mock_test_case.assertIsStringKeyPrimitiveValueDict({
+                1: 1
+            })
+
+    def test_when_dict_has_nested_dict_then_fails(self, mock_test_case):
+        with pytest.raises(AssertionError):
+            mock_test_case.assertIsStringKeyPrimitiveValueDict({
+                "k": {}
+            })
+
+    def test_when_dict_has_None_then_fails(self, mock_test_case):
+        with pytest.raises(AssertionError):
+            mock_test_case.assertIsStringKeyPrimitiveValueDict({
+                "k": None
+            })
+
+    def test_when_dict_has_object_then_fails(self, mock_test_case):
+        with pytest.raises(AssertionError):
+            mock_test_case.assertIsStringKeyPrimitiveValueDict({
+                "k": object()
+            })
+
+
+@pytest.fixture
+def mock_runner():
+    result = mock.create_autospec(unittest.result.TestResult, instance=True, spec_set=True)
+    instance = mock.create_autospec(unittest.main, instance=True, result=result)
+    cls = mock.create_autospec(
+        unittest.main, instance=False, spec_set=True, return_value=instance)
+    return cls
+
+
+@pytest.fixture
+def mock_test_loader():
+    return mock.create_autospec(validatorHarness.ValidatorTestLoader, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def mock_test_case(a_fixture_dict, mock_session):
+    return validatorHarness.FixtureAugmentedTestCase(a_fixture_dict, mock_session)
+
+
+@pytest.fixture
+def mock_test_case_class(mock_test_case_one, mock_test_case_two):
+    # Construct a mock TestCase class with two test methods.
+    # In unittest each method runs under a new instance of the
+    # TestCase class.
+    test_case_class = mock.create_autospec(
+        validatorHarness.FixtureAugmentedTestCase, instance=False,
+        test_one=Mock(), test_two=Mock(),
+        # Note that __qualname__ is required simply to prevent
+        # exceptions from `getTestCaseNames`.
+        __qualname__="something",
+        __name__="Test_MockTest"
+    )
+    test_case_class.side_effect = [mock_test_case_one, mock_test_case_two]
+    return test_case_class
+
+
+@pytest.fixture
+def mock_test_case_one():
+    return mock.create_autospec(
+        validatorHarness.FixtureAugmentedTestCase, instance=True, spec_set=True)
+
+
+@pytest.fixture
+def mock_test_case_two():
+    return mock.create_autospec(
+        validatorHarness.FixtureAugmentedTestCase, instance=True, spec_set=True)


### PR DESCRIPTION
Implement the basic manager plugin test harness for #95 

Not covered:
* Nice bootstrap error messages (e.g. loading fixtures, initialising manager)
* Updating wider .dox documentation
