### PR TITLE
[Core] Remove optional entity ref from `managementPolicy`

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -308,7 +308,7 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def managementPolicy(self, specifications, context, entityRef=None):
+    def managementPolicy(self, specifications, context):
         """
         Determines if the manager is interested in participating in
         interactions with the specified types of @ref entity, either
@@ -333,12 +333,6 @@ class Manager(Debuggable):
         publishing. Ignored reads can allow optimisations in a host as
         there is no longer a need to test/resolve applicable strings.
 
-        Calls with an accompanying @ref entity_reference should be used
-        when one is known, to ensure that the manager has the
-        opportunity to prohibit users from attempting to perform an
-        asset-specific action that is not supported by the asset
-        management system.
-
         @note One very important attribute returned as part of this
         policy is the @ref openassetio.constants.kWillManagePath bit. If
         set, you can assume the asset management system will manage the
@@ -356,18 +350,11 @@ class Manager(Debuggable):
 
         @param context Context The calling context.
 
-        @param entityRef `str` If supplied, then the call should be
-        interpreted as a query as to the applicability of the given
-        specification if registered to the supplied entity. For example,
-        attempts to register an ImageSpecification to an entity
-        reference that refers to the top level project may be
-        meaningless, so in this case `kIgnored` would be returned.
-
         @return `List[int]` Bitfields, one for each element in
         `specifications`. See @ref openassetio.constants.
         """
         return self.__impl.managementPolicy(
-            specifications, context, self.__hostSession, entityRef=entityRef)
+            specifications, context, self.__hostSession)
 
     ## @}
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -394,7 +394,7 @@ class ManagerInterface(object):
     # @{
 
     @abc.abstractmethod
-    def managementPolicy(self, specifications, context, hostSession, entityRef=None):
+    def managementPolicy(self, specifications, context, hostSession):
         """
         Determines if the asset manager is interested in participating
         in interactions with the specified specifications of @ref
@@ -416,10 +416,6 @@ class ManagerInterface(object):
         write access to determine if resolution and publishing features
         are applicable to this implementation.
 
-        Calls with an accompanying @ref entity_reference may be used to
-        prevent users from attempting to perform an asset-action that is
-        not supported by the asset management system.
-
         @note One very important attribute returned as part of this
         policy is the @ref openassetio.constants.kWillManagePath bit. If
         set, this instructs the host that the asset management system
@@ -439,13 +435,6 @@ class ManagerInterface(object):
         @param context Context The calling context.
 
         @param hostSession HostSession The API session.
-
-        @param entityRef `str` If supplied, then the call should be
-        interpreted as a query as to the applicability of the given
-        specifications if registered to the supplied entity. For
-        example, attempts to register an ImageSpecification to an
-        entity reference that refers to the top level project may be
-        meaningless, so in this case `kIgnored` should be returned.
 
         @return `List[int]` Bitfields, one for each element in
         `specifications`. See @ref openassetio.constants.

--- a/python/openassetio/test/manager/apiComplianceSuite.py
+++ b/python/openassetio/test/manager/apiComplianceSuite.py
@@ -116,27 +116,7 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
         context.access = context.kWriteMultiple
         self.__assertPolicyResults(1, context)
 
-    def test_calling_with_read_context_and_entity_reference(self):
-        context = self._session.createContext()
-        context.access = context.kRead
-        self.__assertPolicyResults(1, context, self._fixtures['valid_entity_reference'])
-
-    def test_calling_with_write_context_and_entity_reference(self):
-        context = self._session.createContext()
-        context.access = context.kWrite
-        self.__assertPolicyResults(1, context, self._fixtures['valid_entity_reference'])
-
-    def test_calling_with_read_multiple_context_and_entity_reference(self):
-        context = self._session.createContext()
-        context.access = context.kReadMultiple
-        self.__assertPolicyResults(1, context, self._fixtures['valid_entity_reference'])
-
-    def test_calling_with_write_multiple_context_and_entity_reference(self):
-        context = self._session.createContext()
-        context.access = context.kWriteMultiple
-        self.__assertPolicyResults(1, context, self._fixtures['valid_entity_reference'])
-
-    def __assertPolicyResults(self, numSpecifications, context, entityRef=None):
+    def __assertPolicyResults(self, numSpecifications, context):
         """
         Tests the validity and coherency of the results of a call to
         `managementPolicy` for a given number of specifications and
