### PR TITLE
The great `pylint` cleanup - Part IV - `audit.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.pylint.messages_control]
 disable = [
     "too-many-arguments",
+    "too-few-public-methods",
     # Disable Python 3 improvements:
     # - We've not definitely ruled 2 out
     # - Much of this code will move to C++

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -427,10 +427,10 @@ class Auditor(object):
 
         return s
 
-    def __getObjDict(self, dict, obj):
+    def __getObjDict(self, parentDict, obj):
         # Presently, we simply create a child dict for the obj if there isn't one,
         # and ensure it has the count key, and its initialized to 0
-        return dict.setdefault(obj, {self.kKey_Count: 0})
+        return parentDict.setdefault(obj, {self.kKey_Count: 0})
 
     def __classFromObj(self, obj):
 

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -431,7 +431,8 @@ class Auditor(object):
         # and ensure it has the count key, and its initialized to 0
         return parentDict.setdefault(obj, {self.kKey_Count: 0})
 
-    def __classFromObj(self, obj):
+    @staticmethod
+    def __classFromObj(obj):
 
         # If its an instance method then get self, which will be an instance, or a
         # class in the case of @classmethods

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -169,7 +169,7 @@ def __auditObj(aud, obj):
             __auditObj(aud, element)
         return
 
-    elif isinstance(obj, dict):
+    if isinstance(obj, dict):
         for value in obj.values():
             __auditObj(aud, value)
         return

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -157,9 +157,9 @@ def __auditObj(a, obj):
     """
 
     # Here to prevent cyclic dependencies
-    from . import specifications
-    from . import items
-    from . import Context
+    # pylint: disable=import-outside-toplevel
+    from .. import Specification
+    from .. import Context
 
     # Look inside sequence types / dicts
     if isinstance(obj, (list, tuple)):
@@ -172,7 +172,7 @@ def __auditObj(a, obj):
             __auditObj(a, o)
         return
 
-    if isinstance(obj, specifications.Specification):
+    if isinstance(obj, Specification):
         # If its a spec, just add the spec class
         a.addClass(obj, group="Specifications")
 

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -26,8 +26,9 @@ import os
 # Support the existing names for module-level vars
 # pylint: disable=invalid-name
 
-__all__ = ['auditor', 'auditCall', 'auditApiCall', 'auditCalls', 'captureArgs', 'reprArgs',
-           'Auditor']
+
+__all__ = ['auditor', 'auditCall', 'auditApiCall', 'auditCalls',
+           'captureArgs', 'reprArgs', 'Auditor']
 
 ##
 # @namespace openassetio._core.audit

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -255,7 +255,7 @@ class Auditor(object):
         @return dict, The coverage data dict for the Class
         """
         if not self.__enabled:
-            return
+            return {}
 
         cls = self.__classFromObj(obj)
 
@@ -296,7 +296,7 @@ class Auditor(object):
         """
 
         if not self.__enabled:
-            return
+            return {}
 
         # Count a usage of the methods Class, which will conveniently give us back
         # the right dictionary for any child methods, etc....
@@ -345,7 +345,7 @@ class Auditor(object):
         """
 
         if not self.__enabled:
-            return
+            return {}
 
         objDict = self.__getObjDict(self.__coverage, obj)
         objDict[self.kKey_Count] += 1

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -13,6 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+This module provides utility code that allows method and object usage
+to be audited.
+"""
 
 import copy
 import functools
@@ -216,12 +220,25 @@ class Auditor(object):
         self.reset()
 
     def getEnabled(self):
+        """
+        @returns `bool`, The enabled state of the Auditor.
+        """
         return self.__enabled
 
     def setEnabled(self, enabled):
+        """
+        Sets the state of the auditor.
+
+        When disabled, all audit calls will be lightweight no-ops.
+
+        @param enabled `bool` The new enabled state.
+        """
         self.__enabled = enabled
 
     def reset(self):
+        """
+        Clears any recorded usage.
+        """
         self.__coverage = {}
         self.__groups = {}
 

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -59,6 +59,7 @@ def auditor():
     """
     Returns a singleton Auditor, created on demand.
     """
+    # pylint: disable=global-statement
     global __auditor
     if not __auditor:
         __auditor = Auditor()
@@ -318,7 +319,7 @@ class Auditor(object):
             argsList = methodDict.setdefault(self.kKey_Args, [])
             try:
                 argsList.append(copy.deepcopy(arg))
-            except BaseException:
+            except BaseException: # pylint: disable=broad-except
                 pass
 
         # If we have a group, count the method there too. We don't keep args here,
@@ -383,6 +384,7 @@ class Auditor(object):
         @return str, A multi-line formatted string containing recorded
         coverage.
         """
+        # pylint: disable=too-many-nested-blocks
 
         outputStr = ""
 
@@ -407,7 +409,7 @@ class Auditor(object):
                             # Some hosts will raise here based on binding issues, etc...
                             try:
                                 outputStr += "        %r\n" % (arg,)
-                            except BaseException:
+                            except BaseException: # pylint: disable=broad-except
                                 pass
                         outputStr += "\n"
 

--- a/tests/openassetio/_core/test_audit.py
+++ b/tests/openassetio/_core/test_audit.py
@@ -1,0 +1,183 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""
+Minimal tests of the core API auditing functionality. These tests are
+left fairly basic as this aspect of the API is subject to significant
+change when moved to C++. This hopefully is enough to check that it
+works at a basic level.
+"""
+
+import os
+import sys
+
+import pytest
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name
+# pylint: disable=import-outside-toplevel
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+
+audit_env_var_name = "OAIO_AUDIT"
+audit_args_capture_env_var_name = "OAIO_AUDIT_ARGS"
+
+
+# Global toggle tests required a clean slate for each import.
+@pytest.fixture(autouse=True)
+def unload_openassetio_modules():
+    """
+    Removes openassetio modules from the sys.modules cache that
+    otherwise mask cyclic dependencies.
+    """
+    to_delete = [
+        name for name in sys.modules if name.startswith("openassetio")]
+    for name in to_delete:
+        del sys.modules[name]
+
+
+class Test_global_toggles:
+
+    def test_when_imported_with_no_env_set_then_auditing_is_disabled(
+            self, monkeypatch):
+
+        if audit_env_var_name in os.environ:
+            monkeypatch.delenv(audit_env_var_name)
+
+        from openassetio._core import audit
+        assert audit.auditCalls is False
+
+    def test_when_imported_with_env_var_set_to_zero_then_auditing_is_disabled(
+            self, monkeypatch):
+
+        monkeypatch.setenv(audit_env_var_name, "0")
+
+        from openassetio._core import audit
+        assert audit.auditCalls is False
+
+    def test_when_imported_with_env_var_set_to_not_zero_then_auditing_is_enabled(
+            self, monkeypatch):
+
+        monkeypatch.setenv(audit_env_var_name, "1")
+
+        from openassetio._core import audit
+        assert audit.auditCalls is True
+
+    def test_when_imported_with_env_var_empty_then_auditing_is_enabled(
+            self, monkeypatch):
+
+        monkeypatch.setenv(audit_env_var_name, "")
+
+        from openassetio._core import audit
+        assert audit.auditCalls is True
+
+    def test_when_imported_with_no_env_set_then_args_capture_is_disabled(
+            self, monkeypatch):
+
+        if audit_args_capture_env_var_name in os.environ:
+            monkeypatch.delenv(audit_args_capture_env_var_name)
+
+        from openassetio._core import audit
+        assert audit.captureArgs is False
+
+    def test_when_imported_with_env_var_set_to_zero_then_args_capture_is_disabled(
+            self, monkeypatch):
+
+        monkeypatch.setenv(audit_args_capture_env_var_name, "0")
+
+        from openassetio._core import audit
+        assert audit.captureArgs is False
+
+    def test_when_imported_with_env_var_set_to_not_zero_then_args_capture_is_enabled(
+            self, monkeypatch):
+
+        monkeypatch.setenv(audit_args_capture_env_var_name, "1")
+
+        from openassetio._core import audit
+        assert audit.captureArgs is True
+
+    def test_when_imported_with_env_var_empty_then_args_capture_is_enabled(
+            self, monkeypatch):
+
+        monkeypatch.setenv(audit_args_capture_env_var_name, "")
+
+        from openassetio._core import audit
+        assert audit.captureArgs is True
+
+
+class Test_singleton_access:
+
+    def test_when_called_multiple_times_then_returns_the_same_object(self):
+
+        from openassetio._core import audit
+
+        the_auditor = audit.auditor()
+        assert audit.auditor() is the_auditor
+
+
+class Test_auditing:
+
+    def test_when_decorator_applied_usage_is_captured(self):
+
+        from openassetio._core import audit
+
+        audit.auditCalls = True
+
+        @audit.auditCall
+        def a_method(an_arg):
+            return an_arg
+
+        a_method(1)
+        a_method("cat")
+
+        assert audit.auditor().sprintCoverage() == """Coverage:
+
+  function (2)
+    a_method (2)
+"""
+
+    def test_when_api_decorator_applied_usage_and_args_are_captured(self):
+
+        from openassetio._core import audit
+
+        audit.auditCalls = True
+        audit.captureArgs = True
+
+        @audit.auditApiCall(group="test", static=True)
+        def a_method(an_arg):
+            return an_arg
+
+        a_method(1)
+        a_method("cat")
+        a_method(["a", "list"])
+        a_method(object)
+
+        assert audit.auditor().sprintCoverage() == """Coverage:
+
+  function (4)
+    a_method (4)
+        ((1,), {})
+        (('cat',), {})
+        ((['a', 'list'],), {})
+        ((<class 'object'>,), {})
+
+
+Groups:
+
+  test:
+    a_method (4)
+
+"""

--- a/tests/openassetio/managerAPI/test_managerinterface.py
+++ b/tests/openassetio/managerAPI/test_managerinterface.py
@@ -69,8 +69,6 @@ class Test_ManagerInterface_entityVersions:
 
 class Test_ManagerInterface_finalizedEntityVersion:
 
-    # pylint: disable=too-few-public-methods
-
     def test_when_given_refs_then_returns_refs_unaltered(self, manager_interface):
         refs = Mock()
 

--- a/tests/openassetio/pluginSystem/test_pluginsystemmanagerfactory.py
+++ b/tests/openassetio/pluginSystem/test_pluginsystemmanagerfactory.py
@@ -44,8 +44,6 @@ def plugin_path_var_name():
 
 class Test_PluginSystemManagerFactory_init:
 
-    # pylint: disable=too-few-public-methods
-
     def test_when_env_var_not_set_then_logs_warning(
             self, a_logger, plugin_path_var_name, monkeypatch):
 


### PR DESCRIPTION
Cleans up assorted bugs spotted by `pytlint`, adds minimal test coverage to verify fixes. This deliberately keeps coverage light as this whole mechanism will have to change significantly when we port to C++.
