### PR TITLE
[CI] Use `TheFoundryVisionmongers` registry for docs Docker image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build
       run: |
-        GITHUB_ORG=foundrytom make -C src/doc
+        make -C src/doc
 
     - name: Deploy
       run: |
@@ -41,4 +41,4 @@ jobs:
         git config --global user.name "GitHub Actions"
         git config --global user.email "github-actions@github.com"
         # Pass the path to the actions/checkout@v2 docs branch checkout
-        GITHUB_ORG=foundrytom OPENASSETIO_DOCS_REPO_DIR=`pwd`/target make -C src/doc deploy
+        OPENASSETIO_DOCS_REPO_DIR=`pwd`/target make -C src/doc deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         # manually check for warnings/errors at the end. Capture the
         # output so we can parse it later.
         set -o pipefail
-        GITHUB_ORG=foundrytom make -C doc 2>&1 | tee doxygen-log.txt
+        make -C doc 2>&1 | tee doxygen-log.txt
         echo "::remove-matcher owner=doxygen::"
         # Fail the job if we have Doxygen warning/error lines in the
         # output. NB: This is the same regex as doxygen.json, adapted


### PR DESCRIPTION
Lol. Part of #109. Switches (back) to `TheFoundryVisionmongers` org for the docs Docker image, now we can host public packages.