### PR TITLE
[Docs] Add link to working group meetings in Getting Involved section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ pytest
 ## Getting involved
 
 - See the [contribution guide](contributing/PROCESS.md)
+- Join our [working group](https://github.com/TheFoundryVisionmongers/OpenAssetIO-WG) meetings
 
 > Maya&reg;, is a registered trademark of Autodesk, Inc., and/or its
 > subsidiaries and/or affiliates in the USA and/or other countries.


### PR DESCRIPTION
Add link to the working group meetings from the main project readme. Idea from MovieLabs wanting to attend meetings but not being able to find how.

Signed-off-by: mmazerolle <mathieu.mazerolle@foundry.com>