### PR TITLE
[PluginSystem] Switch to `importlib` and other improvements.

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -24,8 +24,13 @@ jobs:
           python -m pip install .
 
       - name: Lint
-        uses: TheFoundryVisionmongers/fn-pylint-action@v1
+        uses: TheFoundryVisionmongers/fn-pylint-action@v1.1
         with:
           pylint-disable: "C,I,R"  # Only errors and warnings, for now.
           pylint-rcfile: "./pyproject.toml"
           pylint-paths: "python/openassetio tests"
+          # Presently it's not possible to disable the `duplicate-code` check
+          # for specific files, so it thinks that the symlink is duplicated
+          # implementation. See:
+          #     https://github.com/PyCQA/pylint/issues/214
+          pylint-ignore-paths: "tests/openassetio/pluginSystem/resources/symlinkPath"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pylint==2.12.1
+          python -m pip install pylint==2.12.2
           python -m pip install -r tests/requirements.txt
 
       - name: Build

--- a/python/openassetio/pluginSystem/ManagerPlugin.py
+++ b/python/openassetio/pluginSystem/ManagerPlugin.py
@@ -13,6 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+A single-class module, providing the ManagerPlugin class.
+"""
 
 from .PluginSystemPlugin import PluginSystemPlugin
 
@@ -56,7 +59,8 @@ class ManagerPlugin(PluginSystemPlugin):
 
         @return str
 
-        @see @ref openassetio.managerAPI.ManagerInterface "ManagerInterface"
+        @see @ref openassetio.managerAPI.ManagerInterface
+        "ManagerInterface"
         """
         raise NotImplementedError
 
@@ -87,9 +91,10 @@ class ManagerPlugin(PluginSystemPlugin):
         openassetio-ui.implementation.ManagerUIDelegate
 
         This is an instance of some class derived from ManagerUIDelegate
-        that is used by the @needsref UISessionManager to provide widgets to
-        a host that may bind into panels in the application, or to allow
-        the application to delegate asset browsing/picking etc...
+        that is used by the @needsref UISessionManager to provide
+        widgets to a host that may bind into panels in the application,
+        or to allow the application to delegate asset browsing/picking
+        etc...
 
         @param interfaceInstance An instance of the plugins interface as
         returned by @ref interface(), this is to allow UI to be

--- a/python/openassetio/pluginSystem/PluginSystem.py
+++ b/python/openassetio/pluginSystem/PluginSystem.py
@@ -14,7 +14,6 @@
 #   limitations under the License.
 #
 
-from ..logging import LoggerInterface
 from .. import exceptions
 
 

--- a/python/openassetio/pluginSystem/PluginSystem.py
+++ b/python/openassetio/pluginSystem/PluginSystem.py
@@ -13,6 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+A single-class module, providing the PluginSystem class.
+"""
 
 from .. import exceptions
 
@@ -35,6 +38,18 @@ class PluginSystem(object):
         self.__logger = logger
 
     def scan(self, paths):
+        """
+        Searches the supplied paths for modules that define a
+        PluginSystemPlugin through a top-level `plugin` variable.
+
+        Paths are searched right-to-left, but only the first instance of
+        any given plugin identifier will be used, and subsequent
+        registrations ignored. This means entries to the left of the
+        paths list take precedence over ones to the right.
+
+        @param paths `str` A list of paths to search, delimited by
+        `os.pathsep`.
+        """
         import os.path
         import imp
         import hashlib
@@ -75,9 +90,25 @@ class PluginSystem(object):
                     self.__logger.log(msg, self.__logger.kError)
 
     def identifiers(self):
+        """
+        Returns the identifiers known to the plugin system.
+
+        If @ref scan has not been called, then this will be empty.
+
+        @return `List[str]`
+        """
         return list(self.__map.keys())
 
     def plugin(self, identifier):
+        """
+        Retrieves the plugin that provides the given identifier.
+
+        @return @ref openassetio.pluginSystem.PluginSystemPlugin
+        "PluginSystemPlugin"
+
+        @exception openassetio.exceptions.PluginError Raised if no
+        plugin provides the specified identifier.
+        """
 
         if identifier not in self.__map:
             msg = "PluginSystem: No plug-in registered with the identifier '%s'" % identifier
@@ -86,7 +117,20 @@ class PluginSystem(object):
         return self.__map[identifier]
 
     def register(self, cls, path="<unknown>"):
+        """
+        Allows manual registration of a PluginSystemPlugin derived
+        class.
 
