### PR TITLE
[Core] Migrate `preflight` to use trait sets

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -183,7 +183,7 @@
  * # Whenever we make new data, we always tell the manager first,
  * # This allows it to create a placeholder version or similar.
  * # NOTE: It is critical to always use the working_ref from now on.
- * working_ref = manager.preflight([entity_ref], [file_spec], context)[0]
+ * working_ref = manager.preflight([entity_ref], file_spec.traitIds(), context)[0]
  *
  * # We then check if the manager can tell us where to save the file
  * if policy & constants.kWillManagePath:
@@ -228,7 +228,7 @@
  * # Preflight the thumbnail spec with the target entity's reference,
  * # this gives us a reference we can now use for all interactions
  * # relating to the thumbnail itself.
- * thumbnail_ref = manager.preflight([final_ref], [thumbnail_spec], context)[0]
+ * thumbnail_ref = manager.preflight([final_ref], thumbnail_spec.traitIds(), context)[0]
  *
  * thumbnail_path = os.path.join(os.path.expanduser('~'), 'greeting.preview.png')
  * thumbnail_attr = {"width": 128, "height": 128}

--- a/doc/src/Thumbnails.dox
+++ b/doc/src/Thumbnails.dox
@@ -29,8 +29,8 @@
  * "managementPolicy" for any given set of entity @needsref traits.
  *
  * If supported by the host, it will then:
- * - Call @ref preflight with the target entity and a @needsref
- * ThumbnailSpecification that describes supported formats.
+ * - Call @ref preflight with the target entity and the traits from the
+ *   @needsref ThumbnailSpecification.
  * - Call @needsref resolve on the returned reference to determine the
  *   desired width/height/format for the thumbnail.
  * - Generate a thumbnail and @ref register it to the same reference.

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -923,7 +923,7 @@ class Manager(Debuggable):
 
     @debugApiCall
     @auditApiCall("Manager methods")
-    def preflight(self, targetEntityRefs, entitySpecs, context):
+    def preflight(self, targetEntityRefs, traitSet, context):
         """
         @note This call is only applicable when the manager you are
         communicating with sets the constants.kWillManagePath bit in
@@ -966,9 +966,8 @@ class Manager(Debuggable):
         @param targetEntityRefs `List[str]` The entity references to
         preflight prior to registration.
 
-        @param entitySpecs `List[`
-            specifications.EntitySpecification `]`
-        A description of each entity that is being published.
+        @param traitSet `Set[str]` The @needsref traitSet of the
+        entites that are being published.
 
         @param context Context The calling context. This is not
         replaced with an array in order to simplify implementation.
@@ -989,15 +988,12 @@ class Manager(Debuggable):
         means the host should retry from the beginning of any given
         process.
 
-        @exception `IndexError` If `targetEntityRefs` and `entitySpecs`
+        @exception `IndexError` If `targetEntityRefs` and `traitSets`
         are not lists of the same length.
 
         @see @ref register
         """
-        if len(targetEntityRefs) != len(entitySpecs):
-            raise IndexError("Parameter lists must be of the same length")
-
-        return self.__impl.preflight(targetEntityRefs, entitySpecs, context, self.__hostSession)
+        return self.__impl.preflight(targetEntityRefs, traitSet, context, self.__hostSession)
 
     @debugApiCall
     @auditApiCall("Manager methods")

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -1039,7 +1039,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
     #
     # @{
 
-    def preflight(self, targetEntityRefs, entitySpecs, context, hostSession):
+    def preflight(self, targetEntityRefs, traitSet, context, hostSession):
         """
         Prepares for some work to be done to create data for the
         referenced entity. The entity may not yet exist (@ref
@@ -1056,9 +1056,8 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
         data to. See the notes in the API documentation for the
         specifics of this.
 
-        @param entitySpecs `List[`
-            specifications.EntitySpecification `]`
-        A description of each entity that is being published.
+        @param traitSet `Set(str)` The @needsref traitSet of the
+        entities that are being published.
 
         @param context Context The calling context. This is not
         replaced with an array in order to simplify implementation.

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -96,11 +96,10 @@ class ValidatingMockManagerInterface(ManagerInterface):
             self, entityRef, relationshipSpec, relatedRefs, context, hostSession, append=True):
         return mock.DEFAULT
 
-    def preflight(self, targetEntityRefs, entitySpecs, context, hostSession):
+    def preflight(self, targetEntityRefs, traitSet, context, hostSession):
         self.__assertIsIterableOf(targetEntityRefs, str)
-        self.__assertIsIterableOf(entitySpecs, EntitySpecification)
+        self.__assertIsIterableOf(traitSet, str)
         self.__assertCallingContext(context, hostSession)
-        assert len(targetEntityRefs) == len(entitySpecs)
         return mock.DEFAULT
 
     def createState(self, hostSession, parentState=None):
@@ -537,19 +536,13 @@ class Test_Manager_managentPolicy:
 class Test_Manager_preflight:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
-            self, manager, mock_manager_interface, host_session, some_refs, some_entity_specs,
+            self, manager, mock_manager_interface, host_session, some_refs, an_entity_trait_set,
             a_context):
 
         method = mock_manager_interface.preflight
-        assert manager.preflight(some_refs, some_entity_specs, a_context) == method.return_value
-        method.assert_called_once_with(some_refs, some_entity_specs, a_context, host_session)
-
-
-    def test_when_called_with_mismatched_array_lengths_then_IndexError_is_raised(
-            self, manager, some_refs, some_entity_specs, a_context):
-
-        with pytest.raises(IndexError):
-            manager.preflight(some_refs, some_entity_specs[1:], a_context)
+        assert manager.preflight(some_refs, an_entity_trait_set, a_context) \
+                == method.return_value
+        method.assert_called_once_with(some_refs, an_entity_trait_set, a_context, host_session)
 
 
 class Test_Manager_register:


### PR DESCRIPTION
Updates the signature for `preflight` to take a set of trait IDs rather than a `Specification`. This removes the ambiguity around whether or not the method should consider the properties of the traits vs their identifiers.

This argument is meant to indicate the "type" of entities that are about to have their data generated. Supplying the properties for a trait here makes no sense, as that data _is_ the data of the entity, and so the host can't provide it yet, as its not been made!

I think I got all the documentation updates here, but am some what sleepy so let me know if anything has slipped through the cracks!

Closes https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/283.