### PR TITLE
[API] Rename logging module to log

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -23,7 +23,7 @@
  * openassetio.hostAPI.HostInterface "HostInterface" implementation.
  *
  * @code{.py}
- * from openassetio.logging import ConsoleLogger, SeverityFilter
+ * from openassetio.log import ConsoleLogger, SeverityFilter
  * from openassetio.hostAPI import HostInterface, Manager, Session
  * from openassetio.pluginSystem import PluginSystemManagerFactory
  *

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -84,10 +84,10 @@
  *    - An instance of the custom class derived from
  *      @ref openassetio.hostAPI.HostInterface "HostInterface".
  *    - A `logger` (derived from
- *      @ref openassetio.logging.LoggerInterface "LoggerInterface"), for
+ *      @ref openassetio.log.LoggerInterface "LoggerInterface"), for
  *      simple console logging you can use a
- *      @ref openassetio.logging.ConsoleLogger "ConsoleLogger" wrapped
- *      in a @ref openassetio.logging.SeverityFilter "SeverityFilter".
+ *      @ref openassetio.log.ConsoleLogger "ConsoleLogger" wrapped
+ *      in a @ref openassetio.log.SeverityFilter "SeverityFilter".
  *    - A `managerFactory` capable of instantiating managers,
  *      in the majority of cases a default-configured @ref
  *      openassetio.pluginSystem.PluginSystemManagerFactory

--- a/python/openassetio/_core/debug.py
+++ b/python/openassetio/_core/debug.py
@@ -24,7 +24,7 @@ kDebug and kDebugAPI logging severity displays
 
 In order to use these decorators the target class must derive from
 Debuggable, and have its `_debugLogFn` set to an callable that matches
-the @ref openassetio.logging.LoggerInterface.log signature. This
+the @ref openassetio.log.LoggerInterface.log signature. This
 callback will be used to output debug information. If no callback is
 set, no debug output will be produced.
 
@@ -43,7 +43,7 @@ import functools
 import os
 import time
 
-from ..logging import LoggerInterface
+from ..log import LoggerInterface
 
 
 __all__ = ['debugCall', 'debugApiCall', 'Debuggable']
@@ -60,7 +60,7 @@ class Debuggable:
 
     ## If enabled, decorated calls on the object will be logged
     _debugCalls = True
-    ## Set to a callable that matches @ref openassetio.logging.LoggerInterface.log
+    ## Set to a callable that matches @ref openassetio.log.LoggerInterface.log
     _debugLogFn = None
 
 

--- a/python/openassetio/constants.py
+++ b/python/openassetio/constants.py
@@ -18,7 +18,7 @@
 Constants used throughout the OpenAssetIO API.
 
 @todo [tc] Should these live here, or with their owning declarations,
-See @ref openassetio.logging.LoggerInterface for example.
+See @ref openassetio.log.LoggerInterface for example.
 """
 
 

--- a/python/openassetio/hostAPI/Session.py
+++ b/python/openassetio/hostAPI/Session.py
@@ -66,11 +66,11 @@ class Session(Debuggable):
         HostInterface is supported, so if multiple sessions are created,
         they should all use the same HostInterface instance).
 
-        @param logger openassetio.logging.LoggerInterface The target for
+        @param logger openassetio.log.LoggerInterface The target for
         all logging output from the session API-level or Manager level
         messages will all be routed through this object. No severity
         filtering is performed. Hosts wishing to filter the messages can
-        use the @ref openassetio.logging.SeverityFilter wrapper if
+        use the @ref openassetio.log.SeverityFilter wrapper if
         desired.
 
         @param managerFactory
@@ -80,7 +80,7 @@ class Session(Debuggable):
 
           @see @ref useManager
           @see @ref currentManager
-          @see @ref openassetio.logging "logging"
+          @see @ref openassetio.log "log"
           @see @ref openassetio.hostAPI.ManagerFactoryInterface
           "ManagerFactoryInterface"
           @see @ref openassetio.pluginSystem.PluginSystemManagerFactory

--- a/python/openassetio/log.py
+++ b/python/openassetio/log.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 """
-@namespace openassetio.logging
+@namespace openassetio.log
 Provides the core classes that facilitate message and progress logging.
 """
 
@@ -57,7 +57,7 @@ class LoggerInterface(object, metaclass=abc.ABCMeta):
         @param message str, The message string to be logged.
 
         @param severity int, One of the severity constants defined in
-        @ref openassetio.logging
+        @ref openassetio.log
         """
         raise NotImplementedError
 

--- a/python/openassetio/managerAPI/HostSession.py
+++ b/python/openassetio/managerAPI/HostSession.py
@@ -18,7 +18,7 @@
 A single-class module, providing the HostSession class.
 """
 
-from ..logging import LoggerInterface
+from ..log import LoggerInterface
 
 
 class HostSession(object):
@@ -76,7 +76,7 @@ class HostSession(object):
         It will be mapped to the correct host sub-systems to ensure that
         it is presented correctly.
 
-        @see @ref openassetio.logging "logging"
+        @see @ref openassetio.log "log"
         """
         self.__logger.log(message, severity)
 

