### PR TITLE
[Core] Migrate `managementPolicy` to use trait sets

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -161,7 +161,7 @@
  * # to publish. It's going to be a text file. In reality you
  * # would use one of the more derived, concrete specification types.
  * file_spec = FileSpecification()
- * file_spec.extensions = ('txt',)
+ * file_spec.blobTrait().mimeType = 'text/plain'
  *
  * # As ever, an appropriately configured context is required
  * context = session.createContext()
@@ -169,7 +169,7 @@
  * context.locale = APIDocumentationExampleLocale()
  *
  * # The first step is to see if the manager wants to manage text files
- * policy = manager.managementPolicy([file_spec], context)[0]
+ * policy = manager.managementPolicy([file_spec.traits], context)[0]
  *
  * if not policy & constants.kManaged:
  *   # The manager doesn't care about this type of asset
@@ -223,7 +223,7 @@
  * # Create a spec that describes the kind(s) of thumbnail that can
  * # be made by the host
  * thumbnail_spec = ThumbnailSpecification()
- * thumbnail_spec.mimeType = ["image/png",]
+ * thumbnail_spec.blobTrait().mimeType = "image/png"
  *
  * # Preflight the thumbnail spec with the target entity's reference,
  * # this gives us a reference we can now use for all interactions

--- a/doc/src/ForHosts.dox
+++ b/doc/src/ForHosts.dox
@@ -96,8 +96,8 @@
  *
  * - Ask the @ref manager if they manage relevant data via
  *   @ref openassetio.hostAPI.Manager.Manager.managementPolicy
- *   "Manager.managementPolicy" using a suitably configured @ref
- *   Specification and a @ref Context with `kRead` access, and
+ *   "Manager.managementPolicy" using a suitable set of @needsref traits
+ *   and a @ref Context with `kRead` access, and
  *   respect the returned flags.
  *
  * - Always check any suspected entity references with @ref
@@ -112,9 +112,9 @@
  *
  * - Ask the @ref manager if they support publishing relevant data via
  *   @ref openassetio.hostAPI.Manager.Manager.managementPolicy
- *   "Manager.managementPolicy" using a suitable configured @ref
- *   Specification and a @ref Context with `kWrite` access, and
- *   respect the returned flags.
+ *   "Manager.managementPolicy" using a suitable set of @needsref traits
+ *   and a @ref Context with `kWrite` access, and respect the returned
+ *   flags.
  *
  * - Follow the @ref openassetio.hostAPI.Manager.Manager.managementPolicy
  *   "policy", @ref preflight, resolve, write, @ref register process

--- a/doc/src/Glossary.dox
+++ b/doc/src/Glossary.dox
@@ -455,7 +455,8 @@
  * requires it to:
  *
  * - Check whether the @ref manager is interested in that particular
- *   @ref Specification of @ref entity, via the manager's @ref openassetio.hostAPI.Manager.Manager.managementPolicy
+ *   @ref entity "entity's" @needsref traits, via the manager's
+ *   @ref openassetio.hostAPI.Manager.Manager.managementPolicy
  *   "managementPolicy".
  * - Call @ref preflight to allow any prerequisite housekeeping
  *   to be performed, and a working @ref entity_reference returned.

--- a/doc/src/Thumbnails.dox
+++ b/doc/src/Thumbnails.dox
@@ -25,7 +25,7 @@
  *
  * To this end, a @ref manager can set the @ref openassetio.constants.kWantsThumbnail
  * "kWantsThumbnail" flag in it's response to @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.managementPolicy
