### PR TITLE
[Core] Remove context passed to `isEntityReference`

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -382,7 +382,7 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def isEntityReference(self, tokens, context):
+    def isEntityReference(self, tokens):
         """
         @warning It is essential, as a host, that only valid
         references are supplied to Manager API calls. Before any
@@ -405,8 +405,6 @@ class Manager(Debuggable):
 
         @param tokens `List[str]` The strings to be inspected.
 
-        @param context openassetio.Context The calling context.
-
         @return `List[bool]` `True` if a supplied token should be
         considered as an @ref entity_reference, `False` if the pattern
         is not recognised.
@@ -424,7 +422,7 @@ class Manager(Debuggable):
         # We need to add support here for using the supplied prefix match string,
         # or regex, if supplied, instead of calling the manager, this is less
         # relevant in python though, more in C, but the note is here to remind us.
-        return self.__impl.isEntityReference(tokens, context, self.__hostSession)
+        return self.__impl.isEntityReference(tokens, self.__hostSession)
 
     @debugApiCall
     @auditApiCall("Manager methods")

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -464,7 +464,7 @@ class ManagerInterface(object):
     # @{
 
     @abc.abstractmethod
-    def isEntityReference(self, tokens, context, hostSession):
+    def isEntityReference(self, tokens, hostSession):
         """
         Determines if each supplied token (in its entirety) matches the
         pattern of a valid @ref entity_reference in your system.  It
@@ -483,8 +483,6 @@ class ManagerInterface(object):
         context Locale.
 
         @param tokens `List[str]` The strings to be inspected.
-
-        @param context Context The calling context.
 
         @param hostSession HostSession The API session.
 

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -150,9 +150,9 @@ class ValidatingMockManagerInterface(ManagerInterface):
 
         return mock.DEFAULT
 
-    def isEntityReference(self, tokens, context, hostSession):
+    def isEntityReference(self, tokens, hostSession):
         self.__assertIsIterableOf(tokens, str)
-        self.__assertCallingContext(context, hostSession)
+        assert isinstance(hostSession, HostSession)
         return mock.DEFAULT
 
     def entityExists(self, entityRefs, context, hostSession):
@@ -365,11 +365,11 @@ class Test_Manager_flushCaches:
 class Test_Manager_isEntityReference:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, a_context):
+            self, manager, mock_manager_interface, host_session, some_refs):
 
         method = mock_manager_interface.isEntityReference
-        assert manager.isEntityReference(some_refs, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, a_context, host_session)
+        assert manager.isEntityReference(some_refs) == method.return_value
+        method.assert_called_once_with(some_refs, host_session)
 
 
 class Test_Manager_entityExists:


### PR DESCRIPTION
As documented, this method should only be testing if the format of the string is valid, as such, the result of this should _never_ be context dependent. Supplying a context is redundant and just creates ambiguity.