### PR TITLE
[Core] Bump pybind11 version to 2.8.1

### DIFF
--- a/resources/build/conanfile.txt
+++ b/resources/build/conanfile.txt
@@ -1,6 +1,8 @@
 [requires]
+# CY2022
 cpython/3.9.7
-pybind11/2.6.1
+# Same as ASWF CY2022 Docker image: https://github.com/AcademySoftwareFoundation/aswf-docker/blob/master/ci-base/README.md
+pybind11/2.8.1
 
 [generators]
 # Generate a CMake toolchain preamble file `conan_paths.cmake`, which


### PR DESCRIPTION
Use the same version as is baked into the CY2022 AWSF Docker image.

See: https://github.com/AcademySoftwareFoundation/aswf-docker/tree/master/ci-base

Amongst other advantages, this version adds a handy `pybind11::attribute_error` exception that can be thrown from C++, appearing in Python as `AttributeError`.

The initial motivation for this PR was to allow use of `attribute_error` in #255, but aligning with ASWF is a compelling reason in its own right.