- * "managementPolicy" for any given entity @ref Specification.
+ * "managementPolicy" for any given set of entity @needsref traits.
  *
  * If supported by the host, it will then:
  * - Call @ref preflight with the target entity and a @needsref ThumbnailSpecification

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -308,11 +308,12 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def managementPolicy(self, specifications, context):
+    def managementPolicy(self, traitSets, context):
         """
         Determines if the manager is interested in participating in
-        interactions with the specified types of @ref entity, either
-        for resolution or publishing. It is *vital* to call this before
+        interactions with entities with the specified sets of @needsref
+        traits. The supplied @ref Context determines whether this is for
+        resolution or publishing. It is *vital* to call this before
         attempting to publish data to the manager, as the entity
         specification you desire to work with may not be supported.
 
@@ -325,6 +326,11 @@ class Manager(Debuggable):
         returned for a query as to the management of scene files, you
         should hide or disable menu items that relate to publish or
         loading of assetized scene files.
+
+        If a manager returns kManaged, then it can be assumed that it is
+        capable of retrieving (for a read context) and storing (for a
+        write context) all of the supplied traits through @needsref
+        resolve and @ref register.
 
         @warning The @ref openassetio.Context.Context.access "access"
         of the supplied context will be considered by the manager. If
@@ -345,16 +351,16 @@ class Manager(Debuggable):
         on disk), and then only call @ref register to create the new
         entity.
 
-        @param specifications `List[Specification]` Specifications to
-        query.
+        @param traitSets `List[Set[str]]` The entity @needsref traits
+        to query.
 
         @param context Context The calling context.
 
         @return `List[int]` Bitfields, one for each element in
-        `specifications`. See @ref openassetio.constants.
+        `traits`. See @ref openassetio.constants.
         """
         return self.__impl.managementPolicy(
-            specifications, context, self.__hostSession)
+            traitSets, context, self.__hostSession)
 
     ## @}
 
@@ -1050,8 +1056,8 @@ class Manager(Debuggable):
         """
         @note This call is only applicable when the manager you are
         communicating with sets the constants.kWillManagePath bit in
-        response to a @ref Manager.managementPolicy for the
-        specification of entity you are intending to publish.
+        response to a @ref Manager.managementPolicy for the traits of
+        entities you are intending to publish.
 
         It signals your intent as a host application to do some work to
         create data in relation to each supplied @ref entity_reference.
@@ -1133,7 +1139,7 @@ class Manager(Debuggable):
         @note The registration call is applicable to all kinds of
         Manager, as long as the @ref constants.kIgnored bit is not set
         in response to a @ref Manager.managementPolicy for the
-        Specification of entity you are intending to publish. In this
+        traits of the entities you are intending to publish. In this
         case, the Manager is saying it doesn't handle that
         Specification of entity, and it should not be registered.
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -367,21 +367,23 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
     # @{
 
     @abc.abstractmethod
-    def managementPolicy(self, specifications, context, hostSession):
+    def managementPolicy(self, traitSets, context, hostSession):
         """
         Determines if the asset manager is interested in participating
-        in interactions with the specified specifications of @ref
-        entity.
+        in interactions with @ref entity "entities" with the specified
+        sets of @needsref traits.
 
         For example, a host may call this in order to see if the manager
         would like to manage the path of a scene file whilst choosing a
         destination to save to.
 
-        This information is then used to determine which options
-        should be presented to the user. For example, if `kIgnored`
-        was returned for a query as to the management of scene files,
-        a Host will hide or disable menu items that relate to publish
-        or loading of assetized scene files.
+        This information is then used to determine which options should
+        be presented to the user or which workflows may be performed by
+        the host. For example, if `kIgnored` was returned for a query as
+        to the management of scene files, a Host will hide or disable
+        menu items that relate to publish or loading of assetized scene
+        files, and not involve the manager in any actions realting to
+        scene files.
 
         @warning The @ref openassetio.Context.Context.access "access"
         specified in the supplied context should be carefully considered.
@@ -402,15 +404,27 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         asset becomes a partially manual task, rather than one that can
         be fully automated for new assets.
 
-        @param specifications `List[Specification]` Specifications to
-        query.
+        For read contexts, kManaged should only be returned if the
+        manager can potentially resolve data for all of the supplied
+        traits. Hosts are required to deal with the properties for any
+        given trait being unset when resolved, as they may not be
+        available for existing assets, as long as the traits are
+        understood.
+
+        For write contexts, kManaged should only be returned if the
+        manager is capable of persisting all traits (and any of their
+        property data) when they are registered for an entity, and
+        returning that data via resolve.
+
+        @param traitSets `List[Set[str]]` The entity @needsref traits
+        to query.
 
         @param context Context The calling context.
 
         @param hostSession HostSession The API session.
 
         @return `List[int]` Bitfields, one for each element in
