### PR TITLE
[Core] Add `Specifications::traitIDs` method

### DIFF
--- a/src/openassetio-core/include/openassetio/specification/Specification.hpp
+++ b/src/openassetio-core/include/openassetio/specification/Specification.hpp
@@ -84,6 +84,11 @@ class OPENASSETIO_CORE_EXPORT Specification {
   virtual ~Specification();
 
   /**
+   * Return the trait ID's held by the specification.
+   */
+  [[nodiscard]] TraitIds traitIds() const;
+
+  /**
    * Return whether this specification supports the given trait.
    *
    * @param traitId ID of trait to check for support.

--- a/src/openassetio-core/specification/Specification.cpp
+++ b/src/openassetio-core/specification/Specification.cpp
@@ -18,6 +18,15 @@ class Specification::Impl {
   }
   ~Impl() = default;
 
+  TraitIds traitIds() const {
+    TraitIds ids;
+    ids.reserve(data_.size());
+    for (const auto& item : data_) {
+      ids.push_back(item.first);
+    }
+    return ids;
+  }
+
   bool hasTrait(const trait::TraitId& traitId) const {
     return static_cast<bool>(data_.count(traitId));
   }
@@ -50,6 +59,8 @@ class Specification::Impl {
 Specification::Specification(const TraitIds& traitIds) : impl_{std::make_unique<Impl>(traitIds)} {}
 
 Specification::~Specification() = default;
+
+Specification::TraitIds Specification::traitIds() const { return impl_->traitIds(); }
 
 bool Specification::hasTrait(const trait::TraitId& traitId) const {
   return impl_->hasTrait(traitId);

--- a/src/openassetio-python/specification/SpecificationBinding.cpp
+++ b/src/openassetio-python/specification/SpecificationBinding.cpp
@@ -16,6 +16,7 @@ void registerSpecification(const py::module& mod) {
 
   py::class_<Specification, Holder<Specification>>(mod, "Specification")
       .def(py::init<const Specification::TraitIds&>(), py::arg("traitIds"))
+      .def("traitIds", &Specification::traitIds)
       .def("hasTrait", &Specification::hasTrait, py::arg("id"))
       .def("setTraitProperty", &Specification::setTraitProperty, py::arg("id"),
            py::arg("propertyKey"), py::arg("propertyValue").none(false))

--- a/tests/openassetio/test_traits.py
+++ b/tests/openassetio/test_traits.py
@@ -10,6 +10,19 @@ import pytest
 from openassetio import specification, trait
 
 
+class Test_Specification_traitIds:
+    def test_when_has_no_traits_returns_empty_list(self):
+        empty_specification = specification.Specification([])
+        assert empty_specification.traitIds() == []
+
+    def test_when_has_traits_returns_expected_trait_ids(self):
+        expected_ids = ["a", "b", "🐠🐟🐠🐟"]
+        populated_specification = specification.Specification(expected_ids)
+        ## TODO: Should we use set instead of vector for TraitIds, as
+        ## the order is meaningless (and not preserved).
+        assert  set(populated_specification.traitIds()) == set(expected_ids)
+
+
 class Test_Specification_hasTrait:
     def test_when_has_trait_then_returns_true(self, a_specification):
         assert a_specification.hasTrait("second_trait")


### PR DESCRIPTION
Retrieves the list of traits the Specification has been populated with. This is the first step to allowing introspection of a Specification's data by exposing which traits have been set.

Be kind, it's been a long time since I've been writing `C++` 🙃.