### PR TITLE
[Core] Migrate `defaultEntityReference` to use trait sets

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -456,19 +456,18 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def defaultEntityReference(self, specifications, context):
+    def defaultEntityReference(self, traitSets, context):
         """
         Returns an @ref entity_reference considered to be a sensible
-        default for each of the given Specifications and Context. This
-        can be used to ensure dialogs, prompts or publish locations
-        default to some sensible value, avoiding the need for a user to
-        re-enter such information. There may be situations where there
-        is no meaningful default, so the caller should be robust to this
-        situation.
+        default for each of the given entity @needsref traits and
+        Context. This can be used to ensure dialogs, prompts or publish
+        locations default to some sensible value, avoiding the need for
+        a user to re-enter such information. There may be situations
+        where there is no meaningful default, so the caller should be
+        robust to this situation.
 
-        @param specifications `List[`
-            specifications.EntitySpecification `]`
-        The relevant specifications for the type of entities required,
+        @param traitSets `List[List[str]]`
+        The relevant trait sets for the type of entities required,
         these will be interpreted in conjunction with the context to
         determine the most sensible default.
 
@@ -477,9 +476,9 @@ class Manager(Debuggable):
         pattern as it has great bearing on the resulting reference.
 
         @return `List[str]` An @ref entity_reference or empty string for
-        each given specification.
+        each given trait set.
         """
-        return self.__impl.defaultEntityReference(specifications, context, self.__hostSession)
+        return self.__impl.defaultEntityReference(traitSets, context, self.__hostSession)
 
     ## @}
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -562,23 +562,22 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         """
         raise NotImplementedError
 
-    def defaultEntityReference(self, specifications, context, hostSession):
+    def defaultEntityReference(self, traitSets, context, hostSession):
         """
         Returns an @ref entity_reference considered to be a sensible
-        default for each of the given specifications and Context. This
-        is often used in a host to ensure dialogs, prompts or publish
-        locations default to some sensible value, avoiding the need for
-        a user to re-enter such information when a Host is being run in
-        some known environment.
+        default for each of the given entity @needsref traits and
+        Context. This is often used in a host to ensure dialogs, prompts
+        or publish locations default to some sensible value, avoiding
+        the need for a user to re-enter such information when a Host is
+        being run in some known environment.
 
         For example, a host may request the default ref for
         'ShotSpecification/kWriteMultiple'. If the Manager has some
         concept of the 'current sequence' it may wish to return this so
         that a 'Create Shots' starts somewhere meaningful.
 
-        @param specifications `List[`
-            specifications.EntitySpecification `]`
-        The relevant specifications for the type of entities a host is
+        @param traitSets `List[List[str]]`
+        The relevant trait sets for the type of entities a host is
         about to work with. These should be interpreted in conjunction
         with the context to determine the most sensible default.
 
@@ -595,9 +594,9 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         object representing the process that initiated the API session.
 
         @return `List[str]` An @ref entity_reference or empty string for
-        each given specification.
+        each given trait set.
         """
-        return ["" for _ in specifications]
+        return ["" for _ in traitSets]
 
     ## @}
 

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -66,8 +66,8 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def flushCaches(self, hostSession):
         return mock.DEFAULT
 
-    def defaultEntityReference(self, specifications, context, hostSession):
-        self.__assertIsIterableOf(specifications, EntitySpecification)
+    def defaultEntityReference(self, traitSets, context, hostSession):
+        self.__assertIsIterableOf(traitSets, (list, tuple))
         self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
@@ -262,6 +262,9 @@ def an_entity_spec():
 def some_entity_specs():
     return [EntitySpecification(), EntitySpecification()]
 
+@pytest.fixture
+def some_entity_trait_sets():
+    return [("blob",), ("blob", "image")]
 
 @pytest.fixture
 def a_context():
@@ -385,11 +388,13 @@ class Test_Manager_entityExists:
 class Test_Manager_defaultEntityReference:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, a_context, some_entity_specs):
+            self, manager, mock_manager_interface, host_session, a_context,
+            some_entity_trait_sets):
 
         method = mock_manager_interface.defaultEntityReference
-        assert manager.defaultEntityReference(some_entity_specs, a_context) == method.return_value
-        method.assert_called_once_with(some_entity_specs, a_context, host_session)
+        assert manager.defaultEntityReference(some_entity_trait_sets, a_context) \
+                == method.return_value
+        method.assert_called_once_with(some_entity_trait_sets, a_context, host_session)
 
 
 class Test_Manager_entityName:

--- a/tests/openassetio/managerAPI/test_managerinterface.py
+++ b/tests/openassetio/managerAPI/test_managerinterface.py
@@ -51,13 +51,13 @@ class Test_ManagerInterface_displayName:
 
 
 class Test_ManagerInterface_defaultEntityReference:
-    def test_when_given_single_spec_then_returns_single_empty_ref(self, manager_interface):
-        refs = manager_interface.defaultEntityReference([Mock()], Mock(), Mock())
+    def test_when_given_single_trait_set_then_returns_single_empty_ref(self, manager_interface):
+        refs = manager_interface.defaultEntityReference([()], Mock(), Mock())
         assert refs == [""]
 
-    def test_when_given_multiple_specs_then_returns_corresponding_number_of_empty_refs(
+    def test_when_given_multiple_trait_set_then_returns_corresponding_number_of_empty_refs(
             self, manager_interface):
-        refs = manager_interface.defaultEntityReference([Mock(), Mock(), Mock()], Mock(), Mock())
+        refs = manager_interface.defaultEntityReference([(), (), ()], Mock(), Mock())
         assert refs == ["", "", ""]
 
 


### PR DESCRIPTION
Updates the signature for `defaultEntityReference` to take a set of trait IDs rather than a `Specification`. This removes the ambiguity around whether or not the method should consider the properties of the traits vs their identifiers.

This method is meant as a high-level starting point for some "kind" of entity, before they exist, so it should not be affected by the data of any particular entity itself.