### PR TITLE
[Test] Provide a suitably configured locale to `FixtureAugmentedTestCase`

### DIFF
--- a/python/openassetio/Specification.py
+++ b/python/openassetio/Specification.py
@@ -94,6 +94,10 @@ class SpecificationBase(FixedInterfaceObject):
     def __repr__(self):
         return str(self)
 
+    def __eq__(self, other):
+        return self.schema() == other.schema() and self.data() == other.data()
+
+
 
 class Specification(SpecificationBase, metaclass=SpecificationFactory):
     """

--- a/python/openassetio/test/manager/_implementation.py
+++ b/python/openassetio/test/manager/_implementation.py
@@ -22,6 +22,8 @@ import unittest
 
 from openassetio import hostAPI, pluginSystem, logging
 
+from .specifications import ManagerTestHarnessLocale
+
 
 __all__ = ['createHarness']
 
@@ -128,13 +130,18 @@ class _ValidatorTestLoader(unittest.loader.TestLoader):
         execute.
         """
         testCaseNames = self.getTestCaseNames(testCaseClass)
-        loadedSuite = self.suiteClass(
-            testCaseClass(
+        cases = []
+        for testCaseName in testCaseNames:
+
+            locale = ManagerTestHarnessLocale()
+            locale.testCase = f"{testCaseClass.__name__}.{testCaseName}"
+
+            cases.append(testCaseClass(
                 self.__fixtures.get(testCaseClass.__name__, {}).get(testCaseName),
-                self.__session, testCaseName
-            )
-            for testCaseName in testCaseNames)
-        return loadedSuite
+                self.__session, locale, testCaseName
+            ))
+
+        return self.suiteClass(cases)
 
     def setFixtures(self, fixtures):
         """

--- a/python/openassetio/test/manager/harness.py
+++ b/python/openassetio/test/manager/harness.py
@@ -131,7 +131,7 @@ class FixtureAugmentedTestCase(unittest.TestCase):
     subclasses via protected members.
     """
 
-    def __init__(self, fixtures, session, *args, **kwargs):
+    def __init__(self, fixtures, session, locale, *args, **kwargs):
         """
         Initializes an instance of this class.
 
@@ -144,6 +144,9 @@ class FixtureAugmentedTestCase(unittest.TestCase):
         @param session hostAPI.Session.Session The OpenAssetIO
         @ref session to be used by test cases.
 
+        @param locale specifications.LocaleSpecification The @ref locale
+        to use by test cases.
+
         @param args `List[Any]` Additional args passed along to the
         base class.
 
@@ -152,6 +155,7 @@ class FixtureAugmentedTestCase(unittest.TestCase):
         """
         self._fixtures = fixtures  # type: dict
         self._session = session  # type: hostAPI.Session
+        self._locale = locale  # type: specifications.LocaleSpecification
         self._manager = session.currentManager()  # type: managerAPI.Manager
         super(FixtureAugmentedTestCase, self).__init__(*args, **kwargs)
 

