### PR TITLE
[CI] Run CI on macOS and Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        # Note: It has been discussed that 3.9 is the first "production
-        # usable" version on Windows this needs further investigation
-        # before we special-case the platform. CY2022 uses 3.9
-        # throughout, so we should probably just target that.
-        python-version: 3.7
+        # CY2022 (https://vfxplatform.com)
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,13 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # We can't properly align to the VFX Reference Platform as this
+        # requires glibc 2.17, which is older than any of the available
+        # environments.
+        os: [ubuntu-18.04, windows-2019, macos-11]
 
     steps:
     - uses: actions/checkout@v2
@@ -18,6 +24,10 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
+        # Note: It has been discussed that 3.9 is the first "production
+        # usable" version on Windows this needs further investigation
+        # before we special-case the platform. CY2022 uses 3.9
+        # throughout, so we should probably just target that.
         python-version: 3.7
 
     - name: Install dependencies

--- a/tests/openassetio/pluginSystem/test_pluginsystem.py
+++ b/tests/openassetio/pluginSystem/test_pluginsystem.py
@@ -61,10 +61,10 @@ class Test_PluginSystem_scan:
         path_c = os.path.join(the_resources_directory_path, "pathC")
 
         a_plugin_system.scan(paths=os.pathsep.join((path_a, path_c)))
-        assert "/pathA/" in a_plugin_system.plugin(module_plugin_identifier).__file__
+        assert "pathA" in a_plugin_system.plugin(module_plugin_identifier).__file__
 
         a_plugin_system.scan(paths=os.pathsep.join((path_c, path_a)))
-        assert "/pathC/" in a_plugin_system.plugin(module_plugin_identifier).__file__
+        assert "pathC" in a_plugin_system.plugin(module_plugin_identifier).__file__
 
     def test_when_path_contains_symlinks_then_plugins_are_loaded(
             self, a_plugin_system, a_plugin_path_with_symlinks,


### PR DESCRIPTION
Introduces CI test coverage on `macOS` and `Windows`. This will most certainly make #181, #182, #183 at little more complex, but even basic coverage would be valuable as we don't have a lot of trig-platform development resource available right now, so catching issues early would be beneficial.  If the `C++` side becomes onerous, we can always disable some platforms in the interim.