### PR TITLE
[Core] Improve context thawing API

### DIFF
--- a/python/openassetio/hostAPI/transactions.py
+++ b/python/openassetio/hostAPI/transactions.py
@@ -19,6 +19,7 @@ This module provides convenience functionality for a @ref host to aid
 working managing transactions when interacting with a @ref manager.
 """
 
+from .. import Context
 from .._core.audit import auditApiCall
 from .._core.debug import debugApiCall, Debuggable
 
@@ -173,16 +174,15 @@ class TransactionCoordinator(Debuggable):
         return "%i_%s" % (context.actionGroupDepth, token)
 
     @auditApiCall("Transactions")
-    def thawManagerState(self, token, context):
+    def thawManagerState(self, token):
         """
-        Restores the @ref manager_state in the supplied Context so that
-        it represents the context as previously frozen.
+        Restores the @ref manager_state returning a Context that is
+        associated with the same state as the context that was
+        previously frozen using @ref freezeManagerState.
 
         @param token str The string returned by @ref freezeManagerState
 
-        @param context Context The context to restore the state into.
-
-        @note It is perfectly legal to thaw the same context multiple
+        @note It is perfectly legal to thaw the same token multiple
         times in parallel, as long as the ActionGroup depth is not
         changed - ie: push/pop/cancelActionGroup should not be called.
         This is because it quickly creates an incoherent state for the
@@ -196,9 +196,11 @@ class TransactionCoordinator(Debuggable):
         """
         ## @todo Sanitize input
         depth, managerToken = token.split('_', 1)
+
+        context = Context()
         context.actionGroupDepth = int(depth)
-        state = self.__manager._thawState(managerToken)  # pylint: disable=protected-access
-        context.managerInterfaceState = state
+        context.managerInterfaceState = self.__manager._thawState(managerToken)  # pylint: disable=protected-access
+        return context
 
     ## @}
 

--- a/tests/openassetio/hostAPI/test_transactions.py
+++ b/tests/openassetio/hostAPI/test_transactions.py
@@ -270,17 +270,14 @@ class Test_TransactionCoordinator_freeze_thaw:
 
         # Clear context (this isn't done by freeze)
 
-        a_context.managerInterfaceState = None
-        a_context.actionGroupDepth = 0
-
         mock_manager.thawState.assert_not_called()
 
         # Thaw
 
-        transaction_coordinator.thawManagerState(token, a_context)
+        thawed_context = transaction_coordinator.thawManagerState(token)
         mock_manager.thawState.assert_called_once_with(mock_frozen_state, mock_host_session)
-        assert a_context.managerInterfaceState == state
-        assert a_context.actionGroupDepth == action_group_depth
+        assert thawed_context.managerInterfaceState == state
+        assert thawed_context.actionGroupDepth == action_group_depth
 
 
 class Test_ScopedActionGroup:


### PR DESCRIPTION
Changes TransactionCoordinator.thawManagerState to be the reverse of freezeManagerState.

The main motivation is to remove a redundant state creation when the host creates a context, then immediately thaws a serialized state back into it, overwriting the one just made by the manager.

This also makes the API more consistent with the actual behaviour, in terms of "context lifetime associates API calls".

Closes #79.
