### PR TITLE
[Core] Misc `Specification` fixes

### DIFF
--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -60,8 +60,8 @@ class SpecificationBase(FixedInterfaceObject):
         """
         if copy:
             return dict(self._data)
-        else:
-            return self._data
+
+        return self._data
 
     def _setSchema(self, schema):
         self.__schema = schema
@@ -209,8 +209,8 @@ class Specification(SpecificationBase):
         """
         if cls.__kPrefixSeparator in schema:
             return schema.rsplit(cls.__kPrefixSeparator, 1)
-        else:
-            return "", schema
+
+        return "", schema
 
     def prefix(self):
         """

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -27,13 +27,10 @@ from .SpecificationFactory import SpecificationFactory
 ## to be re-thought to allow runtime extensions in python or C++ anyway
 ## so we can hopefully pick it up then.
 
-# We want these properties to be available here, so people just deriving a
-# 'Specification' don't need to worry about where these properties really come
-# from - we don't want most people to have to care about the 'core' module.
-from ._core.objects import UntypedProperty, TypedProperty, FixedInterfaceObject
+from ._core.objects import TypedProperty, FixedInterfaceObject
 
 
-__all__ = ['SpecificationBase', 'Specification', 'UntypedProperty', 'TypedProperty']
+__all__ = ['SpecificationBase', 'Specification']
 
 
 class SpecificationBase(FixedInterfaceObject):
@@ -42,6 +39,12 @@ class SpecificationBase(FixedInterfaceObject):
     schema type. This can be used in cases that have no need to work
     with the data in any type-specific way.
     """
+
+    # We want TypedProperty to be available here, so people just
+    # deriving a 'Specification' don't need to worry about where these
+    # properties really come from - we don't want most people to have to
+    # care about the 'core' module.
+    TypedProperty = TypedProperty
 
     _data = {}
 

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -135,7 +135,7 @@ class Specification(SpecificationBase, metaclass=SpecificationFactory):
     def __repr__(self):
         return str(self)
 
-    def isOfType(self, typeOrTypes, includeDerived=True, prefix=None):
+    def isOfType(self, typeOrTypes, includeDerived=True):
         """
         Returns whether the specification is of a requested type, by
         comparison of the type string.
@@ -153,12 +153,10 @@ class Specification(SpecificationBase, metaclass=SpecificationFactory):
         "file.image" would still match. If this is false, it must be the
         exact type match.
 
-        @param prefix str, An optional prefix string, to allow complete
-        comparison of the schema, not just the type.
-
         @note This call doesn't not consider the 'prefix' of the
-        Specification, unless the additional 'prefix' argument is
-        supplied.
+        Specification when type strings are provided. When comparing
+        against another Specification class, then the prefix must
+        also match that of the supplied class.
         """
         if self._type and self._prefix:
             ourPrefix = self._prefix
@@ -166,15 +164,15 @@ class Specification(SpecificationBase, metaclass=SpecificationFactory):
         else:
             ourPrefix, ourType = self.schemaComponents(self.schema())
 
-        if prefix and not prefix == ourPrefix:
-            return False
-
         if not isinstance(typeOrTypes, (list, tuple)):
             typeOrTypes = (typeOrTypes,)
 
         for typ in typeOrTypes:
             if inspect.isclass(typ) and issubclass(typ, Specification):
-                typ = typ._type # pylint: disable=protected-access
+                # pylint: disable=protected-access
+                if typ._prefix != ourPrefix:
+                    continue
+                typ = typ._type
             if includeDerived:
                 if ourType.startswith(typ):
                     return True

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -18,6 +18,15 @@ import inspect
 
 from .SpecificationFactory import SpecificationFactory
 
+## @todo [TC] Though the behavior of Specification is largely correct, the
+## implementation needs re-thinking. The relationship between
+## SpecificationBase and Specification doesn't really make sense.
+## Especially the declaration of `_type` and `_prefix` which then end
+## up duplicated in `__schema`. We still need those components, but
+## there should be a cleaner way to implement this. It's going to need
+## to be re-thought to allow runtime extensions in python or C++ anyway
+## so we can hopefully pick it up then.
+
 # We want these properties to be available here, so people just deriving a
 # 'Specification' don't need to worry about where these properties really come
 # from - we don't want most people to have to care about the 'core' module.

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -51,9 +51,12 @@ class SpecificationBase(FixedInterfaceObject):
     def __init__(self, schema, data=None):
 
         self.__schema = schema
