### PR TITLE
[CI] Build and test via CTest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,9 @@ jobs:
           -Wdev \
           -DOPENASSETIO_ENABLE_TESTS=ON \
           -DOPENASSETIO_WARNINGS_AS_ERRORS=ON \
-          -DCMAKE_VERBOSE_MAKEFILE=ON
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DOPENASSETIO_ENABLE_SANITIZER_ADDRESS=ON \
+          -DOPENASSETIO_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON
 
     - name: Build, install and test
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,16 @@ on:
       - 'docs/**'
 
 jobs:
-  pytest:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # We can't properly align to the VFX Reference Platform as this
         # requires glibc 2.17, which is older than any of the available
         # environments.
-        os: [ubuntu-18.04, windows-2019, macos-11]
+        # TODO(DF): Enable other platforms.
+        # os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2
@@ -27,19 +29,33 @@ jobs:
         # CY2022 (https://vfxplatform.com)
         python-version: 3.9
 
+    - name: Cache conan packages
+      id: cache-conan
+      uses: actions/cache@v2
+      with:
+        path: ~/conan
+        key: ${{ runner.os }}-conan
+
     - name: Install dependencies
+      # Configure the system and install library dependencies via conan
+      # packages.
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r tests/requirements.txt
+        source resources/build/bootstrap-${{ matrix.os }}.sh
 
-    - name: Build
+    - name: Configure CMake build
       run: |
-        python -m pip install .
+        cmake -S . -B build \
+          --install-prefix $GITHUB_WORKSPACE/dist \
+          --toolchain $HOME/conan/conan_paths.cmake \
+          -Wdev \
+          -DOPENASSETIO_ENABLE_TESTS=ON \
+          -DOPENASSETIO_WARNINGS_AS_ERRORS=ON \
+          -DCMAKE_VERBOSE_MAKEFILE=ON
 
-    - name: Test
-      # TODO(DF): Re-enable once CI work has been done.
+    - name: Build, install and test
       run: |
-        echo "Skipping tests until CI build environment is configured"
+        cd build
+        ctest -VV
 
   docs:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 .idea
 .vim
 /dist/
