### PR TITLE
[Test] Assert range of `managementPolicy` in `test.manager.apiComplianceSuite`

### DIFF
--- a/python/openassetio/constants.py
+++ b/python/openassetio/constants.py
@@ -65,6 +65,10 @@ kWantsThumbnail = 16
 ## @}
 
 
+## The maximum integer value of a valid management policy bitfield
+kMaxManagementPolicyValue = 31
+
+
 ## @name Field Names
 ## Field names are to be used whenever data is get or set from a dictionary by
 ## key, rather than through an accessor in some wrapper class (eg:

--- a/python/openassetio/test/manager/apiComplianceSuite.py
+++ b/python/openassetio/test/manager/apiComplianceSuite.py
@@ -34,6 +34,7 @@ handled through additional suites local to the manager's implementation.
 # pylint: disable=invalid-name, missing-function-docstring
 
 from .harness import FixtureAugmentedTestCase
+from ... import constants
 from ...specifications import EntitySpecification
 
 
@@ -128,4 +129,7 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
         policies = self._manager.managementPolicy(specs, context)
 
         self.assertValuesOfType(policies, int)
+        for policy in policies:
+            self.assertGreaterEqual(policy, 0)
+            self.assertLessEqual(policy, constants.kMaxManagementPolicyValue)
         self.assertEqual(len(policies), numSpecifications)


### PR DESCRIPTION
Closes #236 - we weren't being strict enough when just checking its type.