+        self._data = data if data else {}
         # The default for data is None, not {} to avoid mutable defaults issues
         # This data is written to by the SpecificationProperty class
-        self._data = data if data else {}
+        if data is not None :
+            for key, value in data.items():
+                setattr(self, key, value)
 
     def schema(self):
         """

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -216,7 +216,7 @@ class Specification(SpecificationBase, metaclass=SpecificationFactory):
         string if there is none.
         """
         if cls.__kPrefixSeparator in schema:
-            return schema.rsplit(cls.__kPrefixSeparator, 1)
+            return tuple(schema.rsplit(cls.__kPrefixSeparator, 1))
 
         return "", schema
 

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -229,11 +229,11 @@ class Specification(SpecificationBase):
         @return str, the prefix of this specifications schema, or an
         empty string.
         """
-        return self.schemaComponents(self.__schema)[0]
+        return self.schemaComponents(self.schema())[0]
 
     def type(self):
         """
         @return str, the schemas type, without prefix or separator
         token.
         """
-        return self.schemaComponents(self.__schema)[1]
+        return self.schemaComponents(self.schema())[1]

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -89,7 +89,7 @@ class SpecificationBase(FixedInterfaceObject):
         return str(self)
 
 
-class Specification(SpecificationBase):
+class Specification(SpecificationBase, metaclass=SpecificationFactory):
     """
     The simplest form of Specification in common use. It extends the
     base specification to better define the schema.
@@ -117,8 +117,6 @@ class Specification(SpecificationBase):
     The @ref SpecificationFactory understands the concept of prefixes,
     etc... when wrapping on instantiating a Specification from data.
     """
-    __metaclass__ = SpecificationFactory
-
     _prefix = "core"
     _type = ""
     __kPrefixSeparator = ':'

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -185,16 +185,8 @@ class Specification(SpecificationBase, metaclass=SpecificationFactory):
         """
         Fetches the property from the specification, if present,
         otherwise returns the default value.
-
-        This is short hand for the following code, that avoids either
-        copying the data, or exposing the mutable data dictionary.
-        Consequently, it should be used by preference.
-
-        @code
-        data = specification.data(copy=False).get(name, defaultValue)
-        @endcode
         """
-        return self._data.get(name, defaultValue)
+        return getattr(self, name, defaultValue)
 
     @classmethod
     def generateSchema(cls, prefix, typ):

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -164,7 +164,7 @@ class Specification(SpecificationBase):
 
         for typ in typeOrTypes:
             if inspect.isclass(typ) and issubclass(typ, Specification):
-                typ = typ._type
+                typ = typ._type # pylint: disable=protected-access
             if includeDerived:
                 if ourType.startswith(typ):
                     return True

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -68,9 +68,9 @@ class SpecificationBase(FixedInterfaceObject):
 
     def __str__(self):
         data = []
-        for k, v in self._data.items():
-            if v is not None:
-                data.append("'%s':%s" % (k, repr(v)))
+        for key, value in self._data.items():
+            if value is not None:
+                data.append("'%s':%s" % (key, repr(value)))
         return "SpecificationBase('%s', {%s})" % (self.__schema, ", ".join(data))
 
     def __repr__(self):
@@ -117,9 +117,9 @@ class Specification(SpecificationBase):
 
     def __str__(self):
         data = []
-        for k, v in self._data.items():
-            if v is not None:
-                data.append("'%s':%s" % (k, repr(v)))
+        for key, value in self._data.items():
+            if value is not None:
+                data.append("'%s':%s" % (key, repr(value)))
         return "%s({%s})" % (self.__class__.__name__, ", ".join(data))
 
     def __repr__(self):
@@ -162,13 +162,13 @@ class Specification(SpecificationBase):
         if not isinstance(typeOrTypes, (list, tuple)):
             typeOrTypes = (typeOrTypes,)
 
-        for t in typeOrTypes:
-            if inspect.isclass(t) and issubclass(t, Specification):
-                t = t._type
+        for typ in typeOrTypes:
+            if inspect.isclass(typ) and issubclass(typ, Specification):
+                typ = typ._type
             if includeDerived:
-                if ourType.startswith(t):
+                if ourType.startswith(typ):
                     return True
-            elif ourType == t:
+            elif ourType == typ:
                 return True
 
         return False
@@ -189,14 +189,14 @@ class Specification(SpecificationBase):
         return self._data.get(name, defaultValue)
 
     @classmethod
-    def generateSchema(cls, prefix, type):
+    def generateSchema(cls, prefix, typ):
         """
         To be used over naive string concatenation to build a schema
         string.
 
         @return str, The schema string for the given prefix and type.
         """
-        return "%s%s%s" % (prefix, cls.__kPrefixSeparator, type)
+        return "%s%s%s" % (prefix, cls.__kPrefixSeparator, typ)
 
     @classmethod
     def schemaComponents(cls, schema):

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -154,7 +154,7 @@ class Specification(SpecificationBase):
             ourPrefix = self._prefix
             ourType = self._type
         else:
-            ourPrefix, ourType = self.schemaComponents()
+            ourPrefix, ourType = self.schemaComponents(self.schema())
 
         if prefix and not prefix == ourPrefix:
             return False

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -62,18 +62,16 @@ class SpecificationBase(FixedInterfaceObject):
         """
         return self.__schema
 
