### PR TITLE
[Core] Add specification/trait C++ implementation

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -787,7 +787,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ../python \
-                         ./src
+                         ./src \
+                         ../src/openassetio-core/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -2045,7 +2046,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2053,7 +2054,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2085,7 +2086,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = OPENASSETIO_VERSION=v0_0
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/python/openassetio/__init__.py
+++ b/python/openassetio/__init__.py
@@ -70,7 +70,8 @@ API documentation
 The documentation for OpenAssetIO can be found here:
    https://thefoundryvisionmongers.github.io/OpenAssetIO.
 """
-
+# TODO(DF): @pylint - re-enable once Python dev vs. install mess sorted.
+from ._openassetio import *  # pylint: disable=import-error
 from .Context import Context
 from .Specification import Specification
 from .SpecificationFactory import SpecificationFactory

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -47,9 +47,13 @@ endif()
 # Target dependencies
 
 # Source file dependencies.
-target_sources(openassetio-core
+target_sources(
+    openassetio-core
     PRIVATE
-    managerAPI/ManagerInterface.cpp)
+    managerAPI/ManagerInterface.cpp
+    specification/Specification.cpp
+    trait/BlobTrait.cpp
+)
 
 # Public header dependency.
 target_include_directories(openassetio-core

--- a/src/openassetio-core/include/openassetio/specification/Specification.hpp
+++ b/src/openassetio-core/include/openassetio/specification/Specification.hpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+/**
+ * Provide the base dynamic specification class.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <openassetio/export.h>
+
+#include "../trait/property.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+/**
+ * Comprises the base Specification class and concrete classes of core
+ * specifications derived from it.
+ */
+namespace specification {
+
+/**
+ * Structure for data exchange between a @ref host and a @ref
+ * manager.
+ *
+ * A specification is logically a set of supported @needsref trait
+ * "traits", each identified by a unique string, plus optional
+ * key-value properties associated with each of those traits.
+ *
+ * Trait @ref trait::property::Key "property keys" are always strings.
+ * Property values are strings, integers, floating point, or booleans.
+ * Any of a trait's properties can be legitimately left unset - it is up
+ * to the consumer (host or manager, depending on the API method) to
+ * decide how this should be handled.
+ *
+ * @todo Add SimpleMap trait property value type.
+ *
+ * @see trait::property
+ *
+ * Various API methods require a populated specification to be provided
+ * by the host, which the manager can interrogate in order to determine
+ * the correct response.
+ *
+ * Conversely, various API methods, in particular @needsref
+ * ManagerInterface::resolve, require the manager to return a
+ * populated specification to the host. The traits (and hence their
+ * properties) contained within the returned specification are
+ * determined by the intersection of the traits that were requested by
+ * the host and the traits that the manager supports.
+ *
+ * Since specifications are generic dictionary-like data structures,
+ * accurate data access/mutation relies on well-known trait IDs and
+ * property names. This introduces a possible avenue for user error due
+ * to misspelling, as well as difficulty in discovering what properties
+ * may be available for a given trait.
+ *
+ * Therefore, it is strongly advised that accessing and mutating trait
+ * properties is performed using trait view wrapper classes wherever
+ * possible, rather than directly using the accessor/mutator functions
+ * on the specification.
+ *
+ * @see trait::TraitBase
+ *
+ */
+class OPENASSETIO_CORE_EXPORT Specification {
+ public:
+  /// List of supported trait IDs.
+  using TraitIds = std::vector<trait::TraitId>;
+
+  /**
+   * Construct such that this specification supports the given list of
+   * trait IDs.
+   *
+   * @param traitIds List of IDs of traits that this specification
+   * supports.
+   */
+  explicit Specification(const TraitIds& traitIds);
+
+  /**
+   * Defaulted virtual destructor establishing this as a base class
+   * for more concrete specifications.
+   */
+  virtual ~Specification();
+
+  /**
+   * Return whether this specification supports the given trait.
+   *
+   * @param traitId ID of trait to check for support.
+   * @return `true` if trait is supported, `false` otherwise.
+   */
+  [[nodiscard]] bool hasTrait(const trait::TraitId& traitId) const;
+
+  /**
+   * Get the value of a given trait property, if the property has
+   * been set.
+   *
+   * @param[out] out Storage fo result, only written to if the property
+   * is set.
+   * @param traitId ID of trait to query.
+   * @param propertyKey Key of trait's property to query.
+   * @return `true` if value was found, `false` if it is unset.
+   * @exception `std::out_of_range` if the trait is not supported by
+   * this specification.
+   */
+  [[nodiscard]] bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
+                                      const trait::property::Key& propertyKey) const;
+
+  /**
+   * Set the value of given trait property.
+   *
+   * @param traitId ID of trait to update.
+   * @param propertyKey Key of property to set.
+   * @param propertyValue Value to set.
+   * @exception `std::out_of_range` if the trait is not supported by
+   * this specification.
+   */
+  void setTraitProperty(const trait::TraitId& traitId, const trait::property::Key& propertyKey,
+                        trait::property::Value propertyValue);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+}  // namespace specification
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/trait/BlobTrait.hpp
+++ b/src/openassetio-core/include/openassetio/trait/BlobTrait.hpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+/**
+ * Define the core `BlobTrait` trait class.
+ */
+#pragma once
+
+#include <openassetio/export.h>
+
+#include "TraitBase.hpp"
+
+#include "property.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+namespace trait {
+
+/**
+ * Core trait class representing a locatable blob of data of a specific
+ * type.
+ *
+ * Has the ID of "blob" and defines "url" and "mimeType" properties.
+ *
+ * This core trait defines one of the most common set of properties in
+ * the specification::Specification of an @ref entity - specifically, a
+ * URL and data (MIME) type.
+ *
+ * For example, the URL can be a local file system path (i.e.
+ * `file:///`). Thus the common workflow of @ref resolve "resolving" an
+ * @ref entity_reference to a file path is likely to involve the host
+ * requesting, and the manager returning, a @ref
+ * specification::Specification "Specification" supporting this
+ * `BlobTrait`.
+ *
+ * @see TraitBase
+ * @see specification::Specification
+ */
+struct OPENASSETIO_CORE_EXPORT BlobTrait : TraitBase<BlobTrait> {
+  /// ID of this trait.
+  static inline const TraitId kId{"blob"};
+
+  /// Hoist base class constructor.
+  using TraitBase<BlobTrait>::TraitBase;
+
+  /**
+   * Get the URL property for this trait from the wrapped specification.
+   *
+   * @param[out] out Storage for value, if property is set.
+   * @return `true` if property is set, `false` otherwise.
+   * @exception `std::out_of_range` if this trait is not supported by
+   * the wrapped specification.
+   */
+  [[nodiscard]] TraitPropertyStatus getUrl(property::Str* out) const;
+
+  /**
+   * Set the URL property for this trait in the wrapped specification.
+   *
+   * @param url URL value to set.
+   * @exception `std::out_of_range` if this trait is not supported by
+   * the wrapped specification.
+   */
+  void setUrl(property::Str url);
+
+  /**
+   * Get the mime type property for this trait from the wrapped
+   * specification.
+   *
+   * @param[out] out Storage for value, if property is set.
+   * @return `true` if property is set, `false` otherwise.
+   * @exception `std::out_of_range` if this trait is not supported by
+   * the wrapped specification.
+   */
+  [[nodiscard]] TraitPropertyStatus getMimeType(property::Str* out) const;
+
+  /**
+   * Set the mime type property for this trait in the wrapped
+   * specification.
+   *
+   * @param mimeType Mime type value to set.
+   * @exception `std::out_of_range` if this trait is not supported by
+   * the wrapped specification.
+   */
+  void setMimeType(property::Str mimeType);
+};
+}  // namespace trait
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
+++ b/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+/**
+ * Base class for all specification traits.
+ */
+#pragma once
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "../specification/Specification.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+namespace trait {
+
+/**
+ * Abstract CRTP base class for specification traits.
+ *
+ * A trait view provides a way to hide the underlying dictionary-like
+ * data access from hosts and managers. Trait view classes wrap a
+ * @ref specification::Specification "Specification" and provide member
+ * functions that query/mutate properties on the specification.
+ *
+ * @see BlobTrait
+ *
+ * This non-virtual templated base class provides the common interface
+ * for a concrete trait view.
+ *
+ * As an example, assume a trait view called `MyTrait` and an arbitrary
+ * specification. Before we can extract `MyTrait` property values from
+ * the specification we must check that it supports `MyTrait`. We can
+ * then use the trait's concrete accessors to retrieve data from the
+ * underlying dictionary-like specification. Usage may thus look
+ * something like
+ *
+ *     property::Int myValue = 123;  // Default if property not found.
+ *
+ *     MyTrait myTrait{specification};
+ *
+ *     if (myTrait.isValid()) {
+ *
+ *       if (myTrait.getMyValue(&myValue) != TraitPropertyStatus::kFound) {
+ *
+ *         std::cerr << "Warning: myValue not found\n";
+ *       }
+ *     }
+ *
+ * A trait class inheriting from this base must have a
+ * `static inline TraitId kId` member giving the unique string ID of
+ * that trait.
+ *
+ * @see TraitId
+ *
+ * @warning The `kId` member must be `inline` to support @ref
+ * specification::Specification "specifications" that statically
+ * construct their list of supported trait IDs. This is to avoid the
+ * so-called _Static Initialization Order Fiasco_, when a
+ * specification's static trait list is constructed using static trait
+ * IDs.
+ *
+ * In addition, the derived class should implement appropriate typed
+ * accessor / mutator methods that internally call the wrapped
+ * specification's @ref specification::Specification::getTraitProperty
+ * "getTraitProperty" / @ref
+ * specification::Specification::setTraitProperty "setTraitProperty".
+ *
+ * Such accessor/mutator functions then provide developers with
+ * compile-time checks and IDE code-completion, which would not be
+ * available with arbitrary string-based lookups.
+ *
+ * @note Attempting to access a trait's properties without first
+ * ensuring the specification supports that trait via `isValid`, or
+ * otherwise, may trigger a `std::out_of_range` exception if the trait
+ * is not supported by the specification.
+ *
+ * @tparam Derived Concrete subclass.
+ */
+template <class Derived>
+struct TraitBase {
+  /// Ref-counted smart pointer to underlying Specification.
+  using SpecificationPtr = std::shared_ptr<specification::Specification>;
+
+  /**
+   * Construct this trait view, wrapping the given specification.
+   *
+   * @param specification Underlying specification to wrap.
+   */
+  explicit TraitBase(SpecificationPtr specification) : specification_{std::move(specification)} {}
+
+  /**
+   * Check whether the specification this trait has been applied to
+   * actually supports this trait.
+   *
+   * @return `true` if the underlying specification supports this trait,
+   * `false` otherwise.
+   **/
+  [[nodiscard]] bool isValid() const { return specification_->hasTrait(Derived::kId); }
+
+ protected:
+  /**
+   * Get the underlying specification that this trait is wrapping.
+   *
+   * @return Wrapped Specification.
+   */
+  SpecificationPtr& specification() { return specification_; }
+
+  /**
+   * Get the underlying specification that this trait is wrapping.
+   *
+   * @return Wrapped Specification.
+   */
+  [[nodiscard]] const SpecificationPtr& specification() const { return specification_; }
+
+  /**
+   * Convenience typed accessor to properties in the underlying
+   * specification.
+   *
+   * @tparam T Type to extract from variant property.
+   * @param[out] out Storage for value, if property is set.
+   * @param traitId ID of trait to query.
+   * @param propertyKey Key of property to query.
+   * @return Status of property in the specification.
+   */
+  template <class T>
+  [[nodiscard]] TraitPropertyStatus getTraitProperty(T* out, const TraitId& traitId,
+                                                     const property::Key& propertyKey) const {
+    if (property::Value value; specification()->getTraitProperty(&value, traitId, propertyKey)) {
+      if (T* maybeOut = std::get_if<T>(&value)) {
+        *out = *maybeOut;
+        return TraitPropertyStatus::kFound;
+      }
+      return TraitPropertyStatus::kInvalidValue;
+    }
+    return TraitPropertyStatus::kMissing;
+  }
+
+ private:
+  SpecificationPtr specification_;
+};
+}  // namespace trait
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/trait/property.hpp
+++ b/src/openassetio-core/include/openassetio/trait/property.hpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+/**
+ * Typedefs for the trait property data stored within specifications.
+ */
+#pragma once
+
+#include <string>
+#include <variant>
+
+// API export header.
+#include <openassetio/export.h>
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+/**
+ * Comprises concrete trait views wrapping specification::Specification
+ * instances.
+ */
+namespace trait {
+
+/**
+ * Type aliases for @needsref trait properties within a @ref
+ * specification::Specification "Specification"
+ */
+namespace property {
+
+/// Boolean value type for specification property dictionaries.
+using Bool = bool;
+/// Integer value type for specification property dictionaries.
+using Int = int;
+/// Real value type for specification property dictionaries.
+using Float = double;
+/// String value type for specification property dictionaries.
+using Str = std::string;
+
+/**
+ * Property dictionary keys
+ *
+ * Keys must be UTF-8 compatible strings for required portability.
+ *
+ * Note that typically @ref TraitBase "trait views" will be used to
+ * access @ref specification::Specification "Specification" properties
+ * via concrete member functions, so it is highly desirable that keys
+ * are ASCII to maximise portability when mapping property keys to
+ * member function names.
+ */
+using Key = std::string;
+/// Property dictionary values.
+using Value = std::variant<Bool, Int, Float, Str>;
+}  // namespace property
+
+/**
+ * Trait unique ID type.
+ *
+ * IDs must be UTF-8 compatible strings for required portability.
+ *
+ * Note that typically @ref TraitBase "trait views" will be used to
+ * access @ref specification::Specification "Specification" properties
+ * rather than direct property access using a `TraitId`, so it is
+ * desirable that trait IDs are ASCII to maximise portability when
+ * mapping IDs to class names.
+ */
+using TraitId = property::Key;
+
+/// Status of a trait property within a specification.
+enum class TraitPropertyStatus { kFound, kMissing, kInvalidValue };
+}  // namespace trait
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/specification/Specification.cpp
+++ b/src/openassetio-core/specification/Specification.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+
+#include <openassetio/specification/Specification.hpp>
+#include <unordered_map>
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+namespace specification {
+
+class Specification::Impl {
+ public:
+  explicit Impl(const TraitIds& traitIds) {
+    // Initialise data dict with supported traits.
+    for (const auto& traitId : traitIds) {
+      data_[traitId];
+    }
+  }
+  ~Impl() = default;
+
+  bool hasTrait(const trait::TraitId& traitId) const {
+    return static_cast<bool>(data_.count(traitId));
+  }
+
+  bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
+                        const trait::property::Key& propertyKey) const {
+    // Use `at` deliberately to trigger exception if trait doesn't exist
+    const auto& traitDict = data_.at(traitId);
+
+    const auto& iter = traitDict.find(propertyKey);
+    if (iter == traitDict.end()) {
+      return false;
+    }
+    *out = iter->second;
+    return true;
+  }
+
+  void setTraitProperty(const trait::TraitId& traitId, const trait::property::Key& propertyKey,
+                        trait::property::Value propertyValue) {
+    // Use `at` deliberately to trigger exception if trait doesn't exist
+    data_.at(traitId)[propertyKey] = std::move(propertyValue);
+  }
+
+ private:
+  using Properties = std::unordered_map<trait::property::Key, trait::property::Value>;
+  using PropertiesByTrait = std::unordered_map<trait::TraitId, Properties>;
+  PropertiesByTrait data_;
+};
+
+Specification::Specification(const TraitIds& traitIds) : impl_{std::make_unique<Impl>(traitIds)} {}
+
+Specification::~Specification() = default;
+
+bool Specification::hasTrait(const trait::TraitId& traitId) const {
+  return impl_->hasTrait(traitId);
+}
+
+bool Specification::getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
+                                     const trait::property::Key& propertyKey) const {
+  return impl_->getTraitProperty(out, traitId, propertyKey);
+}
+
+void Specification::setTraitProperty(const trait::TraitId& traitId,
+                                     const trait::property::Key& propertyKey,
+                                     trait::property::Value propertyValue) {
+  impl_->setTraitProperty(traitId, propertyKey, std::move(propertyValue));
+}
+}  // namespace specification
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/trait/BlobTrait.cpp
+++ b/src/openassetio-core/trait/BlobTrait.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <utility>
+
+#include <openassetio/trait/BlobTrait.hpp>
+#include <openassetio/trait/property.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+namespace trait {
+
+namespace {
+/// Key for a URL property.
+const property::Key kUrl{"url"};
+/// Key for a mime type property.
+const property::Key kMimeType{"mimeType"};
+}  // namespace
+
+TraitPropertyStatus BlobTrait::getUrl(property::Str* out) const {
+  return getTraitProperty(out, kId, kUrl);
+}
+
+void BlobTrait::setUrl(property::Str url) {
+  specification()->setTraitProperty(kId, kUrl, std::move(url));
+}
+
+TraitPropertyStatus BlobTrait::getMimeType(property::Str* out) const {
+  return getTraitProperty(out, kId, kMimeType);
+}
+
+void BlobTrait::setMimeType(property::Str mimeType) {
+  specification()->setTraitProperty(kId, kMimeType, std::move(mimeType));
+}
+
+}  // namespace trait
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -29,7 +29,17 @@ endif()
 #-----------------------------------------------------------------------
 # Target dependencies
 
-target_sources(openassetio-python PRIVATE _openassetio.cpp)
+target_sources(
+    openassetio-python
+    PRIVATE
+    _openassetio.cpp
+    managerAPI/ManagerInterfaceBinding.cpp
+    specification/SpecificationBinding.cpp
+    trait/BlobTraitBinding.cpp
+)
+
+# Give access to private headers.
+target_include_directories(openassetio-python PRIVATE ../openassetio-core)
 
 target_link_libraries(openassetio-python
     PRIVATE

--- a/src/openassetio-python/_openassetio.cpp
+++ b/src/openassetio-python/_openassetio.cpp
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 
-#include <pybind11/pybind11.h>
+#include "_openassetio.hpp"
 
-#include <openassetio/managerAPI/ManagerInterface.hpp>
-
-PYBIND11_MODULE(_openassetio, m) {
-  using openassetio::managerAPI::ManagerInterface;
+PYBIND11_MODULE(_openassetio, mod) {
   namespace py = pybind11;
 
-  py::module managerAPI = m.def_submodule("managerAPI");
+  py::module managerAPI = mod.def_submodule("managerAPI");
 
-  py::class_<ManagerInterface>(managerAPI, "ManagerInterface").def(py::init());
+  registerManagerInterface(managerAPI);
+
+  py::module specification = mod.def_submodule("specification");
+
+  registerSpecification(specification);
+
+  py::module trait = mod.def_submodule("trait");
+
+  registerBlobTrait(trait);
 }

--- a/src/openassetio-python/_openassetio.hpp
+++ b/src/openassetio-python/_openassetio.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+/**
+ * Python binding bootstrap functions and typedefs.
+ */
+#pragma once
+
+#include <memory>
+
+#include <pybind11/pybind11.h>
+
+/// Concise pybind alias.
+namespace py = pybind11;
+
+/**
+ * Holder type for pybind-registered classes whose instances can exist
+ * simultaneously in C++ and Python.
+ *
+ * Ensuring all such types are constructed and held as a ref-counted
+ * smart pointer saves many object lifetime headaches.
+ */
+template <class T>
+using Holder = std::shared_ptr<T>;
+
+/// Register the ManagerInterface class with Python.
+void registerManagerInterface(const py::module& mod);
+
+/// Register the base specification class with Python.
+void registerSpecification(const py::module& mod);
+
+/// Register the BlobTrait class with Python.
+void registerBlobTrait(const py::module& mod);

--- a/src/openassetio-python/managerAPI/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/managerAPI/ManagerInterfaceBinding.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+
+#include <openassetio/managerAPI/ManagerInterface.hpp>
+
+#include "../_openassetio.hpp"
+
+void registerManagerInterface(const py::module& mod) {
+  using openassetio::managerAPI::ManagerInterface;
+
+  py::class_<ManagerInterface, Holder<ManagerInterface>>(mod, "ManagerInterface").def(py::init());
+}

--- a/src/openassetio-python/specification/SpecificationBinding.cpp
+++ b/src/openassetio-python/specification/SpecificationBinding.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <optional>
+
+#include <pybind11/stl.h>
+
+#include <openassetio/specification/Specification.hpp>
+
+#include "../_openassetio.hpp"
+
+void registerSpecification(const py::module& mod) {
+  using openassetio::specification::Specification;
+  namespace trait = openassetio::trait;
+  namespace property = openassetio::trait::property;
+  using MaybeValue = std::optional<property::Value>;
+
+  py::class_<Specification, Holder<Specification>>(mod, "Specification")
+      .def(py::init<const Specification::TraitIds&>(), py::arg("traitIds"))
+      .def("hasTrait", &Specification::hasTrait, py::arg("id"))
+      .def("setTraitProperty", &Specification::setTraitProperty, py::arg("id"),
+           py::arg("propertyKey"), py::arg("propertyValue").none(false))
+      .def(
+          "getTraitProperty",
+          [](const Specification& self, const trait::TraitId& traitId,
+             const property::Key& key) -> MaybeValue {
+            if (property::Value out; self.getTraitProperty(&out, traitId, key)) {
+              return out;
+            }
+            return {};
+          },
+          py::arg("id"), py::arg("key"));
+}

--- a/src/openassetio-python/trait/BlobTraitBinding.cpp
+++ b/src/openassetio-python/trait/BlobTraitBinding.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <optional>
+#include <type_traits>
+
+#include <pybind11/stl.h>
+
+// Public.
+#include <openassetio/export.h>
+#include <openassetio/trait/BlobTrait.hpp>
+// Private.
+#include "../_openassetio.hpp"
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+namespace trait {
+/**
+ * Utility function to convert a trait accessor result with error status
+ * to a std::optional or an exception.
+ *
+ * @tparam Ret Type of return value if everything is OK.
+ * @param traitId ID of trait to put in any exception message.
+ * @param propKey Name of property to put in any exception message.
+ * @param throwOnError If `true`, throw exceptions rather than returning
+ * an unset `optional`.
+ * @param status Property status.
+ * @param out Return value if status is OK.
+ * @return `out` if property is set, unset otherwise.
+ * @exception `pybind11::attribute_error` if `throwOnError=true` and the
+ * property is not set.
+ * @exception `pybind11::type_error` if `throwOnError=true` and the
+ * property contains the wrong type.
+ */
+template <class Ret>
+std::optional<std::decay_t<Ret>> maybeProperty(const bool throwOnError,
+                                               const TraitPropertyStatus status, Ret&& out) {
+  std::string err;
+  switch (status) {
+    case TraitPropertyStatus::kFound:
+      return {std::forward<Ret>(out)};
+
+    case TraitPropertyStatus::kMissing:
+      if (!throwOnError) {
+        return {};
+      }
+      throw py::attribute_error{"Property not set"};
+
+    case TraitPropertyStatus::kInvalidValue:
+      if (!throwOnError) {
+        return {};
+      }
+      throw py::type_error{"Property set to an unexpected value type"};
+  }
+  // Will (should!) never happen.
+  throw std::runtime_error{"Unknown trait property state"};
+}
+}  // namespace trait
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio
+
+void registerBlobTrait(const py::module& mod) {
+  using openassetio::trait::BlobTrait;
+  using openassetio::trait::maybeProperty;
+  namespace specification = openassetio::specification;
+  namespace trait = openassetio::trait;
+  namespace property = openassetio::trait::property;
+
+  py::class_<BlobTrait, Holder<BlobTrait>>(mod, "BlobTrait")
+      .def(py::init<Holder<specification::Specification>>(), py::arg("specification"))
+      .def_readonly_static("kId", &BlobTrait::kId)
+      .def("isValid", &BlobTrait::isValid)
+      .def(
+          "getUrl",
+          [](const BlobTrait& self, const bool raiseOnError) {
+            property::Str out;
+            trait::TraitPropertyStatus status = self.getUrl(&out);
+            return maybeProperty(raiseOnError, status, std::move(out));
+          },
+          py::arg("raiseOnError") = false)
+      .def("setUrl", &BlobTrait::setUrl, py::arg("url"))
+      .def(
+          "getMimeType",
+          [](const BlobTrait& self, const bool raiseOnError) {
+            property::Str out;
+            trait::TraitPropertyStatus status = self.getMimeType(&out);
+            return maybeProperty(raiseOnError, status, std::move(out));
+          },
+          py::arg("raiseOnError") = false)
+      .def("setMimeType", &BlobTrait::setMimeType, py::arg("mimeType"));
+}

--- a/tests/openassetio/test_traits.py
+++ b/tests/openassetio/test_traits.py
@@ -1,0 +1,190 @@
+"""
+Tests for the traits type system.
+"""
+# pylint: disable=invalid-name,missing-class-docstring
+# pylint: disable=redefined-outer-name,no-self-use
+# pylint: disable=missing-function-docstring
+import pytest
+# TODO(DF): @pylint - re-enable once Python dev vs. install mess sorted.
+# pylint: disable=no-name-in-module
+from openassetio import specification, trait
+
+
+class Test_Specification_hasTrait:
+    def test_when_has_trait_then_returns_true(self, a_specification):
+        assert a_specification.hasTrait("second_trait")
+
+    def test_when_not_has_trait_then_returns_false(self, a_specification):
+        assert not a_specification.hasTrait("unknown_trait")
+
+
+class Test_Specification_getsetTraitProperty:
+    def test_valid_values(self, a_specification):
+        a_specification.setTraitProperty("first_trait", "a string", "string")
+        a_specification.setTraitProperty("second_trait", "an int", 1)
+        a_specification.setTraitProperty("first_trait", "a float", 1.0)
+        a_specification.setTraitProperty("second_trait", "a bool", True)
+
+        assert a_specification.getTraitProperty("first_trait", "a string") == "string"
+        assert isinstance(a_specification.getTraitProperty("first_trait", "a string"), str)
+        assert a_specification.getTraitProperty("second_trait", "an int") == 1
+        assert isinstance(a_specification.getTraitProperty("second_trait", "an int"), int)
+        assert a_specification.getTraitProperty("first_trait", "a float") == 1.0
+        assert isinstance(a_specification.getTraitProperty("first_trait", "a float"), float)
+        assert a_specification.getTraitProperty("second_trait", "a bool") is True
+
+    def test_when_key_is_not_found_then_get_returns_None(self, a_specification):
+        assert a_specification.getTraitProperty("first_trait", "a string") is None
+
+    def test_when_trait_is_not_found_then_IndexError_raised(self, a_specification):
+        with pytest.raises(IndexError):
+            a_specification.setTraitProperty("unknown_trait", "a string", "string")
+
+        with pytest.raises(IndexError):
+            _ = a_specification.getTraitProperty("unknown_trait", "a string")
+
+    def test_when_value_is_not_supported_then_set_raises_TypeError(self, a_specification):
+        with pytest.raises(TypeError):
+            a_specification.setTraitProperty("first_trait", "unknown type", object())
+
+        with pytest.raises(TypeError):
+            a_specification.setTraitProperty("first_trait", "unknown type", None)
+
+
+def test_BlobTrait_traitId():
+    assert trait.BlobTrait.kId == "blob"
+
+
+class Test_BlobTrait_isValid:
+    def test_when_wrapping_BlobSpecification_then_returns_true(self, a_blob_specification):
+        assert trait.BlobTrait(a_blob_specification).isValid()
+
+    def test_when_wrapping_blob_supporting_spec_then_returns_true(self):
+        assert trait.BlobTrait(
+            specification.Specification([trait.BlobTrait.kId, "other"])).isValid()
+
+    def test_when_wrapping_non_blob_spec_then_returns_false(self, a_specification):
+        assert not trait.BlobTrait(a_specification).isValid()
+
+
+class Test_BlobTrait_getURL:
+    def test_when_spec_doesnt_have_blob_trait_then_raises_IndexError(self, a_specification):
+        with pytest.raises(IndexError):
+            trait.BlobTrait(a_specification).getUrl()
+
+    def test_when_spec_has_no_url_then_returns_None(self, a_blob_specification):
+        assert trait.BlobTrait(a_blob_specification).getUrl() is None
+
+    def test_when_url_in_spec_has_wrong_value_type_then_returns_None(self, a_blob_specification):
+        a_blob_specification.setTraitProperty(trait.BlobTrait.kId, "url", 123)
+
+        assert trait.BlobTrait(a_blob_specification).getUrl() is None
+
+    def test_when_raiseOnError_and_spec_has_no_url_then_raises_AttributeError(
+            self, a_blob_specification):
+        with pytest.raises(AttributeError) as err:
+            trait.BlobTrait(a_blob_specification).getUrl(raiseOnError=True)
+
+        assert str(err.value) == "Property not set"
+
+    def test_when_raiseOnError_and_url_in_spec_has_wrong_value_type_then_raises_TypeError(
+            self, a_blob_specification):
+        a_blob_specification.setTraitProperty(trait.BlobTrait.kId, "url", 123)
+
+        with pytest.raises(TypeError) as err:
+            trait.BlobTrait(a_blob_specification).getUrl(raiseOnError=True)
+
+        assert str(err.value) == "Property set to an unexpected value type"
+
+    def test_when_spec_has_url_then_returns_url(self, a_blob_specification):
+        expected = "some://url"
+        a_blob_specification.setTraitProperty(trait.BlobTrait.kId, "url", expected)
+
+        actual = trait.BlobTrait(a_blob_specification).getUrl()
+
+        assert actual == expected
+
+
+class Test_BlobTrait_setURL:
+    def test_when_spec_doesnt_have_blob_trait_then_raises_IndexError(self, a_specification):
+        with pytest.raises(IndexError):
+            trait.BlobTrait(a_specification).setUrl("some://url")
+
+    def test_when_url_is_wrong_type_then_TypeError_is_raised(self, a_blob_specification):
+        with pytest.raises(TypeError):
+            trait.BlobTrait(a_blob_specification).setUrl(123)
+
+    def test_when_url_is_a_str_then_url_is_added_to_spec(self, a_blob_specification):
+        expected = "some://url"
+
+        trait.BlobTrait(a_blob_specification).setUrl(expected)
+
+        assert a_blob_specification.getTraitProperty(trait.BlobTrait.kId, "url") == expected
+
+
+class Test_BlobTrait_getMimeType:
+    def test_when_spec_doesnt_have_blob_trait_then_raises_IndexError(self, a_specification):
+        with pytest.raises(IndexError):
+            trait.BlobTrait(a_specification).getMimeType()
+
+    def test_when_spec_has_no_mimeType_then_returns_None(self, a_blob_specification):
+        assert trait.BlobTrait(a_blob_specification).getMimeType() is None
+
+    def test_when_mimeType_in_spec_has_wrong_value_type_then_returns_None(
+            self, a_blob_specification):
+        a_blob_specification.setTraitProperty(trait.BlobTrait.kId, "mimeType", 123)
+
+        assert trait.BlobTrait(a_blob_specification).getMimeType() is None
+
+    def test_when_raiseOnError_and_spec_has_no_mimeType_then_raises_AttributeError(
+            self, a_blob_specification):
+        with pytest.raises(AttributeError) as err:
+            trait.BlobTrait(a_blob_specification).getMimeType(raiseOnError=True)
+
+        assert str(err.value) == "Property not set"
+
+    def test_when_raiseOnError_and_mimeType_in_spec_has_wrong_value_type_then_raises_TypeError(
+            self, a_blob_specification):
+        a_blob_specification.setTraitProperty(trait.BlobTrait.kId, "mimeType", 123)
+
+        with pytest.raises(TypeError) as err:
+            trait.BlobTrait(a_blob_specification).getMimeType(raiseOnError=True)
+
+        assert str(err.value) == "Property set to an unexpected value type"
+
+    def test_when_data_has_mimeType_then_returns_mimeType(self, a_blob_specification):
+        expected = "some://url"
+        a_blob_specification.setTraitProperty(trait.BlobTrait.kId, "mimeType", expected)
+
+        actual = trait.BlobTrait(a_blob_specification).getMimeType()
+
+        assert actual == expected
+
+
+class Test_BlobTrait_setMimeType:
+    def test_when_spec_doesnt_have_blob_trait_then_raises_IndexError(self, a_specification):
+        with pytest.raises(IndexError):
+            trait.BlobTrait(a_specification).setMimeType("application/x-something")
+
+    def test_when_mimeType_is_a_str_then_mimeType_is_added_to_spec(
+            self, a_blob_specification):
+        expected = "application/x-something"
+
+        trait.BlobTrait(a_blob_specification).setMimeType(expected)
+
+        assert a_blob_specification.getTraitProperty(
+            trait.BlobTrait.kId, "mimeType") == expected
+
+    def test_when_mimeType_is_wrong_type_then_TypeError_is_raised(self, a_blob_specification):
+        with pytest.raises(TypeError):
+            trait.BlobTrait(a_blob_specification).setMimeType(123)
+
+
+@pytest.fixture
+def a_specification():
+    return specification.Specification(["first_trait", "second_trait"])
+
+
+@pytest.fixture
+def a_blob_specification():
+    return specification.Specification([trait.BlobTrait.kId])


### PR DESCRIPTION
For #250 we require the C++ infrastructure to support specifications following the new design of #238 et al. 

This PR introduces an initial draft of specifications as dictionary-like data structures and traits as views on a specification, coded in C++ with Python bindings, and tested exclusively through the Python bindings.

Initial performance tests using #270 and reported in #253 lead us to believe the performance of this dictionary-like design is unlikely to be a serious bottleneck.

The Doxygen config is updated to render docs for the new C++ classes.