+        This can be used to register plugins using means other than
+        the built-in file system scanning.
+
+        @param cls @ref openassetio.pluginSystem.PluginSystemPlugin
+        "PluginSystemPlugin"
+
+        @param path `str` Some reference to where this plugin
+        originated, used for debug messaging when duplicate
+        registrations of the same identifier are encountered.
+        """
         identifier = cls.identifier()
         if identifier in self.__map:
             msg = "PluginSystem: Skipping class '%s' defined in '%s'. Already registered by '%s'" \

--- a/python/openassetio/pluginSystem/PluginSystem.py
+++ b/python/openassetio/pluginSystem/PluginSystem.py
@@ -18,8 +18,9 @@ A single-class module, providing the PluginSystem class.
 """
 
 import os.path
-import imp
+import importlib.util
 import hashlib
+import sys
 
 from .. import exceptions
 
@@ -35,11 +36,18 @@ class PluginSystem(object):
     a plug-in has registered an identifier, any subsequent registrations
     with that id will be skipped.
     """
+    __validModuleExtensions = (".py", ".pyc")
 
     def __init__(self, logger):
+        self.__logger = logger
+        self.reset()
+
+    def reset(self):
+        """
+        Clears any previously loaded plugins.
+        """
         self.__map = {}
         self.__paths = {}
-        self.__logger = logger
 
     def scan(self, paths):
         """
@@ -51,43 +59,49 @@ class PluginSystem(object):
         registrations ignored. This means entries to the left of the
         paths list take precedence over ones to the right.
 
+        Any existing plugins registered with the PluginSystem will be
+        cleared before scanning.
+
         @param paths `str` A list of paths to search, delimited by
         `os.pathsep`.
         """
-        self.__logger.log(
-            "PluginSystem: Looking for packages on: %s" % paths, self.__logger.kDebug)
+        self.reset()
+
+        self.__logger.log("PluginSystem: Searching %s" % paths, self.__logger.kDebug)
 
         for path in paths.split(os.pathsep):
 
             if not os.path.isdir(path):
+                msg = "PluginSystem: Skipping as it is not a directory %s" % path
+                self.__logger.log(msg, self.__logger.kDebug)
+
+            for item in os.listdir(path):
+
+                itemPath = os.path.join(path, item)
+
+                if os.path.isdir(itemPath):
+                    # The directory could be a package, check for __init__.py
+                    initFile = os.path.join(itemPath, "__init__.py")
+                    if os.path.exists(initFile):
+                        itemPath = initFile
+                    else:
+                        msg = "PluginSystem: Ignoring as it is not a python package " \
+                              "contianing __init__.py %s" % itemPath
+                        self.__logger.log(msg, self.__logger.kDebug)
+                        continue
+                else:
+                    # Its a file, check if it is a .py/.pyc module
+                    _, ext = os.path.splitext(itemPath)
+                    if ext not in self.__validModuleExtensions:
+                        msg = "PluginSystem: Ignoring as its not a python module %s" % itemPath
+                        self.__logger.log(msg, self.__logger.kDebug)
+                        continue
+
                 self.__logger.log(
-                    "PluginSystem: Omitting '%s' from plug-in search as"
-                    " its not a directory" % path, self.__logger.kDebug)
+                    "PluginSystem: Attempting to load %s" % itemPath,
+                    self.__logger.kDebug)
 
-            for bundle in os.listdir(path):
-
-                bundlePath = os.path.join(path, bundle)
-                if not os.path.isdir(bundlePath):
-                    self.__logger.log(
-                        "PluginSystem: Omitting '%s' as its not a package directory" % path,
-                        self.__logger.kDebug)
-                    continue
-
-                # Make a unique namespace to ensure the plugin identifier is all that
-                # really matters
-                moduleName = hashlib.md5(bundlePath.encode("utf-8")).hexdigest()
-
-                try:
-
-                    module = imp.load_module(
-                        moduleName, None, bundlePath, ("", "", imp.PKG_DIRECTORY))
-                    if hasattr(module, 'plugin'):
-                        self.register(module.plugin, bundlePath)
-
-                except Exception as e:
-                    msg = "PluginSystem: Caught exception loading plug-in from '%s':\n%s" % (
-                        bundlePath, e)
-                    self.__logger.log(msg, self.__logger.kError)
+                self.__load(itemPath)
 
     def identifiers(self):
         """
