### PR TITLE
[Lint] clang-format preserve #include groups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,4 @@ BasedOnStyle: Google
 Language: Cpp
 Standard: c++17
 ColumnLimit: 99
+IncludeBlocks: Preserve


### PR DESCRIPTION
`clang-format` can group includes in such a way that `cpplint` complains. So disable re-grouping of includes (but still sort includes within groups).

For example, given
```
#include <iostream>
#include <cassert>

#include <pybind11/pybind11.h>

#include <openassetio/managerAPI/ManagerInterface.hpp>
```
before this PR running `clang-format` would produce
```
#include <pybind11/pybind11.h>

#include <cassert>
#include <iostream>
#include <openassetio/managerAPI/ManagerInterface.hpp>
```
which `cpplint` would complain with an error like
```
Found C++ system header after other system header. Should be: _openassetio.h, c system, c++ system, other.  [build/include_order] [4]
```
After this PR the result it
```
#include <cassert>
#include <iostream>

#include <pybind11/pybind11.h>

#include <openassetio/managerAPI/ManagerInterface.hpp>
```
Note that the first two includes have been sorted, but the grouping of includes are left untouched.