### PR TITLE
[Lint] Add other build artifacts to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 /dist/
 /resources/build/.vagrant/
 /.pybuild/
+/build


### PR DESCRIPTION
As these are created by README instructed steps, it helps make the default dev experience less chaotic.