### PR TITLE
[Core] Validate specification trait sets passed to `register`

### DIFF
--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -1079,6 +1079,15 @@ class Manager(Debuggable):
         if len(targetEntityRefs) != len(entitySpecs):
             raise IndexError("Parameter lists must be of the same length")
 
+        if entitySpecs:
+            # Check supplied specifcations share a trait set
+            expectedTraits = entitySpecs[0].traitIds()
+            for i, spec in enumerate(entitySpecs[1:]):
+                specTraits = spec.traitIds()
+                if specTraits != expectedTraits:
+                    raise ValueError(
+                            f"Mismatched traits at index {i+1}: {specTraits} != {expectedTraits}")
+
         return self.__impl.register(targetEntityRefs, entitySpecs, context, self.__hostSession)
 
     ## @}

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -577,3 +577,13 @@ class Test_Manager_register:
 
         with pytest.raises(IndexError):
             manager.register(some_refs, specifications[1:], a_context)
+
+
+    def test_when_called_with_varying_trait_sets_then_ValueError_is_raised(
+            self, manager, some_refs, a_context):
+
+        specifications = [
+                specification.Specification({f"trait{i}", "🦀"})for i in range(len(some_refs))]
+
+        with pytest.raises(ValueError):
+            manager.register(some_refs, specifications, a_context)


### PR DESCRIPTION
Closes #328.

This is a follow up PR to #327, so ignore anything other than [this commit](https://github.com/TheFoundryVisionmongers/OpenAssetIO/pull/329/commits/a7f8ba6b78f453b68315e96f24e53d01cbf50415) until it is merged.