### PR TITLE
[CI] Fix `GITHUB_ORG` used for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,9 +33,7 @@ jobs:
 
     - name: Build
       run: |
-        # TODO [tc] We should really publish the Docker
-        # image to the GitHub registry
-        make -C src/doc
+        GITHUB_ORG=foundrytom make -C src/doc
 
     - name: Deploy
       run: |


### PR DESCRIPTION
This was inadvertently missed in 33f1f99 in #156.