### PR TITLE
[Tests] Remove code duplication

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+#
+#   Copyright 2013-2021 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+Shared fixtures/code for pytest cases.
+"""
+
+import sys
+
+import pytest
+
+# pylint: disable=invalid-name
+
+
+@pytest.fixture
+def unload_openassetio_modules():
+    """
+    Removes openassetio modules from the sys.modules cache that
+    otherwise mask cyclic dependencies or bleed state from a
+    previous test case.
+    """
+    to_delete = [
+        name for name in sys.modules if name.startswith("openassetio")]
+    for name in to_delete:
+        del sys.modules[name]

--- a/tests/openassetio/_core/test_audit.py
+++ b/tests/openassetio/_core/test_audit.py
@@ -22,7 +22,6 @@ works at a basic level.
 """
 
 import os
-import sys
 
 import pytest
 
@@ -36,17 +35,12 @@ audit_env_var_name = "OPENASSETIO_AUDIT"
 audit_args_capture_env_var_name = "OPENASSETIO_AUDIT_ARGS"
 
 
-# Global toggle tests required a clean slate for each import.
 @pytest.fixture(autouse=True)
-def unload_openassetio_modules():
+def always_unload_openassetio_modules(unload_openassetio_modules): # pylint: disable=unused-argument
     """
-    Removes openassetio modules from the sys.modules cache that
-    otherwise mask cyclic dependencies.
+    Removes openassetio modules from the sys.modules cache to
+    ensure we have a clean module state for each test.
     """
-    to_delete = [
-        name for name in sys.modules if name.startswith("openassetio")]
-    for name in to_delete:
-        del sys.modules[name]
 
 
 class Test_global_toggles:

--- a/tests/openassetio/test_imports.py
+++ b/tests/openassetio/test_imports.py
@@ -20,8 +20,6 @@ dependencies between packages due to the hoisting required to hide
 duplicate namespaces to match the future C++ implementation appearance.
 """
 
-import sys
-
 import pytest
 
 # pylint: disable=no-self-use
@@ -31,15 +29,11 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def unload_openassetio_modules():
+def always_unload_openassetio_modules(unload_openassetio_modules): # pylint: disable=unused-argument
     """
     Removes openassetio modules from the sys.modules cache that
     otherwise mask cyclic dependencies.
     """
-    to_delete = [
-        name for name in sys.modules if name.startswith("openassetio")]
-    for name in to_delete:
-        del sys.modules[name]
 
 
 class Test_package_imports:


### PR DESCRIPTION
Highlighted as part of #101, we were duplicating the module cache cleanup code.

@feltech - know any `pytest` tricks to auto-use an existing fixture without the dance here?