### PR TITLE
[Docs] Add notes on currently supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ for work in progress, as well as up-coming topics.
  - Migrate `ManagerPlugin` test harness
  - C++ port of Core API
  - Katana Asset API migration guide/shims
+ - `Windows` and `macOS` support
 
 ## Background
 
@@ -108,6 +109,7 @@ which appears to overlap with a subset of `OpenAssetIO`s concerns.
 
 ### System requirements
 
+- `linux` (`macOS` and `Windows` are currently unsupported)
 - `Python 3.7` or later
 
 ### Installation


### PR DESCRIPTION
 Long-term, we need to support all three platforms, but right now, testing and development resources are keeping us focused on `linux`.

