### PR TITLE
The great `pylint` cleanup - Part X - docstrings

### DIFF
--- a/python/openassetio/Context.py
+++ b/python/openassetio/Context.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.Context
 A single-class module, providing the Context class.
 """
 

--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -13,6 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.Specification
+Provies the Specification and SpecificationBase classes.
+"""
 
 import inspect
 

--- a/python/openassetio/SpecificationFactory.py
+++ b/python/openassetio/SpecificationFactory.py
@@ -13,6 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.SpecificationFactory
+A single-class module, providing the SpecificationFactory class.
+"""
 
 from ._core.objects import UntypedProperty
 

--- a/python/openassetio/SpecificationFactory.py
+++ b/python/openassetio/SpecificationFactory.py
@@ -82,5 +82,14 @@ class SpecificationFactory(type):
 
     @classmethod
     def upcast(cls, specification):
+        """
+        Casts the supplied Specification to the most derived
+        implementation available.
+
+        This is done by introspection of the specification's schema
+        against all registered specifications.
+
+        @param specification @ref openassetio.Specification.Specification "Specification"
+        """
         schema = specification.schema()
         return cls.instantiate(schema, specification.data(copy=False))

--- a/python/openassetio/__init__.py
+++ b/python/openassetio/__init__.py
@@ -13,6 +13,63 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+OpenAssetIO
+===========
+
+An open-source interoperability standard for tools and content
+management systems used in media production.
+
+OpenAssetIO defines a common set of interactions between a host of the
+API (eg: a Digital Content Creation tool or pipeline script) and an
+Asset Management System.
+
+It aims to reduce the integration effort and maintenance overhead of
+modern CGI pipelines, and pioneer new, standardized asset-centric
+workflows in post-production tooling.
+
+OpenAssetIO enabled tools and asset management systems can freely
+communicate with each other, without needing to know any specifics of
+their respective implementations.
+
+The API has no inherent functionality. It exists as a bridge - at the
+boundary between a process that consumes or produces data (the host),
+and the systems that provide data coordination and version management
+functionality.
+
+Scope
+-----
+
+The API covers the following areas:
+
+- Resolution of asset references (URIs) into locatable data (URLs).
+
+- Publishing and retrieval of data for file-based and non-file-based
+  assets.
+
+- Discovery and registration of related assets.
+
+- Replacement/augmentation of in-application UI elements such as
+  browsers and other panels/controls.
+
+The API, by design, does not:
+
+- Define any standardized data structures for the storage or description
+  of assets or asset hierarchies.
+
+- Dictate any aspect of how an asset management system operates,
+  organizes, locates or manages asset data and versions.
+
+- The API builds upon the production-tested Katana Asset API, addressing
+  several common integration challenges and adding support for a wider
+  range of asset types and publishing workflows.
+
+API documentation
+-----------------
+
+The documentation for OpenAssetIO can be found here:
+   https://thefoundryvisionmongers.github.io/OpenAssetIO.
+"""
 
 from .Context import Context
 from .Specification import Specification

--- a/python/openassetio/_core/audit.py
+++ b/python/openassetio/_core/audit.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio._core.audit
 This module provides utility code that allows method and object usage
 to be audited.
 """

--- a/python/openassetio/_core/debug.py
+++ b/python/openassetio/_core/debug.py
@@ -14,7 +14,26 @@
 #   limitations under the License.
 #
 """
