### PR TITLE
[Lint] Lint C/C++ test directory

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,7 +58,7 @@ CheckOptions:
     # Trompeloeil mock setup.
     # TODO(DF): This should be placed in `tests/.clang-tidy` but that
     #   doesn't work. Reported upstream: https://github.com/llvm/llvm-project/issues/54781
-    - { key: readability-identifier-naming.VariableIgnoredRegexp,  value: "^_\d+$"   }
+    - { key: readability-identifier-naming.VariableIgnoredRegexp,  value: "^_[0-9]+$"}
     - { key: readability-identifier-naming.ClassMemberCase,        value: camelBack  }
     - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
     - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ if (IS_GCC_OR_CLANG)
 endif ()
 message(STATUS "Linter: clang-tidy              = ${OPENASSETIO_ENABLE_CLANG_TIDY}")
 message(STATUS "Linter: cpplint                 = ${OPENASSETIO_ENABLE_CPPLINT}")
+message(STATUS "Linter: clang-format            = ${OPENASSETIO_ENABLE_CLANG_FORMAT}")
 
 #-----------------------------------------------------------------------
 # Recurse to library targets

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,18 @@
+set noparent
+linelength=99
+root=.
+# -runtime/references: Allow non-const references as function params.
+# -readability/nolint: Don't complain if unrecognized checks are
+#   disabled by a NOLINT comment. This is because both cpplint
+#   and clang-tidy use NOLINT, annoyingly.
+# -readability/check: CppLint seems to assume `CHECK` is a Google Test
+#   macro, not a Catch2 macro, and erroneously complains that we should
+#   use `CHECK_EQ` instead.
+# -whitespace/braces: Causes false positives with uniform initialization
+#   syntax (e.g. `std::string_view{data, size}`). This check is also
+#   performed by ClangFormat, anyway.
+# -readability/casting: Causes false positives with Trompeloeil mocks,
+#   where CppLint seems to think a macro is actually a C-style cast.
+#   This check is also performed by Clang-Tidy, anyway.
+filter=-runtime/references,-readability/nolint,-readability/check,-whitespace/braces
+filter=-readability/casting

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -48,6 +48,7 @@ macro(enable_cpplint)
             --includeorder=standardcfirst
             --recursive
             ${PROJECT_SOURCE_DIR}/src
+            ${PROJECT_SOURCE_DIR}/tests
         )
 
     else ()
@@ -64,6 +65,8 @@ macro(enable_clang_format)
             CONFIGURE_DEPENDS # Ensure we re-scan if files change.
             ${PROJECT_SOURCE_DIR}/src/*.[ch]pp
             ${PROJECT_SOURCE_DIR}/src/*.[ch]
+            ${PROJECT_SOURCE_DIR}/tests/*.[ch]pp
+            ${PROJECT_SOURCE_DIR}/tests/*.[ch]
         )
 
         # Create a custom target to be added as a dependency to other

--- a/src/CPPLINT.cfg
+++ b/src/CPPLINT.cfg
@@ -1,8 +1,0 @@
-set noparent
-linelength=99
-root=.
-# -runtime/references: Allow non-const references as function params.
-# -readability/nolint: Don't complain if unrecognized checks are
-#   disabled by a NOLINT comment. This is because both cpplint
-#   and clang-tidy use NOLINT, annoyingly.
-filter=-runtime/references,-readability/nolint

--- a/tests/openassetio-core-c/private/errorsTest.cpp
+++ b/tests/openassetio-core-c/private/errorsTest.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
-#include <catch2/catch.hpp>
-
 #include <openassetio/c/SimpleString.h>
 #include <openassetio/c/errors.h>
 #include <openassetio/c/namespace.h>
+
+#include <catch2/catch.hpp>
+
 // private headers
 #include <errors.hpp>
 

--- a/tests/openassetio-core-c/private/managerAPI/CManagerInterfaceTest.cpp
+++ b/tests/openassetio-core-c/private/managerAPI/CManagerInterfaceTest.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <openassetio/c/errors.h>
+#include <openassetio/c/namespace.h>
+
 #include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
 
-#include <openassetio/c/errors.h>
-#include <openassetio/c/namespace.h>
 // private headers
 #include <managerAPI/CManagerInterface.hpp>
 


### PR DESCRIPTION
Now that we have C/C++ tests, we need to add the `tests` directory to the linter search paths.