--- a/python/openassetio/test/manager/_implementation.py
+++ b/python/openassetio/test/manager/_implementation.py
@@ -20,7 +20,7 @@ Private implementation classes for the manager test framework.
 """
 import unittest
 
-from openassetio import hostAPI, pluginSystem, logging
+from openassetio import hostAPI, log, pluginSystem
 
 from .specifications import ManagerTestHarnessLocale
 
@@ -34,7 +34,7 @@ def createHarness(managerIdentifier):
     @private
     """
     hostInterface = _ValidatorHarnessHostInterface()
-    logger = logging.SeverityFilter(logging.ConsoleLogger())
+    logger = log.SeverityFilter(log.ConsoleLogger())
     managerFactory = pluginSystem.PluginSystemManagerFactory(logger)
 
     session = hostAPI.Session(hostInterface, logger, managerFactory)

--- a/tests/openassetio/hostAPI/test_session.py
+++ b/tests/openassetio/hostAPI/test_session.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 import pytest
 
-from openassetio import constants, exceptions, logging, Context
+from openassetio import constants, exceptions, log, Context
 from openassetio.specifications import LocaleSpecification
 from openassetio.hostAPI import Session, HostInterface, Manager, ManagerFactoryInterface
 from openassetio.managerAPI import Host, ManagerInterface
@@ -50,7 +50,7 @@ def mock_manager_factory(mock_manager_interface):
 
 @pytest.fixture
 def mock_logger():
-    return mock.create_autospec(spec=logging.LoggerInterface)
+    return mock.create_autospec(spec=log.LoggerInterface)
 
 
 @pytest.fixture

--- a/tests/openassetio/managerAPI/test_hostsession.py
+++ b/tests/openassetio/managerAPI/test_hostsession.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 import pytest
 
-from openassetio import logging
+from openassetio import log
 from openassetio.managerAPI import Host, HostSession
 
 
@@ -36,7 +36,7 @@ def mock_host():
 
 @pytest.fixture
 def mock_logger():
-    return mock.create_autospec(spec=logging.LoggerInterface)
+    return mock.create_autospec(spec=log.LoggerInterface)
 
 
 @pytest.fixture
@@ -53,7 +53,7 @@ class TestHostSession():
         mock_logger.reset_mock()
 
         a_message = "A message"
-        a_severity = logging.LoggerInterface.kCritical
+        a_severity = log.LoggerInterface.kCritical
 
         host_session.log(a_message, a_severity)
         mock_logger.log.assert_called_once_with(a_message, a_severity)

--- a/tests/openassetio/pluginSystem/test_pluginsystem.py
+++ b/tests/openassetio/pluginSystem/test_pluginsystem.py
@@ -25,7 +25,7 @@ import os
 
 import pytest
 
-from openassetio.logging import ConsoleLogger
+from openassetio.log import ConsoleLogger
 from openassetio.pluginSystem import PluginSystem
 
 

--- a/tests/openassetio/pluginSystem/test_pluginsystemmanagerfactory.py
+++ b/tests/openassetio/pluginSystem/test_pluginsystemmanagerfactory.py
@@ -28,7 +28,7 @@ from unittest import mock
 
 import pytest
 
-from openassetio.logging import LoggerInterface
+from openassetio.log import LoggerInterface
 from openassetio.pluginSystem import PluginSystemManagerFactory
 
 #

--- a/tests/openassetio/test/manager/conftest.py
+++ b/tests/openassetio/test/manager/conftest.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 import pytest
 
-from openassetio import hostAPI, logging
+from openassetio import hostAPI, log
 from openassetio.specifications import LocaleSpecification
 
 
@@ -68,7 +68,7 @@ def mock_manager():
 
 @pytest.fixture
 def mock_logger():
-    return mock.create_autospec(logging.LoggerInterface, instance=True, spec_set=False)
+    return mock.create_autospec(log.LoggerInterface, instance=True, spec_set=False)
 
 
 @pytest.fixture

--- a/tests/openassetio/test_imports.py
+++ b/tests/openassetio/test_imports.py
@@ -50,8 +50,8 @@ class Test_package_imports:
     def test_importing_exceptions_succeeds(self):
         from openassetio import exceptions
 
-    def test_importing_logging_succeeds(self):
-        from openassetio import logging
+    def test_importing_log_succeeds(self):
+        from openassetio import log
 
     def test_importing_Specification_succeeds(self):
         from openassetio import Specification

--- a/tests/openassetio/test_log.py
+++ b/tests/openassetio/test_log.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 """
-Tests that cover the openassetio.logging module.
+Tests that cover the openassetio.log module.
 """
 
 # pylint: disable=no-self-use
@@ -25,7 +25,7 @@ from unittest import mock
 
 import pytest
 
-import openassetio.logging as lg
+import openassetio.log as lg
 
 
 # The logging mechanism is very much in flux right now, as we move away from


### PR DESCRIPTION
Rename the module from logging to log and fix all references in tests and documentation.

Closes #58 