@@ -143,3 +157,45 @@ class PluginSystem(object):
 
         self.__map[identifier] = cls
         self.__paths[identifier] = path
+
+    def __load(self, path):
+        """
+        Loads the specified python file and registers it's plugin.
+        The file must expose a top-level 'plugin' variable.
+
+        @param path `str` This can be either a single-file module,
+        or the __init__.py at the root of a package.
+        """
+
+        # Make a unique namespace to ensure the plugin identifier is
+        # all that really matters
+        moduleName = hashlib.md5(path.encode("utf-8")).hexdigest()
+
+        try:
+
+            spec = importlib.util.spec_from_file_location(moduleName, path)
+            if spec is None:
+                raise RuntimeError("Unable to determine module spec")
+
+            module = importlib.util.module_from_spec(spec)
+
+            # Without this, for package imports we get:
+            #   'No module named '<moduleName>'
+            sys.modules[spec.name] = module
+
+            spec.loader.exec_module(module)
+
+            # Avoid polluting the module cache long-term
+            del sys.modules[spec.name]
+
+        except Exception as ex:  # pylint: disable=broad-except
+            msg = "PluginSystem: Caught exception loading plug-in from %s:\n%s" % (path, ex)
+            self.__logger.log(msg, self.__logger.kWarning)
+            return
+
+        if not hasattr(module, 'plugin'):
+            msg = "PluginSystem: No top-level 'plugin' variable %s" % path
+            self.__logger.log(msg, self.__logger.kWarning)
+            return
+
+        self.register(module.plugin, path)

--- a/python/openassetio/pluginSystem/PluginSystem.py
+++ b/python/openassetio/pluginSystem/PluginSystem.py
@@ -198,4 +198,9 @@ class PluginSystem(object):
             self.__logger.log(msg, self.__logger.kWarning)
             return
 
+        # Store where this plugin was loaded from. Not entirely
+        # accurate, but more useful for debugging than it not being
+        # there.
+        module.plugin.__file__ = path
+
         self.register(module.plugin, path)

--- a/python/openassetio/pluginSystem/PluginSystem.py
+++ b/python/openassetio/pluginSystem/PluginSystem.py
@@ -59,6 +59,9 @@ class PluginSystem(object):
         registrations ignored. This means entries to the left of the
         paths list take precedence over ones to the right.
 
+        @note Precedence order is undefined for plugins sharing the
+        same identifier within the same directory.
+
         Any existing plugins registered with the PluginSystem will be
         cleared before scanning.
 

--- a/python/openassetio/pluginSystem/PluginSystem.py
+++ b/python/openassetio/pluginSystem/PluginSystem.py
@@ -17,6 +17,10 @@
 A single-class module, providing the PluginSystem class.
 """
 
+import os.path
+import imp
+import hashlib
+
 from .. import exceptions
 
 
@@ -50,10 +54,6 @@ class PluginSystem(object):
         @param paths `str` A list of paths to search, delimited by
         `os.pathsep`.
         """
-        import os.path
-        import imp
-        import hashlib
-
         self.__logger.log(
             "PluginSystem: Looking for packages on: %s" % paths, self.__logger.kDebug)
 

--- a/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
@@ -108,28 +108,28 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
         managers = {}
 
         identifiers = self.__pluginManager.identifiers()
-        for i in identifiers:
+        for identifier in identifiers:
 
             try:
