### PR TITLE
[Build] Fix `ctest` invocation of `pytest`

### DIFF
--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -151,8 +151,8 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
     # for debugging regardless).
     add_custom_target(
         openassetio-python-pytest
-        COMMAND ${pytest_env} "${venv_python_dir}/pytest" -s
-        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/tests"
+        COMMAND ${pytest_env} "${venv_python_dir}/pytest" -s tests
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         DEPENDS "${venv_python_dir}/pytest"
         USES_TERMINAL
     )

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -151,7 +151,7 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
     # for debugging regardless).
     add_custom_target(
         openassetio-python-pytest
-        COMMAND ${pytest_env} "${venv_python_dir}/pytest" -s tests
+        COMMAND ${pytest_env} "${venv_python_dir}/pytest" -s tests resources
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         DEPENDS "${venv_python_dir}/pytest"
         USES_TERMINAL


### PR DESCRIPTION
Ensures that `pytest` is run from the project root, and includes the `resources` dir in checks so example code is covered.

Resolves one of two issues surfaced by #276.