-Decorators to aid the debugging of OpenAssetIO integrations within a host.
+@namespace openassetio._core.debug
+Assorted decorators to help with API development. For the sake of
+optimisation, and help(fn) still making sense, then they may be disabled by
+default.
+
+@envvar **OPENASSETIO_DEBUG** *int* [1] when non-zero, debug decorators
+will be enabled, allowing API calls to be monitored and timed using the
+kDebug and kDebugAPI logging severity displays
+
+In order to use these decorators the target class must derive from Debuggable, and
+have its `_debugLogFn` set to an callable that matches the
+@ref openassetio.logging.LoggerInterface.log signature. This callback will be used
+to output debug information. If no callback is set, no debug output will be
+produced.
+
+@todo The current logging implementation doesn't have any global 'display severity'
+concept (for good reasons), this has precluded any of the optimisations we used to
+make earlying-out when we're at kInfo or less. Once we port this implementation
+to cpp, then we may wish to adjust how we enable/disable this functionality to
+avoid any unwanted overhead per-call.
 """
 
 # For private decorator implementation methods
@@ -29,26 +48,6 @@ from ..logging import LoggerInterface
 
 __all__ = ['debugCall', 'debugApiCall', 'Debuggable']
 
-## @class decorators
-## Assorted decorators to help with API development. For the sake of
-## optimisation, and help(fn) still making sense, then they may be disabled by
-## default.
-##
-## @envvar **OPENASSETIO_DEBUG** *int* [1] when non-zero, debug decorators
-## will be enabled, allowing API calls to be monitored and timed using the
-## kDebug and kDebugAPI logging severity displays
-##
-## In order to use these decorators the target class must derive from Debuggable, and
-## have its `_debugLogFn` set to an callable that matches the
-## @ref openassetio.logging.LoggerInterface.log signature. This callback will be used
-## to output debug information. If no callback is set, no debug output will be
-## produced.
-##
-## @todo The current logging implementation doesn't have any global 'display severity'
-## concept (for good reasons), this has precluded any of the optimisations we used to
-## make earlying-out when we're at kInfo or less. Once we port this implementation
-## to cpp, then we may wish to adjust how we enable/disable this functionality to
-## avoid any unwanted overhead per-call.
 
 enableDebugDecorators = os.environ.get("OPENASSETIO_DEBUG", "1") != "0"
 

--- a/python/openassetio/_core/objects.py
+++ b/python/openassetio/_core/objects.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio._core.objects
 The OpenAssetIO API is built using the core FixedInterfaceObject class. This
 provides python objects that reject the addition of any new attributes
 at runtime, and provide type validation for their predefined

--- a/python/openassetio/constants.py
+++ b/python/openassetio/constants.py
@@ -13,6 +13,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.constants
+Constants used throughout the OpenAssetIO API.
+
+@todo [tc] Should these live here, or with their owning declarations,
+See @ref openassetio.logging.LoggerInterface for example.
+"""
 
 
 kSupportedAttributeTypes = (str, int, float, bool, type(None))

--- a/python/openassetio/exceptions.py
+++ b/python/openassetio/exceptions.py
@@ -14,7 +14,9 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.exceptions
 Defines exceptions used in the OpenAssetIO codebase.
+
 @todo [tc] Should these all live here, or in their respective homes
 eg: pluginSystem, ManagerInterface, etc.
 """

--- a/python/openassetio/hostAPI/HostInterface.py
+++ b/python/openassetio/hostAPI/HostInterface.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.hostAPI.HostInterface
 A single-class module, providing the HostInterface class.
 """
 

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.hostAPI.Manager
 A single-class module, providing the Manager class.
 """
 

--- a/python/openassetio/hostAPI/ManagerFactoryInterface.py
+++ b/python/openassetio/hostAPI/ManagerFactoryInterface.py
@@ -13,6 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.hostAPI.ManagerFactoryInterface
+A single-class module, providing the ManagerFactoryInterface class.
+"""
 
 
 import abc

--- a/python/openassetio/hostAPI/Session.py
+++ b/python/openassetio/hostAPI/Session.py
@@ -13,6 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.hostAPI.Session
+A single-class module, providing the Session class.
+"""
 
 from .._core.debug import debugApiCall, Debuggable
 from .._core.audit import auditApiCall

--- a/python/openassetio/hostAPI/__init__.py
+++ b/python/openassetio/hostAPI/__init__.py
@@ -13,16 +13,16 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.hostAPI
+This module contains code relevant to anyone hosting the API in a
+tool or application, wanting to communicate with some asset management
+system.
 
-##
-# @namespace openassetio.hostAPI
-# This module contains code relevant to anyone hosting the API in a
-# tool or application, wanting to communicate with some asset management
-# system.
-#
-# If you are wanting to provide support for an asset management system,
-# see @ref openassetio.managerAPI.
-#
+If you are wanting to provide support for an asset management system,
+see @ref openassetio.managerAPI.
+"""
+
 from .HostInterface import HostInterface
 from .Manager import Manager
 from .ManagerFactoryInterface import ManagerFactoryInterface

--- a/python/openassetio/hostAPI/terminology.py
+++ b/python/openassetio/hostAPI/terminology.py
@@ -13,6 +13,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.hostAPI.terminology
+This module provides utilities for a @ref host that simplify the
+integration of a @ref manager "manager's" custom terminology into its
+user-facing components.
+"""
 
 from .._core.audit import auditApiCall
 

--- a/python/openassetio/hostAPI/terminology.py
+++ b/python/openassetio/hostAPI/terminology.py
@@ -64,6 +64,10 @@ defaultTerminology = {
 
 
 class Mapper:
+    """
+    The Mapper class provides string substitution methods and lookups to
+    determine the correct terminology for the supplied @ref manager.
+    """
 
     def __init__(self, manager, terminology=defaultTerminology):
         """