-                p = self.__pluginManager.plugin(i)
-                interface = p.interface()
-            except Exception as e:
+                plugin = self.__pluginManager.plugin(identifier)
+                interface = plugin.interface()
+            except Exception as ex:
                 self._logger.log(
-                    "Error loading plugin for '%s': %s" % (i, e), self._logger.kCritical)
+                    "Error loading plugin for '%s': %s" % (identifier, ex), self._logger.kCritical)
                 continue
 
             managerIdentifier = interface.identifier()
-            managers[i] = {
+            managers[identifier] = {
                 'name': interface.displayName(),
                 'identifier': managerIdentifier,
                 'info': interface.info(),
-                'plugin': p
+                'plugin': plugin
             }
 
-            if i != managerIdentifier:
+            if identifier != managerIdentifier:
                 msg = ("Manager '%s' is not registered with the same identifier as it's plugin"
                        " ('%s' instead of '%s')"
-                       % (interface.displayName(), managerIdentifier, i))
+                       % (interface.displayName(), managerIdentifier, identifier))
                 self._logger.log(msg, self._logger.kWarning)
 
         return managers

--- a/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
@@ -13,6 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+A single-class module, providing the PluginSystemManagerFactory class.
+"""
 
 import os
 
@@ -54,9 +57,9 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
         Scans for ManagerPlugins, and registers them with the factory
         instance.
 
-        @param paths str, A searchpath string to search for plug-ins. If
-        None, then the contents of the Environment Variable @ref
-        kPluginEnvVar is used instead.
+        @param paths `str` A searchpath string to search for plug-ins.
+        If None, then the contents of the Environment Variable
+        @ref kPluginEnvVar is used instead.
         """
 
         if not self.__paths:
@@ -95,7 +98,8 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
           openassetio.managerAPI.ManagerInterface.ManagerInterface.info
           "ManagerInterface.info")
           @li **plugin** The plugin class that represents the Manager
-          (see: @ref openassetio.pluginSystem.ManagerPlugin "ManagerPlugin")
+          (see: @ref openassetio.pluginSystem.ManagerPlugin
+          "ManagerPlugin")
         """
 
         if not self.__pluginManager:
@@ -146,10 +150,10 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
         openassetio.managerAPI.ManagerInterface "ManagerInterface" with
         the specified identifier.
 
-        @param identifier str, The identifier of the ManagerInterface
+        @param identifier `str` The identifier of the ManagerInterface
         to instantiate.
 
-        @param cache bool, When True the created instance will be
+        @param cache `bool` When True the created instance will be
         cached, and immediately returned by subsequence calls to this
         function with the same identifier - instead of creating a new
         instance. If False, a new instance will be created each, and
@@ -178,11 +182,11 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
         Creates an instance of the @needsref ManagerUIDelegate for the
         specified identifier.
 
-        @param managerInterfaceInstance openassetio.managerAPI.ManagerInterface,
-        the instance of a ManagerInterface to retrieve the UI
+        @param managerInterfaceInstance openassetio.managerAPI.ManagerInterface
+        The instance of a ManagerInterface to retrieve the UI
         delegate for.
 
-        @param cache bool, When True the created instance will be
+        @param cache `bool` When True the created instance will be
         cached, and immediately returned by subsequence calls to this
         function with the same identifier - instead of creating a new
         instance. If False, a new instance will be created each, and

--- a/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
@@ -17,7 +17,6 @@
 import os
 
 from ..hostAPI.ManagerFactoryInterface import ManagerFactoryInterface
-from ..logging import LoggerInterface
 
 from .PluginSystem import PluginSystem
 

--- a/python/openassetio/pluginSystem/PluginSystemPlugin.py
+++ b/python/openassetio/pluginSystem/PluginSystemPlugin.py
@@ -13,8 +13,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+A single-class module, providing the PluginSystemPlugin class.
+"""
 
 class PluginSystemPlugin(object):
+    """
+    The base class that defines a plugin of the plugin system.
+
+    Only modules and packages that expose an instance of this class
+    will be loaded by the plugin system when scanning any given
+    path.
+    """
 
     @classmethod
     def identifier(cls):

--- a/python/openassetio/pluginSystem/__init__.py
+++ b/python/openassetio/pluginSystem/__init__.py
@@ -19,6 +19,12 @@
 # This module provides a manager factory that loads plugins found on a search path.
 # Each plugin can provide support for a new asset management system.
 #
