### PR TITLE
Use `when`/`then` form for test names - Part 1

### DIFF
--- a/python/openassetio/hostAPI/Session.py
+++ b/python/openassetio/hostAPI/Session.py
@@ -150,6 +150,13 @@ class Session(Debuggable):
             raise ManagerException("Unknown Manager '%s'" % identifier)
 
         # No need to do anything if its the same
+        ## @todo [tc] If we want to keep `settings` as part of this method
+        ## (so a deferred constructed manager can have its settings set)
+        ## then we should make sure the following does actually apply the
+        ## settings:
+        ##     useManager(an_id)
+        ##     useManager(an_id, setting=some_settings)
+        ## Right now, this won't happen, and the settings will be lost.
         if identifier == self._managerId:
             return
 

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -444,11 +444,6 @@ class Test_Manager_getEntityAttribute:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        # TODO(DF): This test doesn't cover the default implementation
-        #   in ManagerInterface. We will redesign the attributes mechanism
-        #   soon (including removing this method), so deliberately
-        #   leaving untested.
-
         method = mock_manager_interface.getEntityAttribute
         a_key = "key"
         a_default = 2
@@ -468,11 +463,6 @@ class Test_Manager_setEntityAttribute:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
-
-        # TODO(DF): This test doesn't cover the default implementation
-        #   in ManagerInterface. We will redesign the attributes mechanism
-        #   soon (including removing this method), so deliberately
-        #   leaving untested.
 
         a_key = "key"
         a_value = "value"

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -277,95 +277,154 @@ def a_ref():
 def some_refs():
     return ["asset://a", "asset://b"]
 
+# __str__ and __repr__ aren't tested as they're debug tricks that need
+# assessing when this is ported to cpp
 
-class TestManager():
+class Test_Manager_init:
 
-    # pylint: disable=too-many-public-methods,too-many-arguments
+    def test_interface_returns_the_constructor_supplied_object(
+            self, mock_manager_interface, host_session):
 
-    # __str__ and __repr__ aren't tested as they're debug tricks that need
-    # assessing when this is ported to cpp
-
-    def test__interface(self, mock_manager_interface, host_session):
         # pylint: disable=protected-access
         a_manager = Manager(mock_manager_interface, host_session)
         assert a_manager._interface() is mock_manager_interface
 
-    def test_identifier(self, manager, mock_manager_interface):
+
+class Test_Manager_identifier:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface):
+
         method = mock_manager_interface.identifier
         assert manager.identifier() == method.return_value
         method.assert_called_once_with()
 
-    def test_updateTerminology(self, manager, mock_manager_interface, host_session):
+
+class Test_Manager_updateTerminology:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface, host_session):
+
         method = mock_manager_interface.updateTerminology
         a_dict = {"k", "v"}
         assert manager.updateTerminology(a_dict) is a_dict
         method.assert_called_once_with(a_dict, host_session)
 
-    def test_getSettings(self, manager, mock_manager_interface, host_session):
+
+class Test_Manager_getSettings:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface, host_session):
+
         method = mock_manager_interface.getSettings
         assert manager.getSettings() == method.return_value
         method.assert_called_once_with(host_session)
 
-    def test_setSettings(self, manager, mock_manager_interface, host_session):
+
+class Test_Manager_setSettings:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface, host_session):
+
         method = mock_manager_interface.setSettings
         a_dict = {"k", "v"}
         assert manager.setSettings(a_dict) == method.return_value
         method.assert_called_once_with(a_dict, host_session)
 
-    def test_initialize(self, manager, mock_manager_interface, host_session):
+
+class Test_Manager_initialize:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface, host_session):
+
         method = mock_manager_interface.initialize
         assert manager.initialize() == method.return_value
         method.assert_called_once_with(host_session)
 
