### PR TITLE
[Build] Simplify Python install build target

### DIFF
--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -79,19 +79,14 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
         "${CMAKE_INSTALL_PREFIX}/bin/pip" install -r "${PROJECT_SOURCE_DIR}/tests/requirements.txt"
     )
 
-    # Command and target to install the Python project. Use a target
-    # wrapping a command so that if the OUTPUT of the command exists,
-    # the target build is a no-op.
-    add_custom_command(
-        OUTPUT "${CMAKE_INSTALL_PREFIX}/${OPENASSETIO_PYTHON_SITEDIR}/openassetio.egg-link"
+    # Target to install the pure Python component of the project.
+    add_custom_target(
+        openassetio-python-py-install
         COMMAND "${CMAKE_INSTALL_PREFIX}/bin/pip" install "${PROJECT_SOURCE_DIR}"
         DEPENDS "${CMAKE_INSTALL_PREFIX}/bin/pip"
     )
-    add_custom_target(
-        openassetio-python-dev-py-install
-        DEPENDS "${CMAKE_INSTALL_PREFIX}/${OPENASSETIO_PYTHON_SITEDIR}/openassetio.egg-link"
-    )
-    add_dependencies(openassetio-python-dev-py-install openassetio-install)
+    # Ensure pre-requisite C++ component has been installed first.
+    add_dependencies(openassetio-python-py-install openassetio-install)
 
     # Target to run pytest in the install directory, ensuring the lib has
     # been built and installed first.
@@ -101,7 +96,7 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests"
         DEPENDS "${CMAKE_INSTALL_PREFIX}/bin/pytest"
     )
-    add_dependencies(openassetio-python-pytest openassetio-python-dev-py-install)
+    add_dependencies(openassetio-python-pytest openassetio-python-py-install)
 
     # Add a CTest target.
     add_test(


### PR DESCRIPTION
For #183 - tidy up to remove the now-pointless `add_custom_command` and roll it into the `add_custom_target`.

Also remove `dev` from the target name, since that was originally there to reflect the `--editable` nature.