+"""
+This module provides a plugin system that can be used to register and
+instantiate manager plugins from code that lives outside of the
+openassetio package.
+"""
+
 from .ManagerPlugin import ManagerPlugin
 from .PluginSystem import PluginSystem
 from .PluginSystemPlugin import PluginSystemPlugin

--- a/tests/openassetio/pluginSystem/resources/README.md
+++ b/tests/openassetio/pluginSystem/resources/README.md
@@ -2,7 +2,7 @@
 
 This directory contains resources for the plugin system tests.
 
-## pathA, pathB
+## pathA, pathB, pathC, symlinkPath
 
 These sub-directories contain minimal implementations of two
 `PluginSystemPlugins`:
@@ -10,6 +10,10 @@ These sub-directories contain minimal implementations of two
 - `PackagePlugin` : A plugin implemented in a python package.
 - `ModulePlugin` A plugin implemented in a single-file python module.
 
-`ModulePlugin` is avilable via `pathA`, `PackagePlugin` is available via
-`pathB`.
+`PackagePlugin` is only available via `pathB`, but `ModulePlugin`
+is installed in both `pathA` and `pathC`.
 
+`symlinkPath` exposes `pathA` and `pathB` plugins via symlinks.
+
+These permutations allow path precedence and traversal behaviors
+to be properly tested.

--- a/tests/openassetio/pluginSystem/resources/README.md
+++ b/tests/openassetio/pluginSystem/resources/README.md
@@ -1,0 +1,15 @@
+# Plugin System Test Resources
+
+This directory contains resources for the plugin system tests.
+
+## pathA, pathB
+
+These sub-directories contain minimal implementations of two
+`PluginSystemPlugins`:
+
+- `PackagePlugin` : A plugin implemented in a python package.
+- `ModulePlugin` A plugin implemented in a single-file python module.
+
+`ModulePlugin` is avilable via `pathA`, `PackagePlugin` is available via
+`pathB`.
+

--- a/tests/openassetio/pluginSystem/resources/pathA/modulePlugin.py
+++ b/tests/openassetio/pluginSystem/resources/pathA/modulePlugin.py
@@ -1,0 +1,16 @@
+"""
+Provides a test PluginSystemPlugin implemented within a single file
+module.
+"""
+
+from openassetio.pluginSystem import PluginSystemPlugin
+
+class ModulePlugin(PluginSystemPlugin):
+    # pylint: disable=missing-class-docstring
+
+    @classmethod
+    def identifier(cls):
+        return "org.openassetio.test.pluginSystem.resources.modulePlugin"
+
+# pylint: disable=invalid-name
+plugin = ModulePlugin

--- a/tests/openassetio/pluginSystem/resources/pathB/packagedPlugin/PackagePlugin.py
+++ b/tests/openassetio/pluginSystem/resources/pathB/packagedPlugin/PackagePlugin.py
@@ -1,0 +1,12 @@
+"""
+Provides a test PluginSystemPlugin implementation.
+"""
+
+from openassetio.pluginSystem import PluginSystemPlugin
+
+class PackagePlugin(PluginSystemPlugin):
+    # pylint: disable=missing-class-docstring
+
+    @classmethod
+    def identifier(cls):
+        return "org.openassetio.test.pluginSystem.resources.packagePlugin"

--- a/tests/openassetio/pluginSystem/resources/pathB/packagedPlugin/__init__.py
+++ b/tests/openassetio/pluginSystem/resources/pathB/packagedPlugin/__init__.py
@@ -1,0 +1,8 @@
+"""
+Provides a test PluginSystemPlugin implemented within a package.
+"""
+
+from .PackagePlugin import PackagePlugin
+
+# pylint: disable=invalid-name
+plugin = PackagePlugin

