### PR TITLE
[Core] Migrate `getRelatedReferences` to use trait sets

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -824,7 +824,8 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def getRelatedReferences(self, references, relationshipSpecOrSpecs, context, resultSpec=None):
+    def getRelatedReferences(
+            self, references, relationshipSpecOrSpecs, context, resultTraitSet=None):
         """
         Returns related entity references, based on a relationship
         specification.
@@ -875,9 +876,8 @@ class Manager(Debuggable):
         @param relationshipSpecOrSpecs
         List[openassetio.specifications.RelationshipSpecification]
 
-        @param resultSpec openassetio.specifications.EntitySpecification
-        or None, a hint as to what kind of entity you want to be
-        returned. May be None.
+        @param resultTraitSet `Set[str]` or None, a hint as to what
+        traits the returned entities should have.
 
         @param context Context The calling context.
 
@@ -911,7 +911,7 @@ class Manager(Debuggable):
 
         result = self.__impl.getRelatedReferences(
             references,
-            relationshipSpecOrSpecs, context, self.__hostSession, resultSpec=resultSpec)
+            relationshipSpecOrSpecs, context, self.__hostSession, resultTraitSet=resultTraitSet)
 
         return result
 

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -972,8 +972,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
 
     @abc.abstractmethod
     def getRelatedReferences(
-            self, entityRefs, relationshipSpecs, context, hostSession,
-            resultSpec=None):
+            self, entityRefs, relationshipSpecs, context, hostSession, resultTraitSet=None):
         """
         Returns related entity references, based on a relationship
         specification.
@@ -1029,9 +1028,8 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         logging and provides access to the openassetio.managerAPI.Host
         object representing the process that initiated the API session.
 
-        @param resultSpec openassetio.specifications.EntitySpecification
-        or None, a hint as to what kind of entity the caller is
-        expecting to be returned. May be None.
+        @param resultTraitSet `Set[str]` or None, a hint as to what
+        traits the caller is expecting the returned entities to have.
 
         @return List[List[str]] This MUST be the correct length,
         returning an empty outer list is NOT valid. (ie: max(len(refs),


### PR DESCRIPTION
Updates the signature for `getRelatedReferences` to take a set of trait IDs rather than a `Specification`. This removes the ambiguity around whether or not the method should consider the properties of the traits vs their identifiers.

This argument is meant to indicate the "type" of entities returned, trait properties form the data of a specific entity.

Closes https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/282.

NB: This assumes #305 is merged imminently, and defines trait sets as a `set` not `list`/`tuple`.