### PR TITLE
[Core] Remove the host document API

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -29,7 +29,7 @@
  *
  * class ExampleHost(HostInterface):
  *     """
- *     A minimal host implementation with no document model.
+ *     A minimal host implementation.
  *     """
  *     @staticmethod
  *     def identifier():

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -22,9 +22,7 @@
  *   implementation of the @ref HostInterface class. This represents the
  *   application or tool in a generic fashion <i>to</i> the asset
  *   management system. This allows the manager to adapt its behavior
- *   if necessary, or query information about entity usage within the
- *   host's data model (if applicable) without needing to use a
- *   proprietary API.
+ *   if necessary.
  *
  * - The specific implementation of the @ref HostInterface class
  *   provided by a host when starting a @ref session is wrapped in the
@@ -160,9 +158,6 @@
  *
  * - Derive @ref openassetio.specifications "Specifications" for any
  *   custom 'asset types' you may deal with.
- *
- * - If you have a document model, implement the entity query methods
- *   in your @ref openassetio.hostAPI.HostInterface class.
  *
  * - You should map any widgets returned by @needsref ManagerUIDelegate.widgets
  *   with the @needsref ui.widgets.attributes.kCreateApplicationPanel flag set to

--- a/python/openassetio/hostAPI/HostInterface.py
+++ b/python/openassetio/hostAPI/HostInterface.py
@@ -31,8 +31,10 @@ class HostInterface(object):
     a simple pipeline tool, or a full content creation application.
 
     The HostInterface provides a generic mechanism for a @ref manager to
-    query information about the identity of the host, its available
-    documents and the @ref entity "entities" they may reference.
+    query information about the identity of the host. In future, this
+    interface may be extended to include the ability to retrieve
+    information about available documents and their known entity
+    references.
 
     In order for a host to use the API, it must provide an
     implementation of the HostInterface to the @ref
@@ -94,64 +96,5 @@ class HostInterface(object):
         @todo Definitions for well-known keys such as 'version' etc.
         """
         return {}
-
-    ## @}
-
-    def documentReference(self):
-        """
-        Returns the path, or @ref entity_reference of the current
-        document, or an empty string if not applicable. If a Host
-        supports multiple concurrent documents, it should be the
-        'front-most' one. If there is no meaningful document reference,
-        then an empty string should be returned.
-
-        @todo Update to properly support multiple documents
-        @return str A path or @ref entity_reference.
-        """
-        return ''
-
-    ##
-    # @name Entity Reference retrieval
-    #
-    ## @{
-
-    def knownEntityReferences(self, specification=None):
-        """
-        Returns an @ref entity_reference for each Entities known to the
-        host that are used in the current document, or an empty list if
-        none are known.
-
-        @param specification openassetio.Specification [None] If
-        supplied, then only entities of the supplied specification
-        should be returned.
-
-        @return List[@ref entity_reference] References discovered in the
-        current document.
-
-        @todo Update to support multiple documents
-        """
-        return []
-
-    def entityReferenceForItem(self, item, allowRelated=False):
-        """
-        This should be capable of taking any item that may be set in a
-        locale/etc... or a Host-native API object and returning an @ref
-        entity_reference for it, if applicable.
-
-        @param item object, a Host-native SDK object.
-
-        @param allowRelated bool, If True, the Host can return a
-        reference for some parent or child or relation of the supplied
-        item, if applicable. This can be useful for broadening the area
-        of search in less specific cases.
-
-        @return str, An @ref entity_reference of an empty string if no
-        applicable Entity Reference could be determined for the supplied
-        item.
-
-        @todo Evaluate whether this method makes sense and is properly
-        implementable through Python/C++.
-        """
-        return ''
 
     ## @}

--- a/python/openassetio/managerAPI/Host.py
+++ b/python/openassetio/managerAPI/Host.py
@@ -32,8 +32,9 @@ class Host(Debuggable):
     within a @ref manager.
 
     The Host provides a generalised API to query the identity of the
-    caller of the API, as well as which entities are used within the
-    current document.
+    caller of the API. In the future, this interface may be extended to
+    allow retrieval of information about available documents as well as
+    which entities are used within these documents.
 
     Hosts should never be directly constructed by the Manager's
     implementation. Instead, the @ref HostSession class provided to all
@@ -108,40 +109,5 @@ class Host(Debuggable):
         @return Dict[str, pod]
         """
         return self.__impl.info()
-
-    ## @}
-
-    @debugApiCall
-    @auditApiCall("Host methods")
-    def documentReference(self):
-        """
-        The path, or @ref entity_reference of the current document, or
-        an empty string if not applicable. If a Host supports multiple
-        concurrent documents, it will be the 'frontmost' one. If there
-        is no meaningful document reference, then an empty string will
-        be returned.
-
-        @return str
-        """
-        return self.__impl.documentReference()
-
-    ##
-    # @name Entity Reference retrieval
-    #
-    ## @{
-
-    @debugApiCall
-    @auditApiCall("Host methods")
-    def knownEntityReferences(self, specification=None):
-        """
-        @return list, An @ref entity_reference for each Entities known
-        by the host to be used in the current document, or an empty list
-        if none are known.
-
-        @param specification openassetio.Specification [None] If
-        supplied, then only entities of the supplied specification will
-        be returned.
-        """
-        return self.__impl.knownEntityReferences(specification=specification)
 
     ## @}

--- a/tests/openassetio/managerAPI/test_host.py
+++ b/tests/openassetio/managerAPI/test_host.py
@@ -75,13 +75,3 @@ class TestHost():
         method = mock_host_interface.info
         assert host.info() == method.return_value
         method.assert_called_once_with()
-
-    def test_documentReference(self, host, mock_host_interface):
-        method = mock_host_interface.documentReference
-        assert host.documentReference() == method.return_value
-        method.assert_called_once_with()
-
-    def test_knownEntityReferences(self, host, mock_host_interface, an_entity_spec):
-        method = mock_host_interface.knownEntityReferences
-        assert host.knownEntityReferences(an_entity_spec) == method.return_value
-        method.assert_called_once_with(specification=an_entity_spec)


### PR DESCRIPTION
We still fundamentally believe that the ability for a manager to query the current host for information about entity usage and its documents is critical. However, the current API was not well thought out (as it
assumed a 'current' document, which may be a little tenuous).

This PR closes #6 by removing the current API, so that we can add a more fit-for-purpose API in over time as we have more concrete use cases from manager authors.