-    def test_prefetch(self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
+class Test_Manager_prefetch:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.prefetch
-        # Not testing Entity variant of call as this will be removed shortly
         assert manager.prefetch(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_flushCaches(self, manager, mock_manager_interface, host_session):
+
+class Test_Manager_flushCaches:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface, host_session):
+
         method = mock_manager_interface.flushCaches
         assert manager.flushCaches() == method.return_value
         method.assert_called_once_with(host_session)
 
-    def test_isEntityReference(
+
+class Test_Manager_isEntityReference:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.isEntityReference
         assert manager.isEntityReference(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_entityExists(
+
+class Test_Manager_entityExists:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.entityExists
         assert manager.entityExists(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    # Not testing getEntity as it will be removed
 
-    def test_defaultEntityReference(
+class Test_Manager_defaultEntityReference:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, a_context, some_entity_specs):
+
         method = mock_manager_interface.defaultEntityReference
         assert manager.defaultEntityReference(some_entity_specs, a_context) == method.return_value
         method.assert_called_once_with(some_entity_specs, a_context, host_session)
 
-    def test_entityName(self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
+class Test_Manager_entityName:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.entityName
         assert manager.entityName(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_entityDisplayName(
+
+class Test_Manager_entityDisplayNamer:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.entityDisplayName
         assert manager.entityDisplayName(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_getEntityAttributes(
+
+class Test_Manager_getEntityAttributes:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.getEntityAttributes
         assert manager.getEntityAttributes(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_setEntityAttributes(
+
+class Test_Manager_setEntityAttributes:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
         method = mock_manager_interface.setEntityAttributes
@@ -379,7 +438,10 @@ class TestManager():
             some_refs, some_data, a_context, merge=False) == method.return_value
         method.assert_called_once_with(some_refs, some_data, a_context, host_session, merge=False)
 
-    def test_getEntityAttribute(
+
+class Test_Manager_getEntityAttribute:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
         # TODO(DF): This test doesn't cover the default implementation
@@ -401,7 +463,10 @@ class TestManager():
         method.assert_called_once_with(
             some_refs, a_key, a_context, host_session, defaultValue=a_default)
 
-    def test_setEntityAttribute(
+
+class Test_Manager_setEntityAttribute:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
         # TODO(DF): This test doesn't cover the default implementation
@@ -416,13 +481,20 @@ class TestManager():
             some_refs, a_key, a_value, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_key, a_value, a_context, host_session)
 
-    def test_entityVersionName(
+
+class Test_Manager_entityVersionName:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.entityVersionName
         assert manager.entityVersionName(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_entityVersions(
+
+class Test_Manager_entityVersions:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
         method = mock_manager_interface.entityVersions
@@ -447,10 +519,13 @@ class TestManager():
         method.assert_called_once_with(
             some_refs, a_context, host_session, includeMetaVersions=include_meta,
             maxNumVersions=max_results)
-        method.reset_mock()
 
-    def test_finalizedEntityVersion(
+
+class Test_Manager_finalizedEntityVersion:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.finalizedEntityVersion
         assert manager.finalizedEntityVersion(some_refs, a_context) == method.return_value
         method.assert_called_once_with(
@@ -464,7 +539,10 @@ class TestManager():
         method.assert_called_once_with(
             some_refs, a_context, host_session, overrideVersionName=a_version_name)
 
-    def test_getRelatedReferences(
+
+class Test_Manager_getRelatedReferences:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, a_ref, an_entity_spec, a_context):
 
         # pylint: disable=too-many-locals
@@ -506,13 +584,20 @@ class TestManager():
         method.assert_called_once_with(
             [one_ref], [one_spec], a_context, host_session, resultSpec=an_entity_spec)
 
-    def test_resolveEntityReference(
+
+class Test_Manager_resolveEntityReference:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
+
         method = mock_manager_interface.resolveEntityReference
         assert manager.resolveEntityReference(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
-    def test_managementPolicy(
+
+class Test_Manager_managentPolicy:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_entity_specs, a_context,
             a_ref):
 
@@ -526,18 +611,28 @@ class TestManager():
             some_entity_specs, a_context, entityRef=a_ref) == method.return_value
         method.assert_called_once_with(some_entity_specs, a_context, host_session, entityRef=a_ref)
 
-    def test_preflight(
+
+class Test_Manager_preflight:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, some_entity_specs,
             a_context):
+
         method = mock_manager_interface.preflight
         assert manager.preflight(some_refs, some_entity_specs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, some_entity_specs, a_context, host_session)
 
-        # Check IndexError is raised if list lengths mismatch
+
+    def test_when_called_with_mismatched_array_lengths_then_IndexError_is_raised(
+            self, manager, some_refs, some_entity_specs, a_context):
+
         with pytest.raises(IndexError):
             manager.preflight(some_refs, some_entity_specs[1:], a_context)
 
-    def test_register(
+
+class Test_Manager_register:
+
+    def test_wraps_the_the_held_interface_register_and_setEntityAttributes_methods(
             self, manager, mock_manager_interface, host_session, some_refs, some_entity_specs,
             a_context):
 
@@ -572,7 +667,11 @@ class TestManager():
         setmeta_method.assert_called_once_with(
             mutated_refs, some_attr, a_context, host_session, merge=True)
 
-        # Check IndexError is raised if list lengths mismatch
+    def test_when_called_with_mixed_array_lengths_then_IndexError_is_raised(
+            self, manager, some_refs, some_entity_specs, a_context):
+
+        some_strings = ["primary string 1", "primary string 2"]
+        some_attr = [{"k1": "v1"}, {"k2": "v2"}]
 
         with pytest.raises(IndexError):
             manager.register(

--- a/tests/openassetio/hostAPI/test_terminology.py
+++ b/tests/openassetio/hostAPI/test_terminology.py
@@ -86,30 +86,41 @@ def mapper(mock_manager):
     return tgy.Mapper(mock_manager)
 
 
-def test_defaultTerminology():
-    # Ensure we have pre-defined keys for anything in the default dictionary
-    assert set(all_terminology_keys) == set(tgy.defaultTerminology.keys())
+class Test_defaultTerminology:
 
-    for value in tgy.defaultTerminology.values():
-        assert isinstance(value, str)
-        assert value != ""
+    def test_has_expected_keys(self):
+        # Ensure we have pre-defined keys for anything in the default dictionary
+        assert set(all_terminology_keys) == set(tgy.defaultTerminology.keys())
+
+    def test_values_are_strings_and_not_empty(self):
+
+        for value in tgy.defaultTerminology.values():
+            assert isinstance(value, str)
+            assert value != ""
 
 
-class TestMapper:
+class Test_Mapper_init:
 
-    def test_construction(self, mock_manager):
+    def test_when_constructed_with_custom_terminology_then_it_is_used_for_replacement(
+            self, mock_manager):
+
         custom_terminology = {
             mock_manager.kTerm_custom: mock_manager.kTermValue_custom}
         a_mapper = tgy.Mapper(mock_manager, terminology=custom_terminology)
         assert (a_mapper.replaceTerms(f"{{{mock_manager.kTerm_custom}}}") ==
                 mock_manager.kTermValue_custom)
 
-    def test_replaceTerms(self, mock_manager, mapper):
+
+class Test_Mapper_replaceTerms:
+
+    def test_when_called_with_known_terms_then_they_are_replaced_with_target_terminology(
+            self, mock_manager, mapper):
+
         all_terms_str = ", ".join([f"{k}" for k in all_terminology_keys])
         expected = all_terms_str.format(**mock_manager.expectedTerminology())
         assert mapper.replaceTerms(all_terms_str) == expected
 
-    def test_replaceTermsUnknownTokensDebraced(self, mapper):
+    def test_when_called_with_unknown_terms_then_their_braces_are_removed(self, mapper):
         input_str = "{an} unknown {token}"
         expected = "an unknown token"
         assert mapper.replaceTerms(input_str) == expected

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -154,10 +154,10 @@ class Test_Specification_schemaComponents:
 
 class Test_Specification_generateSchema:
 
-    def test_when_called_with_valid_input_then_returns_expected_schema(self):
+    def test_schema_formatting(self):
         assert Specification.generateSchema("prefix", "type") == "prefix:type"
 
-    def test_when_called_with_schemaComponents_then_result_is_same_as_input(self):
+    def test_decomposes_back_to_input_components(self):
         components = ("prefix", "type")
         assert Specification.schemaComponents(
             Specification.generateSchema(*components)) == components
@@ -165,27 +165,27 @@ class Test_Specification_generateSchema:
 
 class Test_Specification_data:
 
-    def test_when_called_then_returns_default_constructed_property_values(self):
+    def test_default_constructed_values_returned(self):
         a_spec = PrefixASpec()
 
         assert a_spec.data() == {
                 "aString": PrefixASpec.aString.initialValue,
                 "anInt": PrefixASpec.anInt.initialValue}
 
-    def test_when_called_then_returns_specified_constructed_property_values(self):
+    def test_constructor_provided_values_returned(self):
         initial_values = {"aString": "mouse", "anInt": 3}
         another_spec = PrefixASpec(data=initial_values)
 
         assert another_spec.data() == initial_values
 
-    def test_when_properties_set_and_called_then_returns_current_values(self):
+    def test_current_values_returned(self):
         a_spec = PrefixASpec()
         a_spec.aString = "herring"
         a_spec.anInt = 42
 
         assert a_spec.data() == {"aString": "herring", "anInt": 42}
 
-    def test_when_called_then_all_property_keys_are_present_in_the_returned_value(self):
+    def test_all_defined_property_keys_are_returned(self):
         a_spec = PrefixASpec()
         spec_data = a_spec.data()
 


### PR DESCRIPTION
Part of #130, makes a start of refactoring the tests so that they properly describe the expected behaviour rather than the area of code being tested. There are still many test suites to be done, but this PR serves to validate the approach and actually get some of this work in the code base.

The result should be that we have exactly the same coverage, just in a better structure.

Note: This deliberately doesn't address any issues with specific tests, to keep the scope of this work to just the logical structure of the tests themselves. We should pick those up in subsequent work. It also leaves the refactor to move tests above fixtures and utility code to future work.