### PR TITLE
[Core] Update Python 2 `__metaclass__` declarations.

### DIFF
--- a/python/openassetio/hostAPI/ManagerFactoryInterface.py
+++ b/python/openassetio/hostAPI/ManagerFactoryInterface.py
@@ -22,7 +22,7 @@ import abc
 __all__ = ['ManagerFactoryInterface']
 
 
-class ManagerFactoryInterface(object):
+class ManagerFactoryInterface(object, metaclass=abc.ABCMeta):
     """
     Manager Factories are responsible for instantiating classes that
     derive from @ref openassetio.managerAPI.ManagerInterface or @needsref
@@ -32,8 +32,6 @@ class ManagerFactoryInterface(object):
     ManagerFactoryInterface defines the abstract interface that any such
     factory must adopt.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, logger):
         super(ManagerFactoryInterface, self).__init__()

--- a/python/openassetio/logging.py
+++ b/python/openassetio/logging.py
@@ -21,8 +21,7 @@ import sys
 
 ##
 # @name Logger Interface
-class LoggerInterface(object):
-    __metaclass__ = abc.ABCMeta
+class LoggerInterface(object, metaclass=abc.ABCMeta):
 
     ##
     # @name Log Severity

--- a/tests/openassetio/hostAPI/test_logging.py
+++ b/tests/openassetio/hostAPI/test_logging.py
@@ -30,7 +30,13 @@ import openassetio.logging as lg
 # the old API.
 
 def test_LoggerInterface_progress():
-    logger = lg.LoggerInterface()
+
+    # LoggerInterface.log is pure virtual
+    class TestLogger(lg.LoggerInterface):
+        def log(self, message, severity):
+            pass
+
+    logger = TestLogger()
     logger.log = mock.create_autospec(logger.log)
 
     msg = "I am a message"


### PR DESCRIPTION
Some leftovers form the Python 2 -> 3 update. See #151 for this fix in `Specification`. Currently omitting `ManagerInterface` to do as part of #163.