### PR TITLE
[Docs] Add missing `@namespace` to module docstrings

### DIFF
--- a/python/openassetio/pluginSystem/ManagerPlugin.py
+++ b/python/openassetio/pluginSystem/ManagerPlugin.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.pluginSystem.ManagerPlugin
 A single-class module, providing the ManagerPlugin class.
 """
 

--- a/python/openassetio/pluginSystem/PluginSystem.py
+++ b/python/openassetio/pluginSystem/PluginSystem.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.pluginSystem.PluginSystem
 A single-class module, providing the PluginSystem class.
 """
 

--- a/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.pluginSystem.PluginSystemManagerFactory
 A single-class module, providing the PluginSystemManagerFactory class.
 """
 

--- a/python/openassetio/pluginSystem/PluginSystemPlugin.py
+++ b/python/openassetio/pluginSystem/PluginSystemPlugin.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 """
+@namespace openassetio.pluginSystem.PluginSystemPlugin
 A single-class module, providing the PluginSystemPlugin class.
 """
 


### PR DESCRIPTION
A few module docstrings were missing their respective `@namespace` prefix that causes the text to actually get rendered in the Doxygen output for the module - see blank spaces in https://thefoundryvisionmongers.github.io/OpenAssetIO/annotated.html