-    def data(self, copy=True):
+    def data(self):
         """
-        @param copy bool, When True (default) then a copy of the data
-        will be returned, rather than a reference, to help avoid
-        mutating the specifications data by accident.
+        Returns a dict containing the values for the Specification's
+        properties.
 
-        @return dict, The data of the specification.
+        @return dict
+
+        @todo [tc] Do we actually need this method?
         """
-        if copy:
-            return dict(self._data)
-
-        return self._data
+        return {key: getattr(self, key) for key in self.definedPropertyNames()}
 
     def _setSchema(self, schema):
         self.__schema = schema

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -49,6 +49,7 @@ class SpecificationBase(FixedInterfaceObject):
     _data = {}
 
     def __init__(self, schema, data=None):
+        super(SpecificationBase, self).__init__()
 
         self.__schema = schema
         self._data = data if data else {}

--- a/python/openassetio/SpecificationFactory.py
+++ b/python/openassetio/SpecificationFactory.py
@@ -32,10 +32,10 @@ class SpecificationFactory(type):
     def __new__(cls, name, bases, namespace):
 
         # Make sure properties have a suitable data name and store
-        for k, v in namespace.items():
-            if isinstance(v, UntypedProperty):
-                v.dataVar = '_data'
-                v.dataName = k
+        for key, value in namespace.items():
+            if isinstance(value, UntypedProperty):
+                value.dataVar = '_data'
+                value.dataName = key
 
         newcls = super(SpecificationFactory, cls).__new__(cls, name, bases, namespace)
         if not hasattr(newcls, '__factoryIgnore'):

--- a/python/openassetio/SpecificationFactory.py
+++ b/python/openassetio/SpecificationFactory.py
@@ -66,6 +66,7 @@ class SpecificationFactory(type):
         if not customCls:
             customCls = cls.classMap.get(prefix)
         if customCls:
+            # pylint: disable=protected-access
             instance = customCls(data)
             instance._setSchema(schema)
             instance._type = type

--- a/python/openassetio/SpecificationFactory.py
+++ b/python/openassetio/SpecificationFactory.py
@@ -70,9 +70,9 @@ class SpecificationFactory(type):
             instance._setSchema(schema)
             instance._type = type
             return instance
-        else:
-            ## @todo re-instate logging for missing custom class
-            return SpecificationBase(schema, data)
+
+        ## @todo re-instate logging for missing custom class
+        return SpecificationBase(schema, data)
 
     @classmethod
     def upcast(cls, specification):

