### PR TITLE
[CI] Pin versions for dco check actions

### DIFF
--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
     - name: Get PR Commits
       id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
+      uses: tim-actions/get-pr-commits@v1.2.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: DCO Check
-      uses: tim-actions/dco@master
+      uses: tim-actions/dco@v1.1.0
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
Helps mildly protect against supply chain attacks or unexpected behavioural changes. Spotted by @feltech when copying the actions from this repo to `otio-openassetio` [here](https://github.com/TheFoundryVisionmongers/otio-openassetio/pull/2).