### PR TITLE
[CI] Add check to ensure ASWF docker builds work

### DIFF
--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -1,0 +1,26 @@
+# A simple workflow that runs the documented build steps work.
+
+name: Build Instructions
+on:
+  pull_request:
+    branches-ignore:
+      - docs
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+
+  aswf-docker:
+    name: CY2022
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build, install and test (Docker)
+      # Note: this _must_ be kept in sync with README.md until we
+      # have an established mechanism to test doc-included code.
+      run: |
+        docker run -v `pwd`:/src aswf/ci-base:2022.2 bash -c '
+          cd /src && \
+          cmake -S . -B build && cmake --build build && cmake --install build'


### PR DESCRIPTION
Ensures the steps listed in README.md work. Ideally we'd be grabbing this from the file itself, but this is progress...

This does add some time to the CI check suite though 😞 but given we list these instructions in the top-level readme, and compliance with the reference platform is critical, we need to make sure local dev doesn't diverge.

A failing run is available [here](https://github.com/foundrytom/OpenAssetIO/runs/5867268090?check_suite_focus=true) to show errors in the command are reported.

It could be said that this should be part of the `Test` check, but ideally this would be a "check the steps in the documentation work" PR...