--- a/python/openassetio/test/manager/specifications.py
+++ b/python/openassetio/test/manager/specifications.py
@@ -1,0 +1,28 @@
+#
+#   Copyright 2022 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+@namespace openassetio.test.manager.specifications
+Specifications for use within openassetio manager test harnesses.
+"""
+
+from ..specifications import TestHarnessLocale
+
+
+class ManagerTestHarnessLocale(TestHarnessLocale):
+    """
+    A locale for tests cases in the manager test harness.
+    """
+    _type = f"{TestHarnessLocale._type}.manager"

--- a/python/openassetio/test/specifications.py
+++ b/python/openassetio/test/specifications.py
@@ -1,0 +1,32 @@
+#
+#   Copyright 2022 The Foundry Visionmongers Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+"""
+@namespace openassetio.test.specifications
+Specifications for use within openassetio test harnesses.
+"""
+
+from openassetio.specifications import LocaleSpecification
+
+
+class TestHarnessLocale(LocaleSpecification):
+    """
+    A locale for test cases run as part of one of the API supplied
+    test harnesses.
+    """
+    _type = "test.harness"
+
+    testSuite = LocaleSpecification.TypedProperty(str, doc="The name of the test suite being run")
+    testCase = LocaleSpecification.TypedProperty(str, doc="The name of the test case being run")

--- a/tests/openassetio/test/manager/conftest.py
+++ b/tests/openassetio/test/manager/conftest.py
@@ -26,6 +26,7 @@ from unittest import mock
 import pytest
 
 from openassetio import hostAPI, logging
+from openassetio.specifications import LocaleSpecification
 
 
 @pytest.fixture
@@ -75,3 +76,8 @@ def a_fixture_dict():
     return {
         "identifier": "org.some.manager"
     }
+
+
+@pytest.fixture
+def a_locale():
+    return LocaleSpecification()

--- a/tests/openassetio/test/manager/resources/suite_executeSuiteTests.py
+++ b/tests/openassetio/test/manager/resources/suite_executeSuiteTests.py
@@ -23,6 +23,7 @@ that the harness implementation supplies the correct state to each test.
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
 from openassetio.hostAPI import Manager, Session
+from openassetio.test.manager.specifications import ManagerTestHarnessLocale
 from openassetio.test.manager.harness import FixtureAugmentedTestCase
 
 
@@ -65,6 +66,22 @@ class Test_executeSuite_fixtures(FixtureAugmentedTestCase):
                 "aUniqueValue": 5
             }
         )
+
+
+class Test_executeSuite_locale(FixtureAugmentedTestCase):
+
+    def test_when_test_function_is_run_then_locale_is_set(self):
+        self.assertIsInstance(self._locale, ManagerTestHarnessLocale)
+        self.assertEqual(
+            self._locale.testCase,
+            'Test_executeSuite_locale'
+            '.test_when_test_function_is_run_then_locale_is_set')
+
+    def test_when_test_function_is_run_then_locale_testCase_is_function_specific(self):
+        self.assertEqual(
+            self._locale.testCase,
+            'Test_executeSuite_locale'
+            '.test_when_test_function_is_run_then_locale_testCase_is_function_specific')
 
 
 # Contrived tests that are expected by the actual test suite.

--- a/tests/openassetio/test/manager/test__implementation.py
+++ b/tests/openassetio/test/manager/test__implementation.py
@@ -30,6 +30,7 @@ import pytest
 
 
 from openassetio.test.manager.harness import FixtureAugmentedTestCase
+from openassetio.test.manager.specifications import ManagerTestHarnessLocale
 from openassetio.test.manager._implementation import (
         _ValidatorHarnessHostInterface, _ValidatorTestLoader)
 
@@ -53,8 +54,11 @@ class Test_Loader_loadTestsFromTestCase:
         # Assert that the instances of the TestCase class are given the
         # Host instance in their constructors.
         mock_test_case_class.assert_has_calls([
-            call(None, mock_session, "test_one"),
-            call(None, mock_session, "test_two")])
+            call(None, mock_session,
+                    ManagerTestHarnessLocale({"testCase": "Test_MockTest.test_one"}), "test_one"),
+            call(None, mock_session,
+                    ManagerTestHarnessLocale({"testCase": "Test_MockTest.test_two"}), "test_two")
+        ])
         assert set(suite._tests) == {mock_test_case_one, mock_test_case_two}
 
     def test_when_cases_have_fixtures_then_initializes_test_cases_with_fixtures(
@@ -81,8 +85,10 @@ class Test_Loader_loadTestsFromTestCase:
         # Assert that the instances of the TestCase class are given the
         # Host instance in their constructors.
         mock_test_case_class.assert_has_calls([
-            call(case_one_fixtures, mock_session, "test_one"),
-            call(case_two_fixtures, mock_session, "test_two")])
+            call(case_one_fixtures, mock_session,
+                    ManagerTestHarnessLocale({"testCase": "Test_MockTest.test_one"}), "test_one"),
+            call(case_two_fixtures, mock_session,
+                    ManagerTestHarnessLocale({"testCase": "Test_MockTest.test_two"}), "test_two")])
         assert set(suite._tests) == {mock_test_case_one, mock_test_case_two}
 
     def test_when_case_has_no_fixtures_then_initializes_test_case_with_no_fixtures(
@@ -107,8 +113,11 @@ class Test_Loader_loadTestsFromTestCase:
         # Assert that the instances of the TestCase class are given the
         # Host instance in their constructors.
         mock_test_case_class.assert_has_calls([
-            call(None, mock_session, "test_one"),
-            call(case_two_fixtures, mock_session, "test_two")])
+            call(None, mock_session,
+                    ManagerTestHarnessLocale({"testCase": "Test_MockTest.test_one"}), "test_one"),
+            call(case_two_fixtures, mock_session,
+                    ManagerTestHarnessLocale({"testCase": "Test_MockTest.test_two"}), "test_two")
+        ])
         assert set(suite._tests) == {mock_test_case_one, mock_test_case_two}
 
 
@@ -126,15 +135,16 @@ class Test_ValidatorHostInterface_displayName:
 
 class Test_FixtureAugmentedTestCase_init:
     def test_has_fixtures_session_and_manager(
-            self, mock_test_case, a_fixture_dict, mock_session, mock_manager):
+            self, mock_test_case, a_fixture_dict, mock_session, mock_manager, a_locale):
         assert mock_test_case._fixtures is a_fixture_dict
         assert mock_test_case._session is mock_session
         assert mock_test_case._manager is mock_manager
+        assert mock_test_case._locale is a_locale
 
 
 @pytest.fixture
-def mock_test_case(a_fixture_dict, mock_session):
-    return FixtureAugmentedTestCase(a_fixture_dict, mock_session)
+def mock_test_case(a_fixture_dict, mock_session, a_locale):
+    return FixtureAugmentedTestCase(a_fixture_dict, mock_session, a_locale)
 
 
 @pytest.fixture

--- a/tests/openassetio/test/manager/test_harness.py
+++ b/tests/openassetio/test/manager/test_harness.py
@@ -96,9 +96,9 @@ class Test_executeSuite:
 class Test_FixtureAugmentedTestCase:
 
     def test_when_constructed_then_objects_are_exposed_via_protected_members(
-            self, a_fixture_dict, mock_session):
+            self, a_fixture_dict, a_locale, mock_session):
 
-        case = FixtureAugmentedTestCase(a_fixture_dict, mock_session)
+        case = FixtureAugmentedTestCase(a_fixture_dict, mock_session, a_locale)
         # pylint: disable=protected-access
         assert case._session == mock_session
         assert case._fixtures == a_fixture_dict
@@ -219,8 +219,8 @@ def executeSuiteTests_fixtures(resources_dir):
 
 
 @pytest.fixture
-def a_test_case(a_fixture_dict, mock_session):
-    return FixtureAugmentedTestCase(a_fixture_dict, mock_session)
+def a_test_case(a_fixture_dict, mock_session, a_locale):
+    return FixtureAugmentedTestCase(a_fixture_dict, mock_session, a_locale)
 
 #
 # Helpers

--- a/tests/openassetio/test_specification.py
+++ b/tests/openassetio/test_specification.py
@@ -190,3 +190,18 @@ class Test_Specification_data:
         spec_data = a_spec.data()
 
         assert set(a_spec.definedPropertyNames()) == set(spec_data.keys())
+
+
+class Test_Specification_equality:
+
+    def test_matching_specifications_are_equal(self):
+        assert PrefixASpec() == PrefixASpec()
+
+    def test_differing_properties_are_not_equal(self):
+        assert PrefixASpec() != PrefixASpec({"anInt":420})
+
+    def test_differing_prefixes_are_not_equal(self):
+        assert PrefixASpec() != PrefixBSpec()
+
+    def test_differing_types_are_not_equal(self):
+        assert PrefixASpec() != PrefixAChildSpec()


### PR DESCRIPTION
Following on from #219, makes the test harness hosts follow best practice of setting a suitably configured locale in all context's passed to API calls. Doing it in the test loader saves the test author from having to write a lot of boilerplate.

Ultimately, we should probably make `Context.locale` required and enforce that is its not `None` somewhere.