-        `specifications`. See @ref openassetio.constants.
+        `traitSets`. See @ref openassetio.constants.
         """
         raise NotImplementedError
 

--- a/python/openassetio/test/manager/apiComplianceSuite.py
+++ b/python/openassetio/test/manager/apiComplianceSuite.py
@@ -23,8 +23,8 @@ requirements of the API, and can handle all documented calling patterns.
 For example, that when a
 @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.managementPolicy
 "managementPolicy" query returns a non-ignored state, that there are no
-errors calling the other required methods for a managed entity of that
-Specification.
+errors calling the other required methods for a managed entity with
+those @needsref traits.
 
 The suite does not validate any specific business logic by checking the
 values API methods _may_ return in certain situations. This should be
@@ -35,7 +35,6 @@ handled through additional suites local to the manager's implementation.
 
 from .harness import FixtureAugmentedTestCase
 from ...exceptions import EntityResolutionError
-from ...specifications import EntitySpecification
 from ... import Context
 
 
@@ -125,11 +124,11 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
     Check plugin's implementation of managerAPI.ManagerInterface.managementPolicy
     """
 
-    def test_when_called_with_single_specification_returns_single_result(self):
+    def test_when_called_with_single_trait_set_returns_single_result(self):
         context = self.createTestContext()
         self.__assertPolicyResults(1, context)
 
-    def test_when_called_with_ten_specifications_returns_ten_results(self):
+    def test_when_called_with_ten_trait_sets_returns_ten_results(self):
         context = self.createTestContext()
         self.__assertPolicyResults(10, context)
 
@@ -153,19 +152,31 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
         context.access = context.kWriteMultiple
         self.__assertPolicyResults(1, context)
 
-    def __assertPolicyResults(self, numSpecifications, context):
+    def test_calling_with_empty_trait_set_does_not_error(self):
+        context = self.createTestContext()
+        self.__assertPolicyResults(1, context, traitSet=())
+
+    def test_calling_with_unknown_complex_trait_set_does_not_error(self):
+        context = self.createTestContext()
+        traits = ("🐟🐠🐟🐠", "asdfsdfasdf", "⿂")
+        self.__assertPolicyResults(1, context, traitSet=traits)
+
+    def __assertPolicyResults(self, numTraitSets, context, traitSet=("entity",)):
         """
         Tests the validity and coherency of the results of a call to
-        `managementPolicy` for a given number of specifications and
+        `managementPolicy` for a given number of trait sets and
         context. It checks lengths match and values are of the correct
         type.
-        """
-        specs = [EntitySpecification() for _ in range(numSpecifications)]
 
-        policies = self._manager.managementPolicy(specs, context)
+        @param traitSet `List[str]` The set of traits to pass to
+        the call to managementPolicy.
+        """
+        traitSets = [traitSet for _ in range(numTraitSets)]
+
+        policies = self._manager.managementPolicy(traitSets, context)
 
         self.assertValuesOfType(policies, int)
-        self.assertEqual(len(policies), numSpecifications)
+        self.assertEqual(len(policies), numTraitSets)
 
 
 class Test_isEntityReference(FixtureAugmentedTestCase):

--- a/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
+++ b/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
@@ -87,10 +87,10 @@ class BasicAssetLibraryInterface(ManagerInterface):
         )
         self.__library = bal.load_library(self.__settings["library_path"])
 
-    def managementPolicy(self, specifications, context, hostSession):
+    def managementPolicy(self, traitSets, context, hostSession):
         # pylint: disable=unused-argument
         policy = constants.kManaged if context.isForRead() else constants.kIgnored
-        return [policy for _ in specifications]
+        return [policy for _ in traitSets]
 
     def isEntityReference(self, tokens, hostSession):
         # pylint: disable=unused-argument

--- a/resources/examples/manager/BasicAssetLibrary/tests/bal_business_logic_suite.py
+++ b/resources/examples/manager/BasicAssetLibrary/tests/bal_business_logic_suite.py
@@ -33,21 +33,21 @@ class Test_managementPolicy(FixtureAugmentedTestCase):
     for write.
     """
 
