### PR TITLE
[Doc] Fix `pip` `requirements.txt` path in build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -115,7 +115,7 @@ repository root (the default)
 ```shell
 source dist/bin/activate
 pip install .
-pip install -r tests/requirements.txt
+pip install -r tests/python/requirements.txt
 ```
 
 We can now run the Python tests via `pytest`
@@ -157,8 +157,8 @@ cmake --install build
 cmake --build build --target openassetio-python-venv
 source dist/bin/activate
 pip install ./openassetio
-pip install -r openassetio/tests/requirements.txt
-pytest openassetio/tests
+pip install -r openassetio/tests/python/requirements.txt
+pytest openassetio/tests/python
 ```
 or alternatively, simply
 

--- a/tests/python/openassetio/test/manager/resources/plugins/StubManager.py
+++ b/tests/python/openassetio/test/manager/resources/plugins/StubManager.py
@@ -27,7 +27,7 @@ from openassetio.pluginSystem import ManagerPlugin
 class StubManager(ManagerInterface):
     """
     A stub manager implementation that provides functionality
-    required for the tests/openassetio/test/manager
+    required for the tests/python/openassetio/test/manager
     test suite to function.
     """
     # TODO: @pylint Remove once we have closed #163


### PR DESCRIPTION
Inadvertently missed in #312.