### PR TITLE
[Core] Switch `TraitIDs` to `unordered_set`

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -466,7 +466,7 @@ class Manager(Debuggable):
         where there is no meaningful default, so the caller should be
         robust to this situation.
 
-        @param traitSets `List[List[str]]`
+        @param traitSets `List[Set[str]]`
         The relevant trait sets for the type of entities required,
         these will be interpreted in conjunction with the context to
         determine the most sensible default.

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -576,7 +576,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         concept of the 'current sequence' it may wish to return this so
         that a 'Create Shots' starts somewhere meaningful.
 
-        @param traitSets `List[List[str]]`
+        @param traitSets `List[Set[str]]`
         The relevant trait sets for the type of entities a host is
         about to work with. These should be interpreted in conjunction
         with the context to determine the most sensible default.

--- a/src/openassetio-core/include/openassetio/specification/Specification.hpp
+++ b/src/openassetio-core/include/openassetio/specification/Specification.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <memory>
-#include <vector>
+#include <unordered_set>
 
 #include <openassetio/export.h>
 
@@ -65,15 +65,20 @@ namespace specification {
  */
 class OPENASSETIO_CORE_EXPORT Specification {
  public:
-  /// List of supported trait IDs.
-  using TraitIds = std::vector<trait::TraitId>;
+  /**
+   * A collection of supported trait IDs
+   *
+   * ID collections are a set, rather than a list. In that,
+   * no single ID can appear more than once and the order of the IDs
+   * has no meaning and is not preserved.
+   */
+  using TraitIds = std::unordered_set<trait::TraitId>;
 
   /**
-   * Construct such that this specification supports the given list of
+   * Construct such that this specification has the given set of
    * trait IDs.
    *
-   * @param traitIds List of IDs of traits that this specification
-   * supports.
+   * @param traitIds The consituent traits IDs.
    */
   explicit Specification(const TraitIds& traitIds);
 
@@ -89,10 +94,10 @@ class OPENASSETIO_CORE_EXPORT Specification {
   [[nodiscard]] TraitIds traitIds() const;
 
   /**
-   * Return whether this specification supports the given trait.
+   * Return whether this specification has the given trait.
    *
-   * @param traitId ID of trait to check for support.
-   * @return `true` if trait is supported, `false` otherwise.
+   * @param traitId ID of trait to check for.
+   * @return `true` if trait is present, `false` otherwise.
    */
   [[nodiscard]] bool hasTrait(const trait::TraitId& traitId) const;
 
@@ -100,13 +105,13 @@ class OPENASSETIO_CORE_EXPORT Specification {
    * Get the value of a given trait property, if the property has
    * been set.
    *
-   * @param[out] out Storage fo result, only written to if the property
+   * @param[out] out Storage for result, only written to if the property
    * is set.
    * @param traitId ID of trait to query.
    * @param propertyKey Key of trait's property to query.
    * @return `true` if value was found, `false` if it is unset.
-   * @exception `std::out_of_range` if the trait is not supported by
-   * this specification.
+   * @exception `std::out_of_range` if the specification does not have
+   * this trait.
    */
   [[nodiscard]] bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
                                       const trait::property::Key& propertyKey) const;
@@ -117,8 +122,8 @@ class OPENASSETIO_CORE_EXPORT Specification {
    * @param traitId ID of trait to update.
    * @param propertyKey Key of property to set.
    * @param propertyValue Value to set.
-   * @exception `std::out_of_range` if the trait is not supported by
-   * this specification.
+   * @exception `std::out_of_range` if the specification does not have
+   * this trait.
    */
   void setTraitProperty(const trait::TraitId& traitId, const trait::property::Key& propertyKey,
                         trait::property::Value propertyValue);

--- a/src/openassetio-core/specification/Specification.cpp
+++ b/src/openassetio-core/specification/Specification.cpp
@@ -22,7 +22,7 @@ class Specification::Impl {
     TraitIds ids;
     ids.reserve(data_.size());
     for (const auto& item : data_) {
-      ids.push_back(item.first);
+      ids.insert(item.first);
     }
     return ids;
   }

--- a/tests/openassetio/hostAPI/test_manager.py
+++ b/tests/openassetio/hostAPI/test_manager.py
@@ -67,7 +67,9 @@ class ValidatingMockManagerInterface(ManagerInterface):
         return mock.DEFAULT
 
     def defaultEntityReference(self, traitSets, context, hostSession):
-        self.__assertIsIterableOf(traitSets, (list, tuple))
+        self.__assertIsIterableOf(traitSets, set)
+        for traitSet in traitSets:
+            self.__assertIsIterableOf(traitSet, str)
         self.__assertCallingContext(context, hostSession)
         return mock.DEFAULT
 
@@ -264,7 +266,7 @@ def some_entity_specs():
 
 @pytest.fixture
 def some_entity_trait_sets():
-    return [("blob",), ("blob", "image")]
+    return [{"blob"}, {"blob", "image"}]
 
 @pytest.fixture
 def a_context():

--- a/tests/openassetio/test_traits.py
+++ b/tests/openassetio/test_traits.py
@@ -12,15 +12,13 @@ from openassetio import specification, trait
 
 class Test_Specification_traitIds:
     def test_when_has_no_traits_returns_empty_list(self):
-        empty_specification = specification.Specification([])
-        assert empty_specification.traitIds() == []
+        empty_specification = specification.Specification(set())
+        assert empty_specification.traitIds() == set()
 
     def test_when_has_traits_returns_expected_trait_ids(self):
-        expected_ids = ["a", "b", "🐠🐟🐠🐟"]
+        expected_ids = {"a", "b", "🐠🐟🐠🐟"}
         populated_specification = specification.Specification(expected_ids)
-        ## TODO: Should we use set instead of vector for TraitIds, as
-        ## the order is meaningless (and not preserved).
-        assert  set(populated_specification.traitIds()) == set(expected_ids)
+        assert populated_specification.traitIds() == expected_ids
 
 
 class Test_Specification_hasTrait:
@@ -74,7 +72,7 @@ class Test_BlobTrait_isValid:
 
     def test_when_wrapping_blob_supporting_spec_then_returns_true(self):
         assert trait.BlobTrait(
-            specification.Specification([trait.BlobTrait.kId, "other"])).isValid()
+            specification.Specification({trait.BlobTrait.kId, "other"})).isValid()
 
     def test_when_wrapping_non_blob_spec_then_returns_false(self, a_specification):
         assert not trait.BlobTrait(a_specification).isValid()
@@ -195,9 +193,9 @@ class Test_BlobTrait_setMimeType:
 
 @pytest.fixture
 def a_specification():
-    return specification.Specification(["first_trait", "second_trait"])
+    return specification.Specification({"first_trait", "second_trait"})
 
 
 @pytest.fixture
 def a_blob_specification():
-    return specification.Specification([trait.BlobTrait.kId])
+    return specification.Specification({trait.BlobTrait.kId})


### PR DESCRIPTION
For any given set of traits, composed to form a specification, logically:

 - Any given trait ID should not be present more than once.
 - The order the traits are considered has no meaning.

We previously used `std::vector` as the container for a specifications's trait IDs. This commit switches to a `std::unordered_set` to make the above logic explicit in the implementation.