--- a/python/openassetio/hostAPI/transactions.py
+++ b/python/openassetio/hostAPI/transactions.py
@@ -13,6 +13,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.hostAPI.transactions
+This module provides convenience functionality for a @ref host to aid
+working managing transactions when interacting with a @ref manager.
+"""
 
 from .._core.audit import auditApiCall
 from .._core.debug import debugApiCall, Debuggable

--- a/python/openassetio/logging.py
+++ b/python/openassetio/logging.py
@@ -23,9 +23,11 @@ import os
 import sys
 
 
-##
-# @name Logger Interface
 class LoggerInterface(object):
+    """
+    An abstract base class that defines the receiving interface for log
+    messages generated a @ref manager or the API middleware.
+    """
     __metaclass__ = abc.ABCMeta
 
     ##
@@ -104,6 +106,11 @@ class SeverityFilter(LoggerInterface):
         self.__upstreamLogger = upstreamLogger
 
     def upstreamLogger(self):
+        """
+        Returns the logger wrapped by the filter.
+
+        @return LoggerInterface
+        """
         return self.__upstreamLogger
 
     ## @name Filter Severity
@@ -114,9 +121,26 @@ class SeverityFilter(LoggerInterface):
     ## @{
 
     def setSeverity(self, severity):
+        """
+        Sets the minimum severity of message that will be passed on to
+        the @ref upstreamLogger.
+
+        @param severity `int`, one of the LoggerInterface severity
+        constants.
+
+        @see @ref LoggerInterface
+        """
         self.__maxSeverity = severity
 
     def getSeverity(self):
+        """
+        Returns the minimum seveirty of message that will be passed on
+        to the @ref upstreamLogger by the filter.
+
+        @return `int`
+
+        @see @ref LoggerInterface
+        """
         return self.__maxSeverity
 
     ## @}
@@ -139,11 +163,12 @@ class SeverityFilter(LoggerInterface):
 
 
 class ConsoleLogger(LoggerInterface):
+    """
+    A simple logger that prints messages to stdout/stderr.
+    """
 
     def __init__(self, colorOutput=True, forceDefaultStreams=False):
         """
-        A simple filtered Logger that prints messages to stdout/stderr.
-
         @param colorOutput bool [True] Make a vague attempt to color
         the output using terminal escape codes.
 

--- a/python/openassetio/logging.py
+++ b/python/openassetio/logging.py
@@ -13,6 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.logging
+Provides the core classes that facilitate message and progress logging.
+"""
 
 import abc
 import os

--- a/python/openassetio/managerAPI/Host.py
+++ b/python/openassetio/managerAPI/Host.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.managerAPI.Host
 A single-class module, providing the Host class.
 """
 

--- a/python/openassetio/managerAPI/HostSession.py
+++ b/python/openassetio/managerAPI/HostSession.py
@@ -13,6 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.managerAPI.HostSession
+A single-class module, providing the HostSession class.
+"""
 
 from ..logging import LoggerInterface
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.managerAPI.ManagerInterface
 A single-class module, providing the ManagerInterface class.
 """
 

--- a/python/openassetio/managerAPI/__init__.py
+++ b/python/openassetio/managerAPI/__init__.py
@@ -13,14 +13,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.managerAPI
+This module contains code relevant to anyone wanting to add support
+for an asset management system.
 
-##
-# @namespace openassetio.managerAPI
-# This module contains code relevant to anyone wanting to add support
-# for an asset management system.
-#
-# If you are a tool or application developer, see @ref openassetio.hostAPI
-#
+If you are a tool or application developer, see @ref openassetio.hostAPI
+"""
+
 from .Host import Host
 from .HostSession import HostSession
 from .ManagerInterface import ManagerInterface

--- a/python/openassetio/pluginSystem/__init__.py
+++ b/python/openassetio/pluginSystem/__init__.py
@@ -13,12 +13,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.pluginSystem
+This module provides a manager factory that loads plugins found on a search path.
+Each plugin can provide support for a new asset management system.
+"""
 
-##
-# @namespace openassetio.pluginSystem
-# This module provides a manager factory that loads plugins found on a search path.
-# Each plugin can provide support for a new asset management system.
-#
 from .ManagerPlugin import ManagerPlugin
 from .PluginSystem import PluginSystem
 from .PluginSystemPlugin import PluginSystemPlugin

--- a/python/openassetio/specifications.py
+++ b/python/openassetio/specifications.py
@@ -13,6 +13,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+"""
+@namespace openassetio.specifications
+Core specifications required to define the main entrypoints in
+ManagerInterface and HostInterface.
+"""
 
 from .Specification import Specification, TypedProperty
 


### PR DESCRIPTION
Part of #101, adds missing docstrings, and/or converts `##` style module comments to docstrings and adds `@namespace` labels.