### PR TITLE
[Tests] Ensures `test.manager` checks use correct interpreter

### DIFF
--- a/tests/openassetio/test/manager/test_main.py
+++ b/tests/openassetio/test/manager/test_main.py
@@ -61,10 +61,7 @@ class Test_CLI_output:
 class Test_CLI_arguments:
 
     def test_when_called_without_fixtures_arg_then_exits_with_usage_and_exit_code_is_two(self):
-        args = ["python", "-m", "openassetio.test.manager"]
-        # We explicitly don't want an exception to be raised.
-        # pylint: disable=subprocess-run-check
-        result = subprocess.run(args, capture_output=True)
+        result = execute_cli(None)
         assert result.returncode == 2
         assert "usage:" in str(result.stderr)
 
@@ -99,7 +96,8 @@ def execute_cli(fixtures_path, *extra_args):
     @return `subprocess.CompletedProcess` The results of the invocation.
     """
     all_args = ["python", "-m", "openassetio.test.manager"]
-    all_args.extend(["-f", fixtures_path])
+    if fixtures_path:
+        all_args.extend(["-f", fixtures_path])
     if extra_args:
         all_args.extend(extra_args)
     # We explicitly don't want an exception to be raised.

--- a/tests/openassetio/test/manager/test_main.py
+++ b/tests/openassetio/test/manager/test_main.py
@@ -23,6 +23,7 @@ Integration tests for CLI operation of the manager test harness.
 
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -95,7 +96,12 @@ def execute_cli(fixtures_path, *extra_args):
 
     @return `subprocess.CompletedProcess` The results of the invocation.
     """
-    all_args = ["python", "-m", "openassetio.test.manager"]
+    # We may well be running inside a venv interpreter, but without
+    # the venv being active in the current environment. The effect
+    # of this is that the python on $PATH may not be the one that is
+    # correctly configured with the appropriate dependencies, so we
+    # attempt to use the same executable as the tests.
+    all_args = [sys.executable, "-m", "openassetio.test.manager"]
     if fixtures_path:
         all_args.extend(["-f", fixtures_path])
     if extra_args:


### PR DESCRIPTION
Ensures the tests run the CLI using the same python as the tests themselves. Fixes one of two issues surfaced by #276 (#278 sorts the other).