### PR TITLE
The great `pylint` cleanup - Part V - `debug.py`

### DIFF
--- a/python/openassetio/_core/debug.py
+++ b/python/openassetio/_core/debug.py
@@ -121,6 +121,8 @@ def __debugCall(function, traceFn, severity, self, *args, **kwargs):
             "Debug tracing methods can only be used on instances of a"
             " class derived from Debuggable")
 
+    # pylint: disable=protected-access
+
     # function and traceFn are provided so that when the function is wrapped,
     # traceFn is printed to the log, but function (usually the wrapper) is
     # still executed.

--- a/python/openassetio/_core/debug.py
+++ b/python/openassetio/_core/debug.py
@@ -17,6 +17,9 @@
 Decorators to aid the debugging of OAIO integrations within a host.
 """
 
+# For private decorator implementation methods
+# pylint: disable=invalid-name
+
 import functools
 import inspect
 import os
@@ -89,8 +92,8 @@ def debugCall(function):
     # otherwise, we obscure the signature of the underlying function
     params = inspect.formatargspec(*inspect.getfullargspec(debugFn))
     sig = "(Debug) %s%s" % (debugFn.__name__, params)
-    d = function.__doc__
-    _debugCall.__doc__ = "%s\n%s" % (sig, d) if d else sig
+    doc = function.__doc__
+    _debugCall.__doc__ = "%s\n%s" % (sig, doc) if doc else sig
 
     return _debugCall
 
@@ -117,8 +120,8 @@ def debugApiCall(function):
 
     params = inspect.signature(debugFn)
     sig = "(DebugAPI) %s%s" % (debugFn.__name__, params)
-    d = function.__doc__
-    _debugApiCall.__doc__ = "%s\n%s" % (sig, d) if d else sig
+    doc = function.__doc__
+    _debugApiCall.__doc__ = "%s\n%s" % (sig, doc) if doc else sig
 
     return _debugApiCall
 

--- a/python/openassetio/_core/debug.py
+++ b/python/openassetio/_core/debug.py
@@ -21,7 +21,6 @@ Decorators to aid the debugging of OAIO integrations within a host.
 # pylint: disable=invalid-name
 
 import functools
-import inspect
 import os
 import time
 
@@ -88,13 +87,6 @@ def debugCall(function):
     def _debugCall(*args, **kwargs):
         return __debugCall(function, debugFn, LoggerInterface.kDebug, *args, **kwargs)
 
-    # Ensure the docstring is updated so the help() messages are meaningful,
-    # otherwise, we obscure the signature of the underlying function
-    params = inspect.formatargspec(*inspect.getfullargspec(debugFn))
-    sig = "(Debug) %s%s" % (debugFn.__name__, params)
-    doc = function.__doc__
-    _debugCall.__doc__ = "%s\n%s" % (sig, doc) if doc else sig
-
     return _debugCall
 
 
@@ -117,11 +109,6 @@ def debugApiCall(function):
     @functools.wraps(function)
     def _debugApiCall(*args, **kwargs):
         return __debugCall(function, debugFn, LoggerInterface.kDebugAPI, *args, **kwargs)
-
-    params = inspect.signature(debugFn)
-    sig = "(DebugAPI) %s%s" % (debugFn.__name__, params)
-    doc = function.__doc__
-    _debugApiCall.__doc__ = "%s\n%s" % (sig, doc) if doc else sig
 
     return _debugApiCall
 

--- a/python/openassetio/_core/debug.py
+++ b/python/openassetio/_core/debug.py
@@ -13,6 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+Decorators to aid the debugging of OAIO integrations within a host.
+"""
 
 import functools
 import inspect
@@ -93,6 +96,11 @@ def debugCall(function):
 
 
 def debugApiCall(function):
+    """
+    Use as a decorator to trace usage of the decorated API functions though
+    the kDebugAPI logging severity. This should only be used on bound
+    methods.
+    """
     # See notes in debugCall
 
     # Early out if we're not enabled
@@ -174,6 +182,13 @@ class _Timer(object):
         self.end = time.time()
 
     def interval(self):
+        """
+        Returns ths interval of time the timer ran for. If the timer
+        is still running, then it will report the interval to the
+        time the method was called.
+
+        @returns float THe time interval as per `time.time()`
+        """
         end = self.end if self.end is not None else time.time()
         return end - self.start
 


### PR DESCRIPTION
Part of #101. Fixes all `pylint` warnings for `debug.py`, and manages to remove some old docs fudgery required for older python versions.