### PR TITLE
[CI] Publish docs artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,12 @@ jobs:
         # to work with GNU grep.
         ! grep -qE "^.*?/src/[^:]+:[0-9]+: ?[a-zA-Z]+: ?.*$" doxygen-log.txt
 
+    - name: Expose archive docs artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: doxygen-documentation
+        path: doc/html
+
   business-language:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Closes #199
Publishes the documentation html built to allow us to access the docs for QA