--- a/tests/openassetio/pluginSystem/resources/pathB/packagedPlugin/__init__.py
+++ b/tests/openassetio/pluginSystem/resources/pathB/packagedPlugin/__init__.py
@@ -2,6 +2,9 @@
 Provides a test PluginSystemPlugin implemented within a package.
 """
 
+# pylint gets upset, but this is fine due to
+# the way the plugin system loads plugins.
+# pylint: disable=import-error
 from .PackagePlugin import PackagePlugin
 
 # pylint: disable=invalid-name

--- a/tests/openassetio/pluginSystem/resources/pathC/modulePlugin.py
+++ b/tests/openassetio/pluginSystem/resources/pathC/modulePlugin.py
@@ -1,0 +1,16 @@
+"""
+Provides a test PluginSystemPlugin implemented within a single file
+module.
+"""
+
+from openassetio.pluginSystem import PluginSystemPlugin
+
+class ModulePlugin(PluginSystemPlugin):
+    # pylint: disable=missing-class-docstring
+
+    @classmethod
+    def identifier(cls):
+        return "org.openassetio.test.pluginSystem.resources.modulePlugin"
+
+# pylint: disable=invalid-name
+plugin = ModulePlugin

--- a/tests/openassetio/pluginSystem/resources/pathC/modulePlugin.py
+++ b/tests/openassetio/pluginSystem/resources/pathC/modulePlugin.py
@@ -1,16 +1,20 @@
 """
-Provides a test PluginSystemPlugin implemented within a single file
-module.
+Provides a plugin that uses the same identifier as the ModulePlugin in
+the `pathA` folder.
 """
 
 from openassetio.pluginSystem import PluginSystemPlugin
 
 class ModulePlugin(PluginSystemPlugin):
-    # pylint: disable=missing-class-docstring
+    """
+    Provides an alternate implementation of the ModulePlugin
+    to aid testing of path precedence.
+    """
 
     @classmethod
     def identifier(cls):
-        return "org.openassetio.test.pluginSystem.resources.modulePlugin"
+        identifier = "org.openassetio.test.pluginSystem.resources.modulePlugin"
+        return identifier
 
 # pylint: disable=invalid-name
 plugin = ModulePlugin

--- a/tests/openassetio/pluginSystem/resources/symlinkPath/modulePlugin.py
+++ b/tests/openassetio/pluginSystem/resources/symlinkPath/modulePlugin.py
@@ -1,0 +1,1 @@
+../pathA/modulePlugin.py

--- a/tests/openassetio/pluginSystem/resources/symlinkPath/packagedPlugin
+++ b/tests/openassetio/pluginSystem/resources/symlinkPath/packagedPlugin
@@ -1,0 +1,1 @@
+../pathB/packagedPlugin

--- a/tests/openassetio/pluginSystem/test_pluginsystem.py
+++ b/tests/openassetio/pluginSystem/test_pluginsystem.py
@@ -1,0 +1,92 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+These tests check the functionality of the PluginSystem class.
+"""
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name,redefined-outer-name
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+import os
+
+import pytest
+
+from openassetio.logging import ConsoleLogger
+from openassetio.pluginSystem import PluginSystem
+
+
+class Test_PluginSystem_scan:
+
+    def test_when_path_contains_a_module_plugin_definition_then_it_is_loaded(
+            self, a_plugin_system, a_module_plugin_path, module_plugin_identifier):
+
+        a_plugin_system.scan(a_module_plugin_path)
+        assert a_plugin_system.identifiers() == [module_plugin_identifier,]
+
+    def test_when_path_contains_a_package_plugin_definition_then_it_is_loaded(
+            self, a_plugin_system, a_package_plugin_path, package_plugin_identifier):
+
+        a_plugin_system.scan(a_package_plugin_path)
+        assert a_plugin_system.identifiers() == [package_plugin_identifier,]
+
+    def test_when_path_contains_multiple_entries_then_all_plugins_are_loaded(
+            self, a_plugin_system, a_package_plugin_path, a_module_plugin_path,
+            package_plugin_identifier, module_plugin_identifier):
+
+        combined_path = os.pathsep.join([a_package_plugin_path, a_module_plugin_path])
+        a_plugin_system.scan(combined_path)
+
+        expected_identifiers = set([package_plugin_identifier, module_plugin_identifier])
+        assert set(a_plugin_system.identifiers()) == expected_identifiers
+
+
+@pytest.fixture
+def a_plugin_system(a_logger):
+    return PluginSystem(a_logger)
+
+
+# We use a real logger vs a mock, as it makes debugging test failures
+# easier as it surfaces any actual in-flight errors from the plugin
+# system.
+@pytest.fixture
+def a_logger():
+    return ConsoleLogger()
+
+
+@pytest.fixture
+def module_plugin_identifier():
+    return "org.openassetio.test.pluginSystem.resources.modulePlugin"
+
+
+@pytest.fixture
+def package_plugin_identifier():
+    return "org.openassetio.test.pluginSystem.resources.packagePlugin"
+
+
+@pytest.fixture
+def a_module_plugin_path(the_resources_directory_path):
+    return os.path.join(the_resources_directory_path, "pathA")
+
+
+@pytest.fixture
+def a_package_plugin_path(the_resources_directory_path):
+    return os.path.join(the_resources_directory_path, "pathB")
+
+
+@pytest.fixture
+def the_resources_directory_path():
+    return os.path.join(os.path.dirname(__file__), "resources")

