### PR TITLE
[Test] Fix locale used in `apiComplianceSuite`

### DIFF
--- a/python/openassetio/test/manager/apiComplianceSuite.py
+++ b/python/openassetio/test/manager/apiComplianceSuite.py
@@ -89,30 +89,30 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
     """
 
     def test_when_called_with_single_specification_returns_single_result(self):
-        context = self._session.createContext()
+        context = self.createTestContext()
         self.__assertPolicyResults(1, context)
 
     def test_when_called_with_ten_specifications_returns_ten_results(self):
-        context = self._session.createContext()
+        context = self.createTestContext()
         self.__assertPolicyResults(10, context)
 
     def test_calling_with_read_context(self):
-        context = self._session.createContext()
+        context = self.createTestContext()
         context.access = context.kRead
         self.__assertPolicyResults(1, context)
 
     def test_calling_with_write_context(self):
-        context = self._session.createContext()
+        context = self.createTestContext()
         context.access = context.kWrite
         self.__assertPolicyResults(1, context)
 
     def test_calling_with_read_multiple_context(self):
-        context = self._session.createContext()
+        context = self.createTestContext()
         context.access = context.kReadMultiple
         self.__assertPolicyResults(1, context)
 
     def test_calling_with_write_multiple_context(self):
-        context = self._session.createContext()
+        context = self.createTestContext()
         context.access = context.kWriteMultiple
         self.__assertPolicyResults(1, context)
 

--- a/python/openassetio/test/manager/harness.py
+++ b/python/openassetio/test/manager/harness.py
@@ -127,8 +127,12 @@ class FixtureAugmentedTestCase(unittest.TestCase):
     provided, hence requires that `unittest` is provided with the custom
     ValidatorTestLoader test case loader.
 
-    Fixtures, session and manager interface are then provided to
-    subclasses via protected members.
+    Fixtures, session manager interface and a suitable locale are then
+    provided to subclasses via protected members.
+
+    @warning The supplied locale should always be used for interactions
+    with the manager under test, the @ref createTestContext convenience
+    method will create a new context pre-configured with this locale.
     """
 
     def __init__(self, fixtures, session, locale, *args, **kwargs):
@@ -158,6 +162,20 @@ class FixtureAugmentedTestCase(unittest.TestCase):
         self._locale = locale  # type: specifications.LocaleSpecification
         self._manager = session.currentManager()  # type: managerAPI.Manager
         super(FixtureAugmentedTestCase, self).__init__(*args, **kwargs)
+
+    def createTestContext(self, access=None):
+        """
+        A convenience method to create a context with the
+        test locale, as provided by the test harness mechanism.
+
+        @param access `int` One of the context access policies (or None),
+        if provided, the context's access will be set to this.
+        """
+        context = self._session.createContext()
+        context.locale = self._locale
+        if access is not None:
+            context.access = access
+        return context
 
     def assertIsStringKeyPrimitiveValueDict(self, dictionary):
         """

--- a/tests/openassetio/test/manager/test_harness.py
+++ b/tests/openassetio/test/manager/test_harness.py
@@ -31,7 +31,7 @@ import uuid
 import pytest
 
 
-from openassetio import constants
+from openassetio import constants, Context
 from openassetio.test.manager.harness import \
         executeSuite, fixturesFromPyFile, FixtureAugmentedTestCase
 
@@ -103,6 +103,20 @@ class Test_FixtureAugmentedTestCase:
         assert case._session == mock_session
         assert case._fixtures == a_fixture_dict
         assert case._manager == mock_session.currentManager.return_value
+
+
+class Test_FixtureAugmentedTestCase_createTestContext:
+
+    def test_has_test_harness_locale(self, a_test_case):
+        context = a_test_case.createTestContext()
+        assert context.locale is a_test_case._locale  # pylint: disable=protected-access
+
+    def test_when_supplied_with_access_then_the_context_access_is_set(self, a_test_case):
+        context = a_test_case.createTestContext(Context.kWriteMultiple)
+        assert context.access == Context.kWriteMultiple
+
+        context = a_test_case.createTestContext(Context.kReadMultiple)
+        assert context.access == Context.kReadMultiple
 
 
 class Test_FixtureAugmentedTestCase_assertIsStringKeyPrimitiveValueDict:


### PR DESCRIPTION
It is very easy for test case authors to forget to set the correct locale. This saves everyone getting it wrong, as long as they remember to use it.