--- a/python/openassetio/SpecificationFactory.py
+++ b/python/openassetio/SpecificationFactory.py
@@ -56,6 +56,8 @@ class SpecificationFactory(type):
         attempts fail, a @ref openassetio.Specification.SpecificationBase will be used.
         """
 
+        # Prevents circular imports
+        # pylint: disable=import-outside-toplevel, cyclic-import
         from .Specification import SpecificationBase, Specification
 
         if not schema:

--- a/python/openassetio/_core/objects.py
+++ b/python/openassetio/_core/objects.py
@@ -67,7 +67,7 @@ class UntypedProperty(object):
         # Allow access to ourself if we're called on the class
         if obj is None:
             return self
-        return getattr(obj, self.dataVar).get(self.dataName, None)
+        return getattr(obj, self.dataVar).get(self.dataName, self.initialValue)
 
     def __set__(self, obj, value):
         getattr(obj, self.dataVar)[self.dataName] = value
@@ -87,6 +87,8 @@ class TypedProperty(UntypedProperty):
     def __init__(
             self, typ, initVal=None, doc=None, dataVar=None, dataName=None,
             order=-1):
+        if initVal is None:
+            initVal = typ()
         super(TypedProperty, self).__init__(initVal, doc, dataVar, dataName, order)
         self.__doc__ = "[%s]" % typ.__name__
         if doc:

--- a/python/openassetio/_core/objects.py
+++ b/python/openassetio/_core/objects.py
@@ -117,7 +117,7 @@ class FixedInterfaceObject(object):
         # will be available in the data var by default too
 
         def predicate(m):
-            return isinstance(m, objectSystem.UntypedProperty)
+            return isinstance(m, UntypedProperty)
 
         members = inspect.getmembers(self.__class__, predicate)
         for name, prop in members:
@@ -145,7 +145,7 @@ class FixedInterfaceObject(object):
         """
 
         def predicate(m):
