### PR TITLE
[Docs] Fix thumbnails example code

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -236,7 +236,7 @@
  * # See if the manager can tell us where to put it, and what it should be like
  * if policy & constants.kWillManagePath:
  *    thumbnail_path = manager.resolveEntityReference([thumbnail_ref], context)[0]
- *    thumbnail_attr.update(manager.getEntityMetadata([thumbnail_ref], context)[0])
+ *    thumbnail_attr.update(manager.getEntityAttributes([thumbnail_ref], context)[0])
  *
  * # Generate a thumbnail using the supplied criteria
  * mk_thumbnail(thumbnail_path, thumbnail_attr["width"], thumbnail_attr["height"])


### PR DESCRIPTION
It was victim of a mid-air-collision when we renamed Metadata to Attributes in #117.

