### PR TITLE
[CI] Ensure Doxygen problemMatcher catches all warnings

### DIFF
--- a/.github/workflows/problem-matchers/doxygen.json
+++ b/.github/workflows/problem-matchers/doxygen.json
@@ -10,9 +10,9 @@
       "owner": "doxygen",
       "pattern": [
         {
-          "regexp": "^.*?\\/src\\/([^:]+):(\\d+): ?(\\w+): ?(.*)$",
+          "regexp": "^.*?\\/src\\/([^:]+):\\d+: ?\\w+: ?(.*)$",
           "file": 1,
-          "message": 4
+          "message": 2
         }
       ]
     }

--- a/.github/workflows/problem-matchers/doxygen.json
+++ b/.github/workflows/problem-matchers/doxygen.json
@@ -10,7 +10,7 @@
       "owner": "doxygen",
       "pattern": [
         {
-          "regexp": "^\\/src\\/([^:]+):(\\d+): ?(\\w+): ?(.*)$",
+          "regexp": "^.*?\\/src\\/([^:]+):(\\d+): ?(\\w+): ?(.*)$",
           "file": 1,
           "message": 4
         }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,5 @@ jobs:
         # Fail the job if we have Doxygen warning/error lines in the
         # output. NB: This is the same regex as doxygen.json, adapted
         # to work with GNU grep.
-        ! grep -qE "^/src/([^:]+):([0-9]+): ?([a-zA-Z]+): ?(.*)$" doxygen-log.txt
+        ! grep -qE "^.*?/src/([^:]+):([0-9]+): ?([a-zA-Z]+): ?(.*)$" doxygen-log.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,5 @@ jobs:
         # Fail the job if we have Doxygen warning/error lines in the
         # output. NB: This is the same regex as doxygen.json, adapted
         # to work with GNU grep.
-        ! grep -qE "^.*?/src/([^:]+):([0-9]+): ?([a-zA-Z]+): ?(.*)$" doxygen-log.txt
+        ! grep -qE "^.*?/src/[^:]+:[0-9]+: ?[a-zA-Z]+: ?.*$" doxygen-log.txt
 

--- a/doc/src/Thumbnails.dox
+++ b/doc/src/Thumbnails.dox
@@ -30,8 +30,8 @@
  * If supported by the host, it will then:
  * - Call @ref preflight with the target entity and a @needsref ThumbnailSpecification
  *   that describes supported formats.
- * - Call @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.getEntityMetadata
- *   "getEntityMetadata" on the returned reference to determine the desired width/height/format
+ * - Call @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.getEntityAttributes
+ *   "getEntityAttributes" on the returned reference to determine the desired width/height/format
  *   for the thumbnail.
  * - Generate a thumbnail and @ref register it to the same reference.
  *


### PR DESCRIPTION
Inadvertently missed off preprocessing warnings that include a prefix before the file path.

https://github.com/foundrytom/OpenAssetIO/actions/runs/1559423183 is a run prior to the second commit, that shows the improved regex catches the existing failure.