+/resources/build/.vagrant/
+/.pybuild/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,168 @@
+# Building OpenAssetIO
+
+## System requirements
+
+We assume the following system packages are installed
+
+- CMake 3.21+
+- GCC 9.3
+
+## Library dependencies
+
+Binary builds additionally require the following packages to be
+available to the CMake build system.
+- Python 3.9 (development install)
+- [pybind11](https://pybind11.readthedocs.io/en/stable/) 2.6.1+
+
+We use the CMake build system for compiling the C++ core library and
+its Python bindings. As such, the library dependencies listed above must
+be discoverable by CMake's `find_package`.
+
+For reference, during development of OpenAssetIO we use the [conan](https://conan.io/)
+package manager, and source the dependencies from the default public
+[ConanCenter](https://conan.io/center/) repository. We therefore assume
+the presence of CMake build targets as exported by these packages.
+
+> Warning: if attempting to build on CentOS 7 using the ConanCenter
+> Python 3.9 package you will likely hit an [issue installing pkgconf](https://github.com/conan-io/conan-center-index/issues/8541).
+
+## Building
+
+We use the CMake build system for compiling the C++ core library and
+its Python bindings.
+
+By default, the project will build shared libraries and set the
+installation directory to `dist` in the repository root. This can be
+overridden by setting the built-in CMake variables `BUILD_SHARED_LIBS`
+and `CMAKE_INSTALL_PREFIX`, respectively.
+
+If shared library builds are disabled, then the core library will be
+built and installed as a static library, and statically linked into the
+Python module.
+
+In order to build and install the binary artifacts, assuming the current
+working directory is at the repository root, run
+
+```shell
+cmake -S . -B build
+cmake --build build
+cmake --install build
+```
+
+The pure Python component can then be installed into a Python
+environment using
+
+```shell
+pip install .
+```
+
+The pure Python component will not function unless the compiled binary
+artifacts are also made available to the Python environment.
+
+## Running tests
+
+Testing is disabled by default and must be enabled by setting the
+`OPENASSETIO_ENABLE_TESTS` CMake variable. Assuming that the working
+directory is the repository root, we can configure the CMake build as
+follows
+
+```shell
+cmake -S . -B build -DOPENASSETIO_ENABLE_TESTS=ON
+```
+
+### Using `ctest`
+
+The manual steps detailed below are conveniently wrapped by CTest -
+CMake's built-in test runner. In order to execute the tests,
+from the `build` directory simply run
+
+```shell
+ctest
+```
+
+This will build and install binary artifacts, create a Python
+environment, install the pure Python component and test dependencies,
+then execute the tests.
+
+A disadvantage of this is that the pure Python component is
+reinstalled every time tests are executed, even if no files changed.
+
+### Step by step
+
+We must first build and install the binary artifacts. Assuming the CMake
+build has been configured as above, then
+
+```shell
+cmake --build build
+cmake --install build
+```
+
+Since the discovered Python may be different from the system Python,
+there is a convenience build target to create a Python virtual
+environment in the installation directory, which ensures that the same
+Python that was linked against is used to create the environment.
+
+```shell
+cmake --build build --target openassetio-python-venv
+```
+
+We can then use this environment to execute the tests.
+
+Next we must install the pure Python component and test-specific
+dependencies. Assuming the install directory is `dist` under the
+repository root (the default)
+
+```shell
+source dist/bin/activate
+pip install .
+pip install -r tests/requirements.txt
+```
+
+We can now run the Python tests via `pytest`
+
+```shell
+pytest tests
+```
+
+## Using Vagrant
+
+Included for convenience is a [Vagrant](https://www.vagrantup.com/)
+configuration for creating reproducible build environments. This is
+configured to create a virtual machine that matches the Linux Github CI
+environment as close as is feasible.
+
+The Vagrant VM installs third-party library dependencies using the
+[conan](https://conan.io/) package manager, and sources the dependencies
+from the default public [ConanCenter](https://conan.io/center/)
+repository.
+
+In order to build and run the tests within a Vagrant VM, assuming
+Vagrant is installed and the current working directory is the root of
+the repository, run the following
+
+```shell
+cd resources/build
+vagrant up
+# Wait a while...
+vagrant ssh
+cmake -S openassetio -B build --install-prefix ~/dist \
+  --toolchain ~/conan/conan_paths.cmake -DOPENASSETIO_ENABLE_TESTS=ON
+```
+
+Then we can run the following steps to build, install and run the tests
+
+```shell
+cmake --build build
+cmake --install build
+cmake --build build --target openassetio-python-venv
+source dist/bin/activate
+pip install ./openassetio
+pip install -r openassetio/tests/requirements.txt
+pytest openassetio/tests
+```
+or alternatively, simply
+
+```shell
+cd build
+ctest
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,11 +191,13 @@ include(ThirdParty)
 if (OPENASSETIO_ENABLE_TESTS)
     enable_testing()
     # Add a top-level install target, useful for tests to ensure the
-    # project is installed. The special `install` target varies by
-    # subdirectory, so we can't use that directly and must wrap it here.
-    add_custom_target(openassetio-install)
-    add_dependencies(openassetio-install install)
+    # project is installed. The special `install` target is unavailable
+    # as a target dependency if the Unix Makefile generator (default on
+    # Linux) is used, so we must shell out the install.
+    add_custom_target(openassetio-install
+        COMMAND "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target install)
 endif()
+
 
 #-----------------------------------------------------------------------
 # Generate OpenAssetIOConfig.cmake et al. for bundling as a CMake lib.

--- a/README.md
+++ b/README.md
@@ -281,6 +281,21 @@ cd build
 ctest
 ```
 
+### Using the ASWF Docker image
+
+The Academy Software Foundation maintains a set of VFX Reference 
+Platform compatible [Docker](https://www.docker.com/) images [here](https://github.com/AcademySoftwareFoundation/aswf-docker).
+
+The CY22 image contains all dependencies currently required for building
+OpenAssetIO. For example, to build and run the tests via a container, 
+from the repository root run
+
+```shell
+docker run -v `pwd`:/src aswf/ci-base:2022.2 bash -c '
+  cd /src && cmake -S . -B build -DOPENASSETIO_ENABLE_TESTS=ON &&\
+  cd build && ctest -VV'
+````
+
 ## Getting involved
 
 - See the [contribution guide](contributing/PROCESS.md)

--- a/README.md
+++ b/README.md
@@ -238,6 +238,48 @@ We can now run the Python tests via `pytest`
 pytest tests
 ```
 
+### Using Vagrant
+
+Included for convenience is a [Vagrant](https://www.vagrantup.com/)
+configuration for creating reproducible build environments. This is
+configured to create a virtual machine that matches the Linux Github CI
+environment as close as is feasible.
+
+The Vagrant VM installs third-party library dependencies using the
+[conan](https://conan.io/) package manager, and sources the dependencies
+from the default public [ConanCenter](https://conan.io/center/)
+repository.
+
+In order to build and run the tests within a Vagrant VM, assuming
+Vagrant is installed and the current working directory is the root of
+the repository, run the following
+
+```shell
+cd ci
+vagrant up
+# Wait a while...
+vagrant ssh
+cmake -S openassetio -B build --install-prefix ~/dist \
+  --toolchain ~/conan/conan_paths.cmake -DOPENASSETIO_ENABLE_TESTS=ON
+```
+
+Then we can run the following steps to build, install and run the tests
+
+```shell
+cmake --build build
+cmake --install build
+cmake --build build --target openassetio-python-venv
+source dist/bin/activate
+pip install ./openassetio
+pip install -r openassetio/tests/requirements.txt
+pytest openassetio/tests
+```
+or alternatively, simply
+
+```shell
+cd build
+ctest
+```
 
 ## Getting involved
 

--- a/README.md
+++ b/README.md
@@ -107,34 +107,6 @@ which appears to overlap with a subset of `OpenAssetIO`s concerns.
 
 ## Getting started
 
-### System requirements
-
-Ubuntu Linux 20.04 is currently the only fully tested platform. Support
-for other platforms is the subject of ongoing work. We further assume
-the following system packages are installed
-
-- CMake 3.21+
-- GCC 9.3
-
-### Library dependencies
-
-Binary builds additionally require the following packages to be
-available to the CMake build system.
-- Python 3.9 (development install)
-- [pybind11](https://pybind11.readthedocs.io/en/stable/) 2.6.1+
-
-We use the CMake build system for compiling the C++ core library and
-its Python bindings. As such, the library dependencies listed above must
-be discoverable by CMake's `find_package`.
-
-For reference, during development of OpenAssetIO we use the [conan](https://conan.io/)
-package manager, and source the dependencies from the default public
-[ConanCenter](https://conan.io/center/) repository. We therefore assume
-the presence of CMake build targets as exported by these packages.
-
-> Warning: if attempting to build on CentOS 7 using the ConanCenter
-> Python 3.9 package you will likely hit an [issue installing pkgconf](https://github.com/conan-io/conan-center-index/issues/8541).
-
 ### Installation
 
 The OpenAssetIO codebase is available as a git repository on GitHub
@@ -143,145 +115,12 @@ The OpenAssetIO codebase is available as a git repository on GitHub
 git clone git@github.com:TheFoundryVisionmongers/OpenAssetIO
 ```
 
-### Building
+### System requirements
 
-By default, the project will build shared libraries and set the
-installation directory to `dist` in the repository root. This can be
-overridden by setting the built-in CMake variables `BUILD_SHARED_LIBS`
-and `CMAKE_INSTALL_PREFIX`, respectively.
+Linux is currently the only fully tested platform. Support
+for other platforms is the subject of ongoing work. 
 
-If shared library builds are disabled, then the core library will be
-built and installed as a static library, and statically linked into the
-Python module.
-
-In order to build and install the binary artifacts, assuming the current
-working directory is at the repository root, run
-
-```shell
-cmake -S . -B build
-cmake --build build
-cmake --install build
-```
-
-The pure Python component can then be installed into a Python
-environment using
-
-```shell
-pip install .
-```
-
-The pure Python component will not function unless the compiled binary
-artifacts are also made available to the Python environment.
-
-### Running tests
-
-Testing is disabled by default and must be enabled by setting the
-`OPENASSETIO_ENABLE_TESTS` CMake variable. Assuming that the working
-directory is the repository root, we can configure the CMake build as
-follows
-
-```shell
-cmake -S . -B build -DOPENASSETIO_ENABLE_TESTS=ON
-```
-
-#### Quick start: using `ctest`
-
-The manual steps detailed below are conveniently wrapped by CTest -
-CMake's built-in test runner. In order to execute the tests,
-from the build directory simply run
-
-```shell
-ctest
-```
-
-This will build and install binary artifacts, create a Python
-environment, install the pure Python component and test dependencies,
-then execute the tests.
-
-A disadvantage of this is that the pure Python component is
-reinstalled every time tests are executed, even if no files changed.
-
-#### Step by step
-
-We must first build and install the binary artifacts. Assuming the CMake
-build has been configured as above, then
-
-```shell
-cmake --build build
-cmake --install build
-```
-
-Since the discovered Python may be different from the system Python,
-there is a convenience build target to create a Python virtual
-environment in the installation directory, which ensures that the same
-Python that was linked against is used to create the environment.
-
-```shell
-cmake --build build --target openassetio-python-venv
-```
-
-We can then use this environment to execute the tests.
-
-Next we must install the pure Python component and test-specific
-dependencies. Assuming the install directory is `dist` under the
-repository root (the default)
-
-```shell
-source dist/bin/activate
-pip install .
-pip install -r tests/requirements.txt
-```
-
-We can now run the Python tests via `pytest`
-
-```shell
-pytest tests
-```
-
-### Using Vagrant
-
-Included for convenience is a [Vagrant](https://www.vagrantup.com/)
-configuration for creating reproducible build environments. This is
-configured to create a virtual machine that matches the Linux Github CI
-environment as close as is feasible.
-
-The Vagrant VM installs third-party library dependencies using the
-[conan](https://conan.io/) package manager, and sources the dependencies
-from the default public [ConanCenter](https://conan.io/center/)
-repository.
-
-In order to build and run the tests within a Vagrant VM, assuming
-Vagrant is installed and the current working directory is the root of
-the repository, run the following
-
-```shell
-cd ci
-vagrant up
-# Wait a while...
-vagrant ssh
-cmake -S openassetio -B build --install-prefix ~/dist \
-  --toolchain ~/conan/conan_paths.cmake -DOPENASSETIO_ENABLE_TESTS=ON
-```
-
-Then we can run the following steps to build, install and run the tests
-
-```shell
-cmake --build build
-cmake --install build
-cmake --build build --target openassetio-python-venv
-source dist/bin/activate
-pip install ./openassetio
-pip install -r openassetio/tests/requirements.txt
-pytest openassetio/tests
-```
-or alternatively, simply
-
-```shell
-cd build
-ctest
-```
-
-### Using the ASWF Docker image
+#### Quick start: Using the ASWF Docker image
 
 The Academy Software Foundation maintains a set of VFX Reference 
 Platform compatible [Docker](https://www.docker.com/) images [here](https://github.com/AcademySoftwareFoundation/aswf-docker).
@@ -294,7 +133,12 @@ from the repository root run
 docker run -v `pwd`:/src aswf/ci-base:2022.2 bash -c '
   cd /src && cmake -S . -B build -DOPENASSETIO_ENABLE_TESTS=ON &&\
   cd build && ctest -VV'
-````
+```
+
+#### Other build methods
+
+For detailed instructions see [BUILDING](BUILDING.md).
+
 
 ## Getting involved
 

--- a/README.md
+++ b/README.md
@@ -109,25 +109,135 @@ which appears to overlap with a subset of `OpenAssetIO`s concerns.
 
 ### System requirements
 
-- `linux` (`macOS` and `Windows` are currently unsupported)
-- `Python 3.7` or later
+Ubuntu Linux 20.04 is currently the only fully tested platform. Support
+for other platforms is the subject of ongoing work. We further assume
+the following system packages are installed
+
+- CMake 3.21+
+- GCC 9.3
+
+### Library dependencies
+
+Binary builds additionally require the following packages to be
+available to the CMake build system.
+- Python 3.9 (development install)
+- [pybind11](https://pybind11.readthedocs.io/en/stable/) 2.6.1+
+
+We use the CMake build system for compiling the C++ core library and
+its Python bindings. As such, the library dependencies listed above must
+be discoverable by CMake's `find_package`.
+
+For reference, during development of OpenAssetIO we use the [conan](https://conan.io/)
+package manager, and source the dependencies from the default public
+[ConanCenter](https://conan.io/center/) repository. We therefore assume
+the presence of CMake build targets as exported by these packages.
+
+> Warning: if attempting to build on CentOS 7 using the ConanCenter
+> Python 3.9 package you will likely hit an [issue installing pkgconf](https://github.com/conan-io/conan-center-index/issues/8541).
 
 ### Installation
 
-```
+The OpenAssetIO codebase is available as a git repository on GitHub
+
+```shell
 git clone git@github.com:TheFoundryVisionmongers/OpenAssetIO
-cd OpenAssetIO
-python3.7 -m venv .venv
-. .venv/bin/activate
-pip install -e .
 ```
+
+### Building
+
+By default, the project will build shared libraries and set the
+installation directory to `dist` in the repository root. This can be
+overridden by setting the built-in CMake variables `BUILD_SHARED_LIBS`
+and `CMAKE_INSTALL_PREFIX`, respectively.
+
+If shared library builds are disabled, then the core library will be
+built and installed as a static library, and statically linked into the
+Python module.
+
+In order to build and install the binary artifacts, assuming the current
+working directory is at the repository root, run
+
+```shell
+cmake -S . -B build
+cmake --build build
+cmake --install build
+```
+
+The pure Python component can then be installed into a Python
+environment using
+
+```shell
+pip install .
+```
+
+The pure Python component will not function unless the compiled binary
+artifacts are also made available to the Python environment.
 
 ### Running tests
 
+Testing is disabled by default and must be enabled by setting the
+`OPENASSETIO_ENABLE_TESTS` CMake variable. Assuming that the working
+directory is the repository root, we can configure the CMake build as
+follows
+
+```shell
+cmake -S . -B build -DOPENASSETIO_ENABLE_TESTS=ON
 ```
+
+#### Quick start: using `ctest`
+
+The manual steps detailed below are conveniently wrapped by CTest -
+CMake's built-in test runner. In order to execute the tests,
+from the build directory simply run
+
+```shell
+ctest
+```
+
+This will build and install binary artifacts, create a Python
+environment, install the pure Python component and test dependencies,
+then execute the tests.
+
+A disadvantage of this is that the pure Python component is
+reinstalled every time tests are executed, even if no files changed.
+
+#### Step by step
+
+We must first build and install the binary artifacts. Assuming the CMake
+build has been configured as above, then
+
+```shell
+cmake --build build
+cmake --install build
+```
+
+Since the discovered Python may be different from the system Python,
+there is a convenience build target to create a Python virtual
+environment in the installation directory, which ensures that the same
+Python that was linked against is used to create the environment.
+
+```shell
+cmake --build build --target openassetio-python-venv
+```
+
+We can then use this environment to execute the tests.
+
+Next we must install the pure Python component and test-specific
+dependencies. Assuming the install directory is `dist` under the
+repository root (the default)
+
+```shell
+source dist/bin/activate
+pip install .
 pip install -r tests/requirements.txt
-pytest
 ```
+
+We can now run the Python tests via `pytest`
+
+```shell
+pytest tests
+```
+
 
 ## Getting involved
 

--- a/cmake/DefaultTargetProperties.cmake
+++ b/cmake/DefaultTargetProperties.cmake
@@ -182,8 +182,21 @@ function(set_default_target_properties target_name)
         list(JOIN sanitizers "," sanitize_arg)
 
         if (sanitize_arg AND NOT "${sanitize_arg}" STREQUAL "")
-            target_compile_options(${target_name} PRIVATE -fsanitize=${sanitize_arg})
-            target_link_options(${target_name} PRIVATE -fsanitize=${sanitize_arg})
+            # Add sanitizers, including
+            # * -fno-omit-frame-pointer to enable stack traces on
+            #   failure.
+            # * -fno-sanitize-recover=all to force the program to exit
+            #   with an error code on failure.
+            target_compile_options(${target_name}
+                PRIVATE
+                -fno-sanitize-recover=all
+                -fsanitize=${sanitize_arg}
+                -fno-omit-frame-pointer)
+            target_link_options(${target_name}
+                PRIVATE
+                -fno-sanitize-recover=all
+                -fsanitize=${sanitize_arg}
+                -fno-omit-frame-pointer)
         endif ()
     endif ()
 

--- a/resources/build/Vagrantfile
+++ b/resources/build/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+workspace_dir = "/home/vagrant/openassetio"
+
+Vagrant.configure("2") do |config|
+  # https://docs.vagrantup.com.
+
+  # Base on Ubuntu. Note that this is not VFX reference platform, but
+  # instead matches CI.
+  config.vm.box = "ubuntu/focal64"
+
+  # Disable default mount/sync of Vagrantfile (sub)directory.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  # Mount parent (i.e. project) directory in the VM.
+  config.vm.synced_folder "../..", workspace_dir
+
+  # Provider-specific configuration.
+  config.vm.provider "virtualbox" do |vb|
+    # Configure hardware to resemble Github Actions CI VM:
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+    vb.memory = 7168
+    vb.cpus = 2
+  end
+
+  # Provision via a shell script.
+  config.vm.provision(
+    "shell", path: "bootstrap-ubuntu-20.04.sh", privileged: false,
+    env: {"GITHUB_WORKSPACE" => workspace_dir})
+end

--- a/resources/build/bootstrap-ubuntu-20.04.sh
+++ b/resources/build/bootstrap-ubuntu-20.04.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# This bootstrap script is used by both the Github CI action and the
+# Vagrant VM configuration.
+
+set -xeo pipefail
+sudo apt-get update
+# Install gcc and Python 3 (via pip, which will bring along Python 3 as
+# a dependency).
+sudo apt-get install -y build-essential python3-pip
+# Install system packages required for the Python 3.9 conan package.
+# These would be installed as part of the conan package install, but
+# we're caching the conan directory via the `actions/cache` Github
+# action, so a fresh Github VM is left without these system packages.
+sudo apt-get install -y  --no-install-recommends libfontenc-dev libx11-xcb-dev libxaw7-dev \
+    libxcb-dri3-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev \
+    libxcb-render-util0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-util-dev libxcb-xfixes0-dev \
+    libxcb-xinerama0-dev libxcb-xkb-dev libxcomposite-dev libxcursor-dev libxdamage-dev \
+    libxfixes-dev libxi-dev libxinerama-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev \
+    libxres-dev libxss-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev
+
+# Install additional build tools.
+sudo pip3 install conan==1.45.0 cmake==3.21 ninja==1.10.2.3
+# Use explicit predictable conan root path, to be used for both packages
+# and conan CMake toolchain config.
+export CONAN_USER_HOME="$HOME/conan"
+# Use old C++11 ABI as per VFX Reference Platform CY2022.
+conan config set compiler.libcxx=libstdc++
+# Install openassetio third-party dependencies from public Conan Center
+# package repo.
+conan install --install-folder "$CONAN_USER_HOME" --build=missing \
+    "$GITHUB_WORKSPACE/resources/build"

--- a/resources/build/conanfile.txt
+++ b/resources/build/conanfile.txt
@@ -1,0 +1,12 @@
+[requires]
+cpython/3.9.7
+pybind11/2.6.1
+
+[generators]
+# Generate a CMake toolchain preamble file `conan_paths.cmake`, which
+# augments package search paths with conan package directories.
+cmake_paths
+# Generate `Find<PackageName>.cmake` finders, required for various
+# public ConanCenter packages (e.g. pybind11) since they disallow
+# bundling of `<PackageName>Config.cmake`-like files in the package.
+cmake_find_package

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[build]
+# Change the default temporary Python `build` directory to help avoid
+# conflicts with common CMake configs that use `build` as the C++ build
+# directory.
+build-base=.pybuild

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -67,16 +67,26 @@ endif ()
 
 if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
 
-    # Command to create a Python environment in the install directory,
-    # then install test-specific dependencies (e.g. pytest).
+    # Command to create a Python environment in the install directory.
     add_custom_command(
         OUTPUT
         "${CMAKE_INSTALL_PREFIX}/bin/pip"
-        "${CMAKE_INSTALL_PREFIX}/bin/pytest"
         COMMAND
         "${Python_EXECUTABLE}" -m venv "${CMAKE_INSTALL_PREFIX}"
+    )
+    # Target to wrap the venv command so it can be executed in isolation.
+    add_custom_target(
+        openassetio-python-venv
+        DEPENDS "${CMAKE_INSTALL_PREFIX}/bin/pip"
+    )
+
+    # Command to install test-specific dependencies (e.g. pytest).
+    add_custom_command(
+        OUTPUT
+        "${CMAKE_INSTALL_PREFIX}/bin/pytest"
         COMMAND
         "${CMAKE_INSTALL_PREFIX}/bin/pip" install -r "${PROJECT_SOURCE_DIR}/tests/requirements.txt"
+        DEPENDS "${CMAKE_INSTALL_PREFIX}/bin/pip"
     )
 
     # Target to install the pure Python component of the project.

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -98,11 +98,33 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
     # Ensure pre-requisite C++ component has been installed first.
     add_dependencies(openassetio-python-py-install openassetio-install)
 
+    # Add ASan-specific environment variables to prepend to the `pytest`
+    # invocation.
+    if (OPENASSETIO_ENABLE_SANITIZER_ADDRESS AND IS_GCC_OR_CLANG)
+        # ASan will error out if libasan is not the first library to be
+        # linked (so it can override `malloc`). Since our executable
+        # (`python` in this case) doesn't link libasan we must add it to
+        # `LD_PRELOAD`. But first we have to find libasan on the system:
+        execute_process(
+            # TODO(DF): This is probably wrong for OSX (clang).
+            COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libasan.so
+            OUTPUT_VARIABLE asan_path
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        # In addition to `LD_PRELOAD`ing libasan, we must override
+        # Python's memory allocator to use the C (or rather, ASan's)
+        # `malloc` rather than the optimized `pymalloc`, so that ASan
+        # can properly count memory (de)allocations.
+        set(pytest_env PYTHONMALLOC=malloc LD_PRELOAD=${asan_path})
+    endif()
+
     # Target to run pytest in the install directory, ensuring the lib has
-    # been built and installed first.
+    # been built and installed first. Add `-s` to ensure no output is
+    # captured, which is needed to show sanitizer errors (and is useful
+    # for debugging regardless).
     add_custom_target(
         openassetio-python-pytest
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/pytest"
+        COMMAND ${pytest_env} "${CMAKE_INSTALL_PREFIX}/bin/pytest" -s
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests"
         DEPENDS "${CMAKE_INSTALL_PREFIX}/bin/pytest"
     )

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -73,6 +73,8 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
         "${CMAKE_INSTALL_PREFIX}/bin/pip"
         COMMAND
         "${Python_EXECUTABLE}" -m venv "${CMAKE_INSTALL_PREFIX}"
+        COMMAND
+        ${CMAKE_INSTALL_PREFIX}/bin/python -m pip install --upgrade pip
     )
     # Target to wrap the venv command so it can be executed in isolation.
     add_custom_target(


### PR DESCRIPTION
For #182, re-enable `pytest` testing, wrapped in a `ctest` target. That is, `cmake` configure the project then run `ctest` in Github CI. 

Only Linux is supported and enabled at the moment in Github CI. Windows and OSX support are left for future work.

The `openassetio-python` CTest target is configured to ensure dependencies are built and installed, including a Python environment for running the tests. 

A [Vagrant](https://www.vagrantup.com/) virtual machine config is included that roughly mirrors the Github Linux CI environment, useful for testing CI changes and onboarding devs.


The [Conan](https://conan.io/) package manager is used to source third-party dependencies from the public [ConanCenter](https://conan.io/center/) repository, for both Github CI and the Vagrant VM.

The README is updated to show both the `ctest` workflow as well as step-by-step.

The address sanitizer (ASan) and undefined behavior sanitizer (UBsan) are enabled for the Github CI action.