-    __schemas = ("file.image", "container.shot", "definitely_unique")
+    __trait_sets = (
+        ("blob", "image"),
+        ("container", "shot", "frame_ranged"),
+        ("definitely_unique")
+    )
 
-    def test_returns_cooperative_policy_for_read_for_all_specifications(self):
+    def test_returns_cooperative_policy_for_read_for_all_trait_sets(self):
         context = self.createTestContext(access=Context.kRead)
-        policies = self._manager.managementPolicy(self.__test_specs(), context)
+        policies = self._manager.managementPolicy(self.__trait_sets, context)
         for policy in policies:
             assert policy & constants.kManaged
             assert policy & constants.kExclusive != constants.kExclusive
 
-    def test_returns_ignored_policy_for_write_for_all_specifications(self):
+    def test_returns_ignored_policy_for_write_for_all_trait_sets(self):
         context = self.createTestContext(access=Context.kWrite)
-        policies = self._manager.managementPolicy(self.__test_specs(), context)
+        policies = self._manager.managementPolicy(self.__trait_sets, context)
         for policy in policies:
             assert policy == constants.kIgnored
-
-    @classmethod
-    def __test_specs(cls):
-        return [SpecificationFactory.instantiate(schema, {}) for schema in cls.__schemas]

--- a/resources/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
+++ b/resources/examples/manager/SampleAssetManager/python/SampleAssetManager/SampleAssetManagerInterface.py
@@ -60,6 +60,6 @@ class SampleAssetManagerInterface(ManagerInterface):
             constants.kField_EntityReferencesMatchPrefix: "sam:///"
         }
 
-    def managementPolicy(self, specifications, context, hostSession):
+    def managementPolicy(self, traitSets, context, hostSession):
         # pylint: disable=unused-argument
-        return [constants.kIgnored for _ in specifications]
+        return [constants.kIgnored for _ in traitSets]

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -145,8 +145,10 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def initialize(self, hostSession):
         return mock.DEFAULT
 
-    def managementPolicy(self, specifications, context, hostSession):
-        self.__assertIsIterableOf(specifications, EntitySpecification)
+    def managementPolicy(self, traitSets, context, hostSession):
+        self.__assertIsIterableOf(traitSets, set)
+        for traitSet in traitSets:
+            self.__assertIsIterableOf(traitSet, str)
         self.__assertCallingContext(context, hostSession)
 
         return mock.DEFAULT
@@ -595,11 +597,12 @@ class Test_Manager_resolveEntityReference:
 class Test_Manager_managentPolicy:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_entity_specs, a_context):
+            self, manager, mock_manager_interface, host_session, some_entity_trait_sets,
+            a_context):
 
         method = mock_manager_interface.managementPolicy
-        assert manager.managementPolicy(some_entity_specs, a_context) == method.return_value
-        method.assert_called_once_with(some_entity_specs, a_context, host_session)
+        assert manager.managementPolicy(some_entity_trait_sets, a_context) == method.return_value
+        method.assert_called_once_with(some_entity_trait_sets, a_context, host_session)
 
 
 class Test_Manager_preflight:

--- a/tests/openassetio/test/manager/resources/plugins/StubManager.py
+++ b/tests/openassetio/test/manager/resources/plugins/StubManager.py
@@ -55,9 +55,9 @@ class StubManager(ManagerInterface):
         # pylint: disable=unused-argument
         pass
 
-    def managementPolicy(self, specifications, context, hostSession):
+    def managementPolicy(self, traitSets, context, hostSession):
         # pylint: disable=unused-argument
-        return [constants.kIgnored for _ in range(len(specifications))]
+        return [constants.kIgnored for _ in traitSets]
 
 
 class StubManagerPlugin(ManagerPlugin):


### PR DESCRIPTION
Closes #280.

Sorry if I've missed anything, too many meetings these days!

NB: This assumes #305 is merged imminently, and defines trait sets as a `set` not `list`/`tuple`.