### PR TITLE
The great `pylint` cleanup - Part XII - a journeys end

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -29,8 +29,8 @@ jobs:
           pylint-disable: "C,I,R"  # Only errors and warnings, for now.
           pylint-rcfile: "./pyproject.toml"
           pylint-paths: "python/openassetio tests"
-          # Presently it's not possible to disable the `duplicate-code` check
-          # for specific files, so it thinks that the symlink is duplicated
-          # implementation. See:
+          # Presently it's not possible to disable the `duplicate-code`
+          # check for specific files, so it thinks that the symlink is
+          # duplicated implementation. See:
           #     https://github.com/PyCQA/pylint/issues/214
           pylint-ignore-paths: "tests/openassetio/pluginSystem/resources/symlinkPath"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint
         uses: TheFoundryVisionmongers/fn-pylint-action@v1.1
         with:
-          pylint-disable: "C,I,R"  # Only errors and warnings, for now.
+          pylint-disable: fixme  # We track 'todo's through other means
           pylint-rcfile: "./pyproject.toml"
           pylint-paths: "python/openassetio tests"
           # Presently it's not possible to disable the `duplicate-code`

--- a/tests/openassetio/pluginSystem/test_pluginsystemmanagerfactory.py
+++ b/tests/openassetio/pluginSystem/test_pluginsystemmanagerfactory.py
@@ -70,7 +70,11 @@ class Test_PluginSystemManagerFactory_identifiers:
             monkeypatch.delenv(plugin_path_var_name)
 
         factory = PluginSystemManagerFactory(a_logger)
-        assert factory.identifiers() == []
+        identifiers = factory.identifiers()
+        # Check it is an empty list, not None, or any other value
+        # that would satisty == [] as a boolean comparison.
+        assert isinstance(identifiers, list)
+        assert len(identifiers) == 0
 
     def test_when_env_var_empty_returns_empty_list(
             self, a_logger, plugin_path_var_name, monkeypatch):


### PR DESCRIPTION
The final part of #101. The `pylint` check should now pass with no warnings, and can be marked as required for Pull Requests.