@@ -145,7 +125,7 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
         """
         specs = [EntitySpecification() for _ in range(numSpecifications)]
 
-        policies = self._manager.managementPolicy(specs, context, entityRef=entityRef)
+        policies = self._manager.managementPolicy(specs, context)
 
         self.assertValuesOfType(policies, int)
         self.assertEqual(len(policies), numSpecifications)

--- a/resources/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
+++ b/resources/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
@@ -61,6 +61,6 @@ class SampleAssetManagerInterface(ManagerInterface):
             constants.kField_EntityReferencesMatchPrefix: "sam:///"
         }
 
-    def managementPolicy(self, specifications, context, hostSession, entityRef=None):
+    def managementPolicy(self, specifications, context, hostSession):
         # pylint: disable=unused-argument
         return [constants.kIgnored for _ in specifications]

--- a/resources/examples/manager/SampleAssetManager/tests/fixtures.py
+++ b/resources/examples/manager/SampleAssetManager/tests/fixtures.py
@@ -19,7 +19,6 @@ Manager test harness test case fixtures for Sample Asset Manager (SAM).
 from openassetio.constants import kField_EntityReferencesMatchPrefix
 
 kIdentifier = "org.openassetio.examples.manager.sam"
-dummy_ref = "sam:///placeholder"
 
 fixtures = {
     "identifier": kIdentifier,
@@ -39,11 +38,5 @@ fixtures = {
                 kField_EntityReferencesMatchPrefix: "sam:///"
             }
         }
-    },
-    "Test_managementPolicy": {
-        "test_calling_with_read_context_and_entity_reference": { "valid_entity_reference": dummy_ref },
-        "test_calling_with_write_context_and_entity_reference": { "valid_entity_reference": dummy_ref },
-        "test_calling_with_read_multiple_context_and_entity_reference": { "valid_entity_reference": dummy_ref },
-        "test_calling_with_write_multiple_context_and_entity_reference": { "valid_entity_reference": dummy_ref }
-    },
+    }
 }

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -143,10 +143,9 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def initialize(self, hostSession):
         return mock.DEFAULT
 
-    def managementPolicy(self, specifications, context, hostSession, entityRef=None):
+    def managementPolicy(self, specifications, context, hostSession):
         self.__assertIsIterableOf(specifications, EntitySpecification)
         self.__assertCallingContext(context, hostSession)
-        assert isinstance(entityRef, str) or entityRef is None
 
         return mock.DEFAULT
 
@@ -588,18 +587,11 @@ class Test_Manager_resolveEntityReference:
 class Test_Manager_managentPolicy:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_entity_specs, a_context,
-            a_ref):
+            self, manager, mock_manager_interface, host_session, some_entity_specs, a_context):
 
         method = mock_manager_interface.managementPolicy
         assert manager.managementPolicy(some_entity_specs, a_context) == method.return_value
-        method.assert_called_once_with(some_entity_specs, a_context, host_session, entityRef=None)
-        method.reset_mock()
-
-        method = mock_manager_interface.managementPolicy
-        assert manager.managementPolicy(
-            some_entity_specs, a_context, entityRef=a_ref) == method.return_value
-        method.assert_called_once_with(some_entity_specs, a_context, host_session, entityRef=a_ref)
+        method.assert_called_once_with(some_entity_specs, a_context, host_session)
 
 
 class Test_Manager_preflight:

--- a/tests/openassetio/test/manager/resources/fixtures_cliFail.py
+++ b/tests/openassetio/test/manager/resources/fixtures_cliFail.py
@@ -37,12 +37,6 @@ fixtures = {
         "test_matches_fixture": {
             "info" : {}
         }
-    },
-    "Test_managementPolicy": {
-        "test_calling_with_read_context_and_entity_reference": { "valid_entity_reference": "" },
-        "test_calling_with_write_context_and_entity_reference": { "valid_entity_reference": "" },
-        "test_calling_with_read_multiple_context_and_entity_reference": { "valid_entity_reference": ""},
-        "test_calling_with_write_multiple_context_and_entity_reference": { "valid_entity_reference": "" }
     }
 }
 

--- a/tests/openassetio/test/manager/resources/fixtures_cliPass.py
+++ b/tests/openassetio/test/manager/resources/fixtures_cliPass.py
@@ -38,11 +38,5 @@ fixtures = {
         "test_matches_fixture": {
             "info" : {}
         }
-    },
-    "Test_managementPolicy": {
-        "test_calling_with_read_context_and_entity_reference": { "valid_entity_reference": "" },
-        "test_calling_with_write_context_and_entity_reference": { "valid_entity_reference": "" },
-        "test_calling_with_read_multiple_context_and_entity_reference": { "valid_entity_reference": ""},
-        "test_calling_with_write_multiple_context_and_entity_reference": { "valid_entity_reference": "" }
     }
 }

--- a/tests/openassetio/test/manager/resources/plugins/StubManager.py
+++ b/tests/openassetio/test/manager/resources/plugins/StubManager.py
@@ -43,7 +43,7 @@ class StubManager(ManagerInterface):
         # pylint: disable=unused-argument
         pass
 
-    def managementPolicy(self, specifications, context, hostSession, entityRef=None):
+    def managementPolicy(self, specifications, context, hostSession):
         # pylint: disable=unused-argument
         return [constants.kIgnored for _ in range(len(specifications))]
 


### PR DESCRIPTION
A partial precursor to #115, removes the optional `entityRef` from `managementPolicy`. It seemed like a good idea at the time, but in reality, just opens up ambiguity, and only half solves the problem.

#9 covers the fact that we need a broader mechanism for working out if operation X can be done in the context of Y. One of these things could be to register a new entity to a specific target entity. A more flexible mechanism that covers this and the topics in #9 would be far better than shoehorning the check into `managementPolicy` - which has no mechanism for communicating why.

With the optional reference, it was not clear if a host should always call this prior to `preflight`/`register` or not. Technically, it should! When we do resolve #9, that would then mean two methods potentially needed to be called before a registration/preflight, which would be a very poor design indeed.

By making `managementPolicy` entity invariant, it makes its use much clearer as to when it should be called by a host, and much easier for a host to respect its response.

It can now be simply defined as a one-off check for each context access pattern in relation to any given specification to enable or disable host-side behaviours.