### PR TITLE
The great `pylint` cleanup - Part VI - `objects.py`

### DIFF
--- a/python/openassetio/_core/objects.py
+++ b/python/openassetio/_core/objects.py
@@ -123,7 +123,7 @@ class FixedInterfaceObject(object):
         # will be available in the data var by default too
 
         def predicate(m):
-            return isinstance(m, objectSystem.UntypedProperty)
+            return isinstance(m, UntypedProperty)
 
         members = inspect.getmembers(self.__class__, predicate)
         for name, prop in members:
@@ -151,7 +151,7 @@ class FixedInterfaceObject(object):
         """
 
         def predicate(m):
-            return isinstance(m, objectSystem.UntypedProperty)
+            return isinstance(m, UntypedProperty)
 
         members = inspect.getmembers(cls, predicate)
 

--- a/python/openassetio/_core/objects.py
+++ b/python/openassetio/_core/objects.py
@@ -13,6 +13,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+The OAIO API is built using the core FixedInterfaceObject class. This
+provides python objects that reject the addition of any new attributes
+at runtime, and provide type validation for their predefined
+properties when their values are set.
+"""
 
 import copy
 import inspect

--- a/python/openassetio/_core/objects.py
+++ b/python/openassetio/_core/objects.py
@@ -122,8 +122,8 @@ class FixedInterfaceObject(object):
         # We need to set any default values of the properties here, so that they
         # will be available in the data var by default too
 
-        def predicate(m):
-            return isinstance(m, UntypedProperty)
+        def predicate(member):
+            return isinstance(member, UntypedProperty)
 
         members = inspect.getmembers(self.__class__, predicate)
         for name, prop in members:
@@ -150,14 +150,14 @@ class FixedInterfaceObject(object):
         specified order.
         """
 
-        def predicate(m):
-            return isinstance(m, UntypedProperty)
+        def predicate(member):
+            return isinstance(member, UntypedProperty)
 
         members = inspect.getmembers(cls, predicate)
 
         # We want to sort by the 'order' key if its greater than -1
-        def sortFn(p):
-            return p[1].order if p[1].order > -1 else 9999999
+        def sortFn(prop):
+            return prop[1].order if prop[1].order > -1 else 9999999
 
         members.sort(key=sortFn)
 


### PR DESCRIPTION
Part of #101. Fixes remanning warnings in the `_core` package.