--- a/tests/openassetio/pluginSystem/test_pluginsystem.py
+++ b/tests/openassetio/pluginSystem/test_pluginsystem.py
@@ -53,6 +53,28 @@ class Test_PluginSystem_scan:
         expected_identifiers = set([package_plugin_identifier, module_plugin_identifier])
         assert set(a_plugin_system.identifiers()) == expected_identifiers
 
+    def test_when_multiple_plugins_share_identifiers_then_leftmost_is_used(
+            self, a_plugin_system, the_resources_directory_path, module_plugin_identifier ):
+
+        # The module plugin exists in pathA and pathC
+        path_a = os.path.join(the_resources_directory_path, "pathA")
+        path_c = os.path.join(the_resources_directory_path, "pathC")
+
+        a_plugin_system.scan(paths=os.pathsep.join((path_a, path_c)))
+        assert "/pathA/" in a_plugin_system.plugin(module_plugin_identifier).__file__
+
+        a_plugin_system.scan(paths=os.pathsep.join((path_c, path_a)))
+        assert "/pathC/" in a_plugin_system.plugin(module_plugin_identifier).__file__
+
+    def test_when_path_contains_symlinks_then_plugins_are_loaded(
+            self, a_plugin_system, a_plugin_path_with_symlinks,
+            package_plugin_identifier, module_plugin_identifier):
+
+        a_plugin_system.scan(a_plugin_path_with_symlinks)
+
+        expected_identifiers = set([package_plugin_identifier, module_plugin_identifier])
+        assert set(a_plugin_system.identifiers()) == expected_identifiers
+
 
 @pytest.fixture
 def a_plugin_system(a_logger):
@@ -75,6 +97,11 @@ def module_plugin_identifier():
 @pytest.fixture
 def package_plugin_identifier():
     return "org.openassetio.test.pluginSystem.resources.packagePlugin"
+
+
+@pytest.fixture
+def a_plugin_path_with_symlinks(the_resources_directory_path):
+    return os.path.join(the_resources_directory_path, "symlinkPath")
 
 
 @pytest.fixture

--- a/tests/openassetio/pluginSystem/test_pluginsystemmanagerfactory.py
+++ b/tests/openassetio/pluginSystem/test_pluginsystemmanagerfactory.py
@@ -14,7 +14,8 @@
 #   limitations under the License.
 #
 """
-These tests check the functionality of the plugin system.
+These tests check the functionality of the plugin system based
+ManagerFactoryInterface implementation.
 """
 
 # pylint: disable=no-self-use


### PR DESCRIPTION
#101 highlighted that `imp` was deprecated. After addressing some minor listing issues, this PR switches the plugin system to `importlib`. Some bonuses include:

 - We now support single file modules and packages.
 - Test coverage!

This has ended up a little larger than one would like, but due to the holidays opportunities for review have been scarce. As such some linter fixes are in here too, as splitting them out would have meant unpicking a whole bunch of conflicts.

> ~Note: On hold pending https://github.com/TheFoundryVisionmongers/fn-pylint-action/pull/2.~