### PR TITLE
The great `pylint` cleanup - Part III - `Manager`/`ManagerInterface`

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -17,6 +17,12 @@
 A single-class module, providing the Manager class.
 """
 
+# Most of this module is documentation, which hopefully is a good thing.
+# pylint: disable=too-many-lines
+# We discussed splitting the interface up, but it ends up making most
+# implementations more complicated.
+# pylint: disable=too-many-public-methods
+
 from ..managerAPI.ManagerInterface import ManagerInterface
 
 from .._core.debug import debugApiCall, Debuggable

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -13,6 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+A single-class module, providing the Manager class.
+"""
 
 from ..managerAPI.ManagerInterface import ManagerInterface
 
@@ -654,6 +657,19 @@ class Manager(Debuggable):
     @debugApiCall
     @auditApiCall("Manager methods")
     def setEntityAttribute(self, entityRefs, name, value, context):
+        """
+        Sets a single attribute for each given entity.
+
+        @see getEntityAttributes
+
+        @param entityRefs `List[str]` Entity references to set attributes for.
+
+        @param name `str` The attribute name to set.
+
+        @param value `primitive` The values to set for each referenced entity.
+
+        @param context Context The calling context.
+        """
         return self.__impl.setEntityAttribute(
             entityRefs, name, value, context, self.__hostSession)
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -1116,9 +1116,9 @@ class ManagerInterface(object):
         if not self.entityExists(entityRef, context, hostSession):
             raise exceptions.InvalidEntityReference(entityReference=entityRef)
 
-        for r in relatedRefs:
-            if not self.entityExists(r, context, hostSession):
-                raise exceptions.InvalidEntityReference(entityReference=r)
+        for ref in relatedRefs:
+            if not self.entityExists(ref, context, hostSession):
+                raise exceptions.InvalidEntityReference(entityReference=ref)
 
     ## @}
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -18,7 +18,7 @@ A single-class module, providing the ManagerInterface class.
 """
 
 # Most of this module is documentation, which hopefully is a good thing.
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,line-too-long
 # We discussed splitting the interface up, but it ends up making most
 # implementations more complicated.
 # pylint: disable=too-many-public-methods

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -278,7 +278,6 @@ class ManagerInterface(object):
         @see @ref openassetio.constants
         @see @ref openassetio.hostAPI.terminology.defaultTerminology
         """
-        pass
 
     ## @}
 
@@ -297,7 +296,6 @@ class ManagerInterface(object):
         """
         @todo Document settings mechanism
         """
-        pass
 
     @abc.abstractmethod
     def initialize(self, hostSession):
@@ -374,7 +372,6 @@ class ManagerInterface(object):
 
         @return `None`
         """
-        pass
 
     def flushCaches(self, hostSession):
         """
@@ -384,7 +381,6 @@ class ManagerInterface(object):
         data to be discarded to ensure future queries are fresh. This
         should have no effect on any open @ref transaction.
         """
-        pass
 
     ## @}
 
@@ -1433,7 +1429,6 @@ class ManagerInterface(object):
         @see cancelTransaction()
         @see The @ref transactions page.
         """
-        pass
 
     def finishTransaction(self, state, hostSession):
         """
@@ -1460,7 +1455,6 @@ class ManagerInterface(object):
         @see cancelTransaction()
         @see The @ref transactions page.
         """
-        pass
 
     def cancelTransaction(self, state, hostSession):
         """

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -13,6 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+A single-class module, providing the ManagerInterface class.
+"""
 
 import abc
 from .. import exceptions
@@ -804,6 +807,24 @@ class ManagerInterface(object):
         return value
 
     def setEntityAttribute(self, entityRefs, name, value, context, hostSession):
+        """
+        Sets a single attribute for each given entity.
+
+        @see getEntityAttributes
+
+        @param entityRefs `List[str]` Entity references to set attributes for.
+
+        @param name `str` The attribute name to set.
+
+        @param value `primitive` The values to set for each referenced entity.
+
+        @param context Context The calling context.
+
+        @param hostSession openassetio.managerAPI.HostSession The host
+        session that maps to the caller, this should be used for all
+        logging and provides access to the openassetio.managerAPI.Host
+        object representing the process that initiated the API session.
+        """
         self.setEntityAttributes(entityRefs, {name: value}, context, hostSession, merge=True)
 
     ## @}

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -17,6 +17,14 @@
 A single-class module, providing the ManagerInterface class.
 """
 
+# Most of this module is documentation, which hopefully is a good thing.
+# pylint: disable=too-many-lines
+# We discussed splitting the interface up, but it ends up making most
+# implementations more complicated.
+# pylint: disable=too-many-public-methods
+# As this is an abstract base class, there are many of these.
+# pylint: disable=unused-argument,no-self-use
+
 import abc
 from .. import exceptions
 


### PR DESCRIPTION
Part of #101. Once #138 is merged, this should hopefully clean up all `pylint` errors in `Manager.py` and `ManagerInterface.py`