### PR TITLE
[Doc] Development process improvements

### DIFF
--- a/contributing/CODE_REVIEWS.md
+++ b/contributing/CODE_REVIEWS.md
@@ -65,7 +65,7 @@ considering.
 ### Suggested approach
 
 1. Grab the branch (or a CI build artifact if available), test
-   functionality against the User Story.
+   functionality against the Acceptance Criteria defined for the work.
 2. Check implementation against the above priorities.
 
 

--- a/contributing/CODE_REVIEWS.md
+++ b/contributing/CODE_REVIEWS.md
@@ -148,5 +148,5 @@ wasted work down the line.
 
 ## See also
 
-- Pull Request guidelines [PULL_REQUESTS.md](PULL_REQUESTS.md)
-- Commit guidelines [COMMITS.md](COMMITS.md)
+- [Pull Requests](PULL_REQUESTS.md)
+- [Commits](COMMITS.md)

--- a/contributing/COMMITS.md
+++ b/contributing/COMMITS.md
@@ -249,7 +249,7 @@ naming convention.
 ## Further reading:
 
 - Pull Request guidelines: [PULL_REQUESTS.md](PULL_REQUESTS.md).
-- Code Review guidelines: [CODEREVIEWS.md](CODEREVIEWS.md).
+- Code Review guidelines: [CODE_REVIEWS.md](CODE_REVIEWS.md).
 
 
 ## Appendix - Code components

--- a/contributing/COMMITS.md
+++ b/contributing/COMMITS.md
@@ -246,10 +246,10 @@ Feature branches should use the `feature/<issueNumber>-camelCaseName`
 naming convention.
 
 
-## Further reading:
+## See also
 
-- Pull Request guidelines: [PULL_REQUESTS.md](PULL_REQUESTS.md).
-- Code Review guidelines: [CODE_REVIEWS.md](CODE_REVIEWS.md).
+- [Pull Requests](PULL_REQUESTS.md).
+- [Code Reviews](CODE_REVIEWS.md).
 
 
 ## Appendix - Code components

--- a/contributing/COMMITS.md
+++ b/contributing/COMMITS.md
@@ -203,11 +203,11 @@ way, and the division of work and general approach makes sense.
 #### Merging inside-out
 
 The inside-out approach can allow more frequent integration of work,
-where feature toggles are either not available or add unnecessary complexity.
-Rather than starting by merging end-to-end tests that require the entire
-system to function - forcing the entirety of the work to be in that one
-Pull Request - we break it down into discreet pieces of work, that
-leave public boundaries intact at each stage.
+where feature toggles are either not available or add unnecessary
+complexity. Rather than starting by merging end-to-end tests that
+require the entire system to function - forcing the entirety of the work
+to be in that one Pull Request - we break it down into discreet pieces
+of work, that leave public boundaries intact at each stage.
 
 End-to-end tests and other outer-layer acceptance tests can still be
 written ahead of time, they are just kept in a separate development

--- a/contributing/COMMITS.md
+++ b/contributing/COMMITS.md
@@ -225,6 +225,27 @@ well suited to cases where the consumer of a component needs to control
 feature visibility rather than just the internal development effort.
 
 
+#### Feature branches
+
+Significant work, particularly that requiring coordination between
+multiple people working simultaneously, should be carried out on a
+separate feature branch. This allows frequent integration of the main
+codebase without requiring in-progress work to be merged into a release
+branch.
+
+Generally speaking one of the other above strategies for managing
+individual units of work should still be applied, i.e. Pull Requests into
+a feature branch should still be complete, logical units of work.
+
+When merging a feature branch into a release branch, a great deal of
+care should be taken as to how it is squashed into a sensible series of
+final commits, that abide by the principals of release branch
+development.
+
+Feature branches should use the `feature/<issueNumber>-camelCaseName`
+naming convention.
+
+
 ## Further reading:
 
 - Pull Request guidelines: [PULL_REQUESTS.md](PULL_REQUESTS.md).

--- a/contributing/PROCESS.md
+++ b/contributing/PROCESS.md
@@ -66,8 +66,8 @@ The process for feature development is as follows (we use the [GitHub flow](http
      - Branches should be named using the
        `work/<issueNumber>-<camelCaseTitle>` convention.
 2. Upon completion, prepare your Pull Request in accordance with the
-   [PR guidelines](PULL_REQUESTS.md), for larger work, this may be
-   targeted at a feature branch, rather than a release branch.
+   [Pull Request guidelines](PULL_REQUESTS.md), for larger work, this
+   may be targeted at a feature branch, rather than a release branch.
 3. Address any feedback with `fixup!` commits, creating a separate
    commit for each comment thread.
 4. Once approved, rebase and squash any `fixups!` or `squash!` commits
@@ -106,12 +106,12 @@ In addition, contributors are required to complete either the Individual
 or Corporate Contribution License Agreement. Please contact one of the
 trusted committers for more information.
 
-## Templates and Guidelines
+## Futher reading
 
-- Coding standards [CODING_STANDARDS.md](CODING_STANDARDS.md)
-- Pull Requests: [PULL_REQUESTS.md](PULL_REQUESTS.md)
-- Commits/Commit messages: [COMMITS.md](COMMITS.md)
-- Code Reviews: [CODE_REVIEWS.md](CODE_REVIEWS.md)
+- [Coding standards](CODING_STANDARDS.md)
+- [Pull Requests](PULL_REQUESTS.md)
+- [Commits and commit messages](COMMITS.md)
+- [Code Reviews](CODE_REVIEWS.md)
 
 
 ## Trusted Committers

--- a/contributing/PULL_REQUESTS.md
+++ b/contributing/PULL_REQUESTS.md
@@ -64,7 +64,7 @@ Follow the steps below if you wish to open a merge-ready PR for review
 1. Implement the functionality as defined by the Issue's acceptance
    criteria, and agreed design in a branch **on your own fork**.
 2. Rebase and prepare your commits for review (see
-   [COMMITS.md](COMMITS.md)).
+   [commit guidelines](COMMITS.md)).
 3. Push your branch to your fork.
 4. Create a Pull Request to the target branch in the main repository.
 5. Add the assigned Trusted Committers as reviewers. NOTE: Only add

--- a/contributing/PULL_REQUESTS.md
+++ b/contributing/PULL_REQUESTS.md
@@ -41,7 +41,8 @@ approve. Does it:
 - Make use of `squash! <target commit title>` to indicate a commit that
   exists to ease review, that will be combined before the PR is merged.
 
-**Important:** PRs will be rejected if they contain any of the following:
+**Important:** PRs to release branches will be rejected if they contain
+any of the following:
 
 - Incomplete functionality exposed through any public interface.
 - Failing tests.


### PR DESCRIPTION
Closes #197, and catches a few other strays. There is no standardised GitHub sourced MD link checker, which means we'd need to give any broader marketplace tools the once-over first, so saving that for another day.