-            return isinstance(m, objectSystem.UntypedProperty)
+            return isinstance(m, UntypedProperty)
 
         members = inspect.getmembers(cls, predicate)
 

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -1,0 +1,45 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Tests that cover the openassetio.hostAPI.Specification class.
+"""
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+import pytest
+
+from openassetio import Specification
+
+
+class PrefixASpec(Specification):
+    _prefix = "prefixA"
+    _type = "spec"
+    # Properties
+    aString = Specification.TypedProperty(str)
+    anInt = Specification.TypedProperty(int)
+
+
+class Test_Specification_construction:
+
+    def test_when_constructed_then_has_expected_schema_components(self):
+        a_spec = PrefixASpec()
+
+        assert a_spec.schema() == "prefixA:spec"
+        assert a_spec.prefix() == "prefixA"
+        assert a_spec.type() == "spec"
+

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -34,7 +34,7 @@ class PrefixASpec(Specification):
     anInt = Specification.TypedProperty(int, initVal=10)
 
 
-class PrefixAChildSpec(Specification):
+class PrefixAChildSpec(PrefixASpec):
     _prefix = "prefixA"
     _type = "spec.child"
 
@@ -79,11 +79,23 @@ class Test_Specification_construction:
         with pytest.raises(ValueError):
             PrefixASpec(data={"anInt": "notAnInt"})
 
+
+class Test_Specification_properties:
+
     def test_when_adding_attributes_after_construction_then_an_attribute_error_is_raised(self):
         a_spec = PrefixASpec()
-
         with pytest.raises(AttributeError):
             a_spec.cat = 5  # pylint: disable=attribute-defined-outside-init
+
+    def test_when_setting_typed_property_to_invalid_value_type_then_a_value_error_is_raised(self):
+        a_spec = PrefixASpec()
+        with pytest.raises(ValueError):
+            a_spec.anInt = "not an int"
+
+    def test_when_class_inherits_another_spec_then_properties_are_inherited(self):
+        parent = PrefixASpec()
+        child = PrefixAChildSpec()
+        assert set(parent.definedPropertyNames()).issubset(set(child.definedPropertyNames()))
 
 
 class Test_Specification_isOfType:

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -43,3 +43,18 @@ class Test_Specification_construction:
         assert a_spec.prefix() == "prefixA"
         assert a_spec.type() == "spec"
 
+    def test_when_constructed_with_data_then_has_corresponding_fields(self):
+        a_spec = PrefixASpec(data={"aString": "cat", "anInt": 5})
+
+        assert a_spec.field("aString") == "cat"
+        assert a_spec.aString == "cat"
+
+        assert a_spec.field("anInt") == 5
+        assert a_spec.anInt == 5
+
+    def test_when_adding_attributes_after_construction_then_an_attribute_error_is_raised(self):
+        a_spec = PrefixASpec()
+
+        with pytest.raises(AttributeError):
+            a_spec.cat = 5  # pylint: disable=attribute-defined-outside-init
+

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -31,7 +31,7 @@ class PrefixASpec(Specification):
     _type = "spec"
     # Properties
     aString = Specification.TypedProperty(str)
-    anInt = Specification.TypedProperty(int)
+    anInt = Specification.TypedProperty(int, initVal=10)
 
 
 class PrefixAChildSpec(Specification):
@@ -52,6 +52,15 @@ class Test_Specification_construction:
         assert a_spec.schema() == "prefixA:spec"
         assert a_spec.prefix() == "prefixA"
         assert a_spec.type() == "spec"
+
+    def test_when_constructed_then_has_default_property_values(self):
+        a_spec = PrefixASpec()
+
+        assert a_spec.field("aString") == ""
+        assert a_spec.aString == ""
+
+        assert a_spec.field("anInt") == 10
+        assert a_spec.anInt == 10
 
     def test_when_constructed_with_data_then_has_corresponding_fields(self):
         a_spec = PrefixASpec(data={"aString": "cat", "anInt": 5})

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -138,6 +138,19 @@ class Test_Specification_schemaComponents:
         a_schema = "prefix:type"
         assert Specification.generateSchema(
             *Specification.schemaComponents(a_schema)) == a_schema
+
+
+class Test_Specification_generateSchema:
+
+    def test_when_called_with_valid_input_then_returns_expected_schema(self):
+        assert Specification.generateSchema("prefix", "type") == "prefix:type"
+
+    def test_when_called_with_schemaComponents_then_result_is_same_as_input(self):
+        components = ("prefix", "type")
+        assert Specification.schemaComponents(
+            Specification.generateSchema(*components)) == components
+
+
 class Test_Specification_data:
 
     def test_when_called_then_returns_default_constructed_property_values(self):

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -106,3 +106,18 @@ class Test_Specification_isOfType:
     def test_when_called_with_class_with_parent_of_own_type_and_derived_disabled_then_returns_false(self):  # pylint: disable=line-too-long
         a_spec = PrefixAChildSpec()
         assert a_spec.isOfType(PrefixASpec, includeDerived=False) is False
+
+
+class Test_Specification_schemaComponents:
+
+    def test_when_called_with_valid_schmea_then_returns_prefix_and_type(self):
+        assert Specification.schemaComponents(
+            "prefix:type") == ("prefix", "type")
+
+    def test_when_called_without_a_prefix_then_returns_empty_prefix(self):
+        assert Specification.schemaComponents("type") == ("", "type")
+
+    def test_when_called_with_generateSchema_then_result_is_same_as_input(self):
+        a_schema = "prefix:type"
+        assert Specification.generateSchema(
+            *Specification.schemaComponents(a_schema)) == a_schema

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -71,6 +71,14 @@ class Test_Specification_construction:
         assert a_spec.field("anInt") == 5
         assert a_spec.anInt == 5
 
+    def test_when_constructed_with_invalid_data_key_then_attribute_error_is_raised(self):
+        with pytest.raises(AttributeError):
+            PrefixASpec(data={"aString": "cat", "unknown": "value"})
+
+    def test_when_constructed_with_invalid_data_value_then_value_error_is_raised(self):
+        with pytest.raises(ValueError):
+            PrefixASpec(data={"anInt": "notAnInt"})
+
     def test_when_adding_attributes_after_construction_then_an_attribute_error_is_raised(self):
         a_spec = PrefixASpec()
 

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -130,3 +130,30 @@ class Test_Specification_schemaComponents:
         a_schema = "prefix:type"
         assert Specification.generateSchema(
             *Specification.schemaComponents(a_schema)) == a_schema
+class Test_Specification_data:
+
+    def test_when_called_then_returns_default_constructed_property_values(self):
+        a_spec = PrefixASpec()
+
+        assert a_spec.data() == {
+                "aString": PrefixASpec.aString.initialValue,
+                "anInt": PrefixASpec.anInt.initialValue}
+
+    def test_when_called_then_returns_specified_constructed_property_values(self):
+        initial_values = {"aString": "mouse", "anInt": 3}
+        another_spec = PrefixASpec(data=initial_values)
+
+        assert another_spec.data() == initial_values
+
+    def test_when_properties_set_and_called_then_returns_current_values(self):
+        a_spec = PrefixASpec()
+        a_spec.aString = "herring"
+        a_spec.anInt = 42
+
+        assert a_spec.data() == {"aString": "herring", "anInt": 42}
+
+    def test_when_called_then_all_property_keys_are_present_in_the_returned_value(self):
+        a_spec = PrefixASpec()
+        spec_data = a_spec.data()
+
+        assert set(a_spec.definedPropertyNames()) == set(spec_data.keys())

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -34,6 +34,16 @@ class PrefixASpec(Specification):
     anInt = Specification.TypedProperty(int)
 
 
+class PrefixAChildSpec(Specification):
+    _prefix = "prefixA"
+    _type = "spec.child"
+
+
+class PrefixBSpec(Specification):
+    _prefix = "prefixB"
+    _type = "spec"
+
+
 class Test_Specification_construction:
 
     def test_when_constructed_then_has_expected_schema_components(self):
@@ -58,3 +68,41 @@ class Test_Specification_construction:
         with pytest.raises(AttributeError):
             a_spec.cat = 5  # pylint: disable=attribute-defined-outside-init
 
+
+class Test_Specification_isOfType:
+
+    def test_when_called_with_own_type_then_returns_true(self):
+        a_spec = PrefixASpec()
+        assert a_spec.isOfType("spec") is True
+
+    def test_when_called_with_another_type_then_returns_false(self):
+        a_spec = PrefixASpec()
+        assert a_spec.isOfType("another") is False
+
+    def test_when_called_with_own_class_then_returns_true(self):
+        a_spec = PrefixASpec()
+        assert a_spec.isOfType(PrefixASpec) is True
+
+    def test_when_called_with_another_class_with_same_type_then_returns_false(self):
+        a_spec = PrefixASpec()
+        assert a_spec.isOfType(PrefixBSpec) is False
+
+    def test_when_called_with_child_of_own_type_then_returns_false(self):
+        a_spec = PrefixASpec()
+        assert a_spec.isOfType("spec.child") is False
+
+    def test_when_called_with_parent_of_own_type_then_returns_true(self):
+        a_spec = PrefixAChildSpec()
+        assert a_spec.isOfType("spec") is True
+
+    def test_when_called_with_parent_of_own_type_and_derived_disabled_then_returns_false(self):
+        a_spec = PrefixAChildSpec()
+        assert a_spec.isOfType("spec", includeDerived=False) is False
+
+    def test_when_called_with_class_with_parent_of_own_type_then_returns_true(self):
+        a_spec = PrefixAChildSpec()
+        assert a_spec.isOfType(PrefixASpec) is True
+
+    def test_when_called_with_class_with_parent_of_own_type_and_derived_disabled_then_returns_false(self):  # pylint: disable=line-too-long
+        a_spec = PrefixAChildSpec()
+        assert a_spec.isOfType(PrefixASpec, includeDerived=False) is False


### PR DESCRIPTION
This started out a routine clean up as part of #101. It however turned up a few bugs in `Specification`. Largely due to the somewhat suspicious dev practices ~we~ I had when I wrote this some very, very, long time ago in a text editor far away.

As `Specification` is quite a pivotal class in this API, it is worth sorting these out now regardless of what is happening when it comes to the `C++` port. 

The first few commits are mild linter fixes, the rest add test coverage to properly define the expected behaviour and fix the issues that surfaced.