### PR TITLE
[Core] Rename `Manager.entityVersionName`

### DIFF
--- a/contributing/CODING_STANDARDS.md
+++ b/contributing/CODING_STANDARDS.md
@@ -55,7 +55,7 @@ class name should include the method under test preceded by its class,
 separated by an underscore. For example,
 
 ```python
-class Test_ManagerInterface_entityVersionName:
+class Test_ManagerInterface_entityVersion:
     ...
 ```
 

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -679,10 +679,10 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def entityVersionName(self, entityRefs, context):
+    def entityVersion(self, entityRefs, context):
         """
-        Retrieves the name of the version pointed to by each supplied
-        @ref entity_reference.
+        Retrieves the identifier of the version pointed to by each
+        supplied @ref entity_reference.
 
         @param entityRefs `List[str]` Entity references to query.
 
@@ -690,6 +690,7 @@ class Manager(Debuggable):
 
         @return `List[str]` A string for each entity representing its
         version, or an empty string if the entity was not versioned.
+        This identifier will be one of the keys of @ref entityVersions.
 
         @note It is not necessarily a requirement that the entity
         exists, if, for example, the version name can be determined from
@@ -698,7 +699,7 @@ class Manager(Debuggable):
         @see @ref entityVersions
         @see @ref finalizedEntityVersion
         """
-        return self.__impl.entityVersionName(entityRefs, context, self.__hostSession)
+        return self.__impl.entityVersion(entityRefs, context, self.__hostSession)
 
     @debugApiCall
     @auditApiCall("Manager methods")
@@ -722,13 +723,14 @@ class Manager(Debuggable):
         value of -1 is used, then all results will be returned.
 
         @return `List[Dict[str, str]]` A dictionary for each entity,
-        where the keys are string versions, and the values are an
-        @ref entity_reference that points to its entity. Additionally
-        the openassetio.constants.kVersionDict_OrderKey can be set to
-        a list of the version names (ie: dict keys) in their natural
-        ascending order, that may be used by UI elements, etc.
+        where the keys are string version identifiers (as returned by
+        @ref entityVersion), and the values are an @ref entity_reference
+        that points to its entity. Additionally the
+        openassetio.constants.kVersionDict_OrderKey can be set to a list
+        of the version names (ie: dict keys) in their natural ascending
+        order, that may be used by UI elements, etc.
 
-        @see @ref entityVersionName
+        @see @ref entityVersion
         @see @ref finalizedEntityVersion
         """
         return self.__impl.entityVersions(
@@ -771,7 +773,7 @@ class Manager(Debuggable):
         returned. It may be that it makes sense in the specific asset
         manager to fall back on 'latest' in this case.
 
-        @see @ref entityVersionName
+        @see @ref entityVersion
         @see @ref entityVersions
         """
         return self.__impl.finalizedEntityVersion(

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -840,10 +840,10 @@ class ManagerInterface(object):
     #
     # @{
 
-    def entityVersionName(self, entityRefs, context, hostSession):
+    def entityVersion(self, entityRefs, context, hostSession):
         """
-        Retrieves the name of the version pointed to by each supplied
-        @ref entity_reference.
+        Retrieves the identifier of the version pointed to by each
+        supplied @ref entity_reference.
 
         @param entityRefs `List[str]` Entity references to query.
 
@@ -851,8 +851,10 @@ class ManagerInterface(object):
 
         @param hostSession HostSession The API session.
 
-        @return `List[str]` A string for each entity representing its
-        version, or an empty string if the entity was not versioned.
+        @return `List[str]` A string identifier for each entity
+        representing its version, or an empty string  if the entity was
+        not versioned. This identifier should be one of the keys in
+        @ref entityVersions.
 
         @note It is not necessarily a requirement that the entity
         exists, if, for example, the version name can be determined from
@@ -890,13 +892,14 @@ class ManagerInterface(object):
         value of -1 is used, then all results should be returned.
 
         @return `List[Dict[str, str]]` A dictionary for each entity,
-        where the keys are string versions, and the values are an
-        @ref entity_reference that points to its entity. Additionally
-        the openassetio.constants.kVersionDict_OrderKey can be set to
-        a list of the version names (ie: dict keys) in their natural
-        ascending order, that may be used by UI elements, etc.
+        where the keys are string version identifiers (as returned by
+        @ref entityVersion), and the values are an @ref entity_reference
+        that points to its entity. Additionally the
+        openassetio.constants.kVersionDict_OrderKey can be set to a list
+        of the version names (ie: dict keys) in their natural ascending
+        order, that may be used by UI elements, etc.
 
-        @see @ref entityVersionName
+        @see @ref entityVersion
         @see @ref finalizedEntityVersion
         """
         return [{} for _ in entityRefs]
@@ -940,7 +943,7 @@ class ManagerInterface(object):
         returned. It may be that it makes sense in the specific asset
         manager to fall back on 'latest' in this case.
 
-        @see @ref entityVersionName
+        @see @ref entityVersion
         @see @ref entityVersions
         """
         return entityRefs

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -85,7 +85,7 @@ class ValidatingMockManagerInterface(ManagerInterface):
         self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
-    def entityVersionName(self, entityRefs, context, hostSession):
+    def entityVersion(self, entityRefs, context, hostSession):
         self.__assertIsIterableOf(entityRefs, str)
         self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
@@ -471,13 +471,13 @@ class Test_Manager_setEntityAttribute:
         method.assert_called_once_with(some_refs, a_key, a_value, a_context, host_session)
 
 
-class Test_Manager_entityVersionName:
+class Test_Manager_entityVersion:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.entityVersionName
-        assert manager.entityVersionName(some_refs, a_context) == method.return_value
+        method = mock_manager_interface.entityVersion
+        assert manager.entityVersion(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
 

--- a/tests/openassetio/managerAPI/test_managerinterface.py
+++ b/tests/openassetio/managerAPI/test_managerinterface.py
@@ -44,14 +44,14 @@ class Test_ManagerInterface_defaultEntityReference:
         assert refs == ["", "", ""]
 
 
-class Test_ManagerInterface_entityVersionName:
+class Test_ManagerInterface_entityVersion:
     def test_when_given_single_ref_then_returns_single_empty_name(self, manager_interface):
-        names = manager_interface.entityVersionName([Mock()], Mock(), Mock())
+        names = manager_interface.entityVersion([Mock()], Mock(), Mock())
         assert names == [""]
 
     def test_when_given_multiple_refs_then_returns_corresponding_number_of_empty_names(
             self, manager_interface):
-        names = manager_interface.entityVersionName([Mock(), Mock(), Mock()], Mock(), Mock())
+        names = manager_interface.entityVersion([Mock(), Mock(), Mock()], Mock(), Mock())
         assert names == ["", "", ""]
 
 


### PR DESCRIPTION
This hopefully reduces the ambiguity where this method could be considered to be in the same area as the `displayName` methods, and ties it more closely with its counterpart - `entityVersions`.

Closes https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/118.