### PR TITLE
[Core] Remove `kField_EntityReferencesMatchRegex`

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -111,8 +111,8 @@
  * optimisations that can reduce the number of inter-language hops
  * required. See @ref
  * openassetio.managerAPI.ManagerInterface.ManagerInterface.info
- * "ManagerInterface.info" and the `kField_EntityReferenceMatch*`
- * keys.
+ * "ManagerInterface.info" and the `kField_EntityReferencesMatchPrefix`
+ * key.
  *
  * @code{.py}
  * from openassetio import Context

--- a/python/openassetio/constants.py
+++ b/python/openassetio/constants.py
@@ -76,12 +76,11 @@ kField_Icon = 'icon'
 
 # Entity Reference Properties
 
-## These fields may be used by the API/Host to optimize queries to
-## isEntityReference in situations where bridging languages, etc.. can be
-## expensive (particularly in the case of python plug-ins called from
-## multi-threaded C). Only one should be set at once.
+## This field may be used by the API to optimize queries to
+## isEntityReference in situations where bridging languages, etc.
+## can be expensive (particularly in the case of python plug-ins
+## called from multi-threaded C++).
 kField_EntityReferencesMatchPrefix = "entityReferencesMatchPrefix"
-kField_EntityReferencesMatchRegex = "entityReferencesMatchRegex"
 
 # Files
 

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -146,7 +146,6 @@ class Manager(Debuggable):
           @li openassetio.constants.kField_SmallIcon (upto 32x32)
           @li openassetio.constants.kField_Icon (any size)
           @li openassetio.constants.kField_EntityReferencesMatchPrefix
-          @li openassetio.constants.kField_EntityReferencesMatchRegex
 
         Keys will always be str, and Values will be int, bool, float or
         str.
@@ -410,8 +409,7 @@ class Manager(Debuggable):
         @see resolveEntityReference
 
         @todo Make use of
-        openassetio.constants.kField_EntityReferenceMatchPrefix or
-        openassetio.constants.kField_EntityReferenceMatchRegex if
+        openassetio.constants.kField_EntityReferencesMatchPrefix if
         supplied, especially when bridging between C/python.
         """
         # We need to add support here for using the supplied prefix match string,

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -232,18 +232,16 @@ class ManagerInterface(object):
           @li openassetio.constants.kField_Icon (any size)
 
         Because it can often be expensive to bridge between languages,
-        info can also contain one of two additional fields - a prefix,
-        or perl regex compatible string to identify a valid entity
-        reference. Only one should be set at once. If supplied, this may
-        be used by the API to optimize calls to isEntityReference when
-        bridging between C/Python etc... can be slow. If neither of
-        these fields are set, then isEntityReference will always be used
-        to determine if a string is an @ref entity_reference or not.
-        Note, not all hosts support this optimisation, so @ref
-        isEntityReference should be implemented regardless.
+        info can also contain an additional field - a prefix that
+        identifies a string as a valid entity reference. If supplied,
+        this will be used by the API to optimize calls to
+        isEntityReference when bridging between C/Python etc.
+        If this isn't supplied, then isEntityReference will always be
+        called to determine if a string is an @ref entity_reference or
+        not. Note, not all invocations require this optimization, so
+        @ref isEntityReference should be implemented regardless.
 
           @li openassetio.constants.kField_EntityReferencesMatchPrefix
-          @li openassetio.constants.kField_EntityReferencesMatchRegex
 
         @note Keys should always be strings, and values must be
         plain-old-data types (ie: str, int, float, bool).


### PR DESCRIPTION
Technically, saying "some calls won't need it" is a bit of a lie. In theory, if this was provided, we could avoid ever calling `isEntityRefrence`. Shall we gloss over that for now, to make sure that people do still implement that method. If feels ripe for fragility otherwise?