### PR TITLE
[Core] Add InfoDictionary type(def) with initial C API

### DIFF
--- a/src/openassetio-core-c/CMakeLists.txt
+++ b/src/openassetio-core-c/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(
     openassetio-core-c
     PRIVATE
     private/managerAPI/CManagerInterface.cpp
+    private/InfoDictionary.cpp
 )
 
 # Public header dependency.

--- a/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
+++ b/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <openassetio/c/export.h>
+
+#include "./StringView.h"
+#include "./errors.h"
+#include "./namespace.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**
+ * @addtogroup CAPI C API
+ * @{
+ */
+
+/**
+ * Opaque handle type representing a @fqref{InfoDictionary} "InfoDictionary"
+ * instance.
+ *
+ * The associated @fqcref{InfoDictionary_s} "InfoDictionary suite" functions
+ * operate on this handle type.
+ */
+// NOLINTNEXTLINE(modernize-use-using)
+typedef struct OPENASSETIO_NS(InfoDictionary_t) * OPENASSETIO_NS(InfoDictionary_h);
+
+/**
+ * Function pointer suite for a @fqref{InfoDictionary} "InfoDictionary" C API.
+ *
+ * Instances of this suite are provided by the `InfoDictionary_suite`
+ * function and operate on a @fqcref{InfoDictionary_h} "InfoDictionary handle".
+ */
+// NOLINTNEXTLINE(modernize-use-using)
+typedef struct {
+  /**
+   * Destructor function.
+   *
+   * This should be called by the owner of the handle when the handle is
+   * no longer in use. The underlying object will be destroyed and its
+   * memory freed.
+   *
+   * @param handle Opaque handle to InfoDictionary.
+   */
+  void (*dtor)(OPENASSETIO_NS(InfoDictionary_h) handle);
+
+  /**
+   * Retrieve a boolean value from the map.
+   *
+   * Missing values will result in a @fqcref{ErrorCode_kOutOfRange} error
+   * code.
+   *
+   * Values with the wrong data type will result in a
+   * @fqcref{ErrorCode_kBadVariantAccess} error code.
+   *
+   * @param[out] error Storage for error message, if any
+   * @param[out] out Storage for retrieved value.
+   * @param handle Opaque handle to InfoDictionary.
+   * @param key Key of entry to query.
+   * @return Error code.
+   */
+  OPENASSETIO_NS(ErrorCode)
+  (*getBool)(OPENASSETIO_NS(StringView) * error, bool* out,
+             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key);
+
+  /**
+   * Retrieve an integer value from the map.
+   *
+   * Missing values will result in a @fqcref{ErrorCode_kOutOfRange} error
+   * code.
+   *
+   * Values with the wrong data type will result in a
+   * @fqcref{ErrorCode_kBadVariantAccess} error code.
+   *
+   * @param[out] error Storage for error message, if any
+   * @param[out] out Storage for retrieved value.
+   * @param handle Opaque handle to InfoDictionary.
+   * @param key Key of entry to query.
+   * @return Error code.
+   */
+  OPENASSETIO_NS(ErrorCode)
+  (*getInt)(OPENASSETIO_NS(StringView) * error, int64_t* out,
+            OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key);
+
+  /**
+   * Retrieve a floating point value from the map.
+   *
+   * Missing values will result in a @fqcref{ErrorCode_kOutOfRange} error
+   * code.
+   *
+   * Values with the wrong data type will result in a
+   * @fqcref{ErrorCode_kBadVariantAccess} error code.
+   *
+   * @param[out] error Storage for error message, if any
+   * @param[out] out Storage for retrieved value.
+   * @param handle Opaque handle to InfoDictionary.
+   * @param key Key of entry to query.
+   * @return Error code.
+   */
+  OPENASSETIO_NS(ErrorCode)
+  (*getFloat)(OPENASSETIO_NS(StringView) * error, double* out,
+              OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key);
+
+  /**
+   * Retrieve a string value from the map.
+   *
+   * Missing values will result in a @fqcref{ErrorCode_kOutOfRange} error
+   * code.
+   *
+   * Values with the wrong data type will result in a
+   * @fqcref{ErrorCode_kBadVariantAccess} error code.
+   *
+   * An `out` parameter with insufficient capacity for the string value
+   * will result in truncation of the string as well as a
+   * @fqcref{ErrorCode_kLengthError} error code.
+   *
+   * @param[out] error Storage for error message, if any
+   * @param[out] out Storage for retrieved value.
+   * @param handle Opaque handle to InfoDictionary.
+   * @param key Key of entry to query.
+   * @return Error code.
+   */
+  OPENASSETIO_NS(ErrorCode)
+  (*getStr)(OPENASSETIO_NS(StringView) * error, OPENASSETIO_NS(StringView) * out,
+            OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key);
+} OPENASSETIO_NS(InfoDictionary_s);
+
+/**
+ * Get an instance of a @fqcref{InfoDictionary_s} "InfoDictionary suite" of C API
+ * function pointers.
+ *
+ * @return Suite of function pointers.
+ */
+OPENASSETIO_CORE_C_EXPORT OPENASSETIO_NS(InfoDictionary_s) OPENASSETIO_NS(InfoDictionary_suite)();
+
+/**
+ * @}
+ */
+#ifdef __cplusplus
+}
+#endif

--- a/src/openassetio-core-c/include/openassetio/c/errors.h
+++ b/src/openassetio-core-c/include/openassetio/c/errors.h
@@ -17,7 +17,13 @@ typedef enum {
   /// Error code indicating an OK result from a C API function.
   OPENASSETIO_NS(ErrorCode_kOK) = 0,
   /// Error code representing a generic C++ exception.
-  OPENASSETIO_NS(ErrorCode_kUnknown)
+  OPENASSETIO_NS(ErrorCode_kUnknown),
+  /// Error code representing a C++ std::bad_variant_access exception.
+  OPENASSETIO_NS(ErrorCode_kBadVariantAccess),
+  /// Error code representing a C++ std::out_of_range exception.
+  OPENASSETIO_NS(ErrorCode_kOutOfRange),
+  /// Error code representing a C++ std::length_error exception.
+  OPENASSETIO_NS(ErrorCode_kLengthError)
 } OPENASSETIO_NS(ErrorCode);
 /**
  * @}

--- a/src/openassetio-core-c/include/openassetio/c/errors.h
+++ b/src/openassetio-core-c/include/openassetio/c/errors.h
@@ -12,9 +12,13 @@ extern "C" {
  * @{
  */
 
-/// Error code indicating an OK result from a C API function.
-const int OPENASSETIO_NS(kOK) = 0;
-
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum {
+  /// Error code indicating an OK result from a C API function.
+  OPENASSETIO_NS(ErrorCode_kOK) = 0,
+  /// Error code representing a generic C++ exception.
+  OPENASSETIO_NS(ErrorCode_kUnknown)
+} OPENASSETIO_NS(ErrorCode);
 /**
  * @}
  */

--- a/src/openassetio-core-c/include/openassetio/c/errors.h
+++ b/src/openassetio-core-c/include/openassetio/c/errors.h
@@ -16,8 +16,10 @@ extern "C" {
 typedef enum {
   /// Error code indicating an OK result from a C API function.
   OPENASSETIO_NS(ErrorCode_kOK) = 0,
-  /// Error code representing a generic C++ exception.
+  /// Error code representing a generic non-exception type thrown.
   OPENASSETIO_NS(ErrorCode_kUnknown),
+  /// Error code representing a generic C++ exception.
+  OPENASSETIO_NS(ErrorCode_kException),
   /// Error code representing a C++ std::bad_variant_access exception.
   OPENASSETIO_NS(ErrorCode_kBadVariantAccess),
   /// Error code representing a C++ std::out_of_range exception.

--- a/src/openassetio-core-c/include/openassetio/c/managerAPI/ManagerInterface.h
+++ b/src/openassetio-core-c/include/openassetio/c/managerAPI/ManagerInterface.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "../StringView.h"
+#include "../errors.h"
 #include "../namespace.h"
 
 #ifdef __cplusplus
@@ -75,11 +76,12 @@ typedef struct {
    * @param[out] out Storage for the identifier string, if no error
    * occurred. @param handle Opaque handle representing
    * `ManagerInterface` instance.
-   * @return @fqcref{kOK} "kOK" if no error occurred, an error code
-   * otherwise.
+   * @return @fqcref{ErrorCode_kOK} "kOK" if no error occurred, an
+   * error code otherwise.
    */
-  int (*identifier)(OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
-                    OPENASSETIO_NS(managerAPI_ManagerInterface_h) handle);
+  OPENASSETIO_NS(ErrorCode)
+  (*identifier)(OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
+                OPENASSETIO_NS(managerAPI_ManagerInterface_h) handle);
 
   /**
    * C equivalent of the
@@ -91,11 +93,12 @@ typedef struct {
    * occurred.
    * @param handle Opaque handle representing `ManagerInterface`
    * instance.
-   * @return @fqcref{kOK} "kOK" if no error occurred, an error code
-   * otherwise.
+   * @return @fqcref{ErrorCode_kOK} "kOK" if no error occurred, an
+   * error code otherwise.
    */
-  int (*displayName)(OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
-                     OPENASSETIO_NS(managerAPI_ManagerInterface_h) handle);
+  OPENASSETIO_NS(ErrorCode)
+  (*displayName)(OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
+                 OPENASSETIO_NS(managerAPI_ManagerInterface_h) handle);
 } OPENASSETIO_NS(managerAPI_ManagerInterface_s);
 
 /**

--- a/src/openassetio-core-c/private/InfoDictionary.cpp
+++ b/src/openassetio-core-c/private/InfoDictionary.cpp
@@ -35,24 +35,26 @@ get(OPENASSETIO_NS(StringView) * err, Type *out, OPENASSETIO_NS(InfoDictionary_h
     const OPENASSETIO_NS(ConstStringView) key) {
   const InfoDictionary *infoDictionary = HandleConverter::toInstance(handle);
 
-  // TODO(DF): @exception messages.
-  try {
-    *out = std::get<Type>(infoDictionary->at({key.data, key.size}));
-  } catch (const std::out_of_range &exc) {
-    // Default exception message:
-    // VS 2019: "invalid unordered_map<K, T> key"
-    // GCC 9: "_Map_base::at"
-    openassetio::assignStringView(err, "Invalid key");
-    return OPENASSETIO_NS(ErrorCode_kOutOfRange);
-  } catch (const std::bad_variant_access &exc) {
-    // Default exception message:
-    // VS 2019: "bad variant access"
-    // GCC 9: "Unexpected index"
-    openassetio::assignStringView(err, "Invalid value type");
-    return OPENASSETIO_NS(ErrorCode_kBadVariantAccess);
-  }
+  return openassetio::errors::catchUnknownExceptionAsCode(err, [&] {
+    // TODO(DF): @exception messages.
+    try {
+      *out = std::get<Type>(infoDictionary->at({key.data, key.size}));
+    } catch (const std::out_of_range &exc) {
+      // Default exception message:
+      // VS 2019: "invalid unordered_map<K, T> key"
+      // GCC 9: "_Map_base::at"
+      openassetio::assignStringView(err, "Invalid key");
+      return OPENASSETIO_NS(ErrorCode_kOutOfRange);
+    } catch (const std::bad_variant_access &exc) {
+      // Default exception message:
+      // VS 2019: "bad variant access"
+      // GCC 9: "Unexpected index"
+      openassetio::assignStringView(err, "Invalid value type");
+      return OPENASSETIO_NS(ErrorCode_kBadVariantAccess);
+    }
 
-  return OPENASSETIO_NS(ErrorCode_kOK);
+    return OPENASSETIO_NS(ErrorCode_kOK);
+  });
 }
 }  // namespace
 

--- a/src/openassetio-core-c/private/InfoDictionary.cpp
+++ b/src/openassetio-core-c/private/InfoDictionary.cpp
@@ -10,20 +10,13 @@
 
 #include "StringView.hpp"
 #include "errors.hpp"
+#include "handles.hpp"
 
 namespace {
 
 using openassetio::InfoDictionary;
-
-/**
- * Convert a InfoDictionary opaque C handle back into the C++ type.
- *
- * @param handle InfoDictionary opaque C handle.
- * @return Reference to InfoDictionary associated with handle.
- */
-InfoDictionary &toCpp(OPENASSETIO_NS(InfoDictionary_h) handle) {
-  return *reinterpret_cast<InfoDictionary *>(handle);
-}
+using HandleConverter =
+    openassetio::handles::Converter<InfoDictionary, OPENASSETIO_NS(InfoDictionary_h)>;
 
 /**
  * Get a primitive value from a InfoDictionary, converting exceptions to
@@ -40,11 +33,11 @@ template <class Type>
 OPENASSETIO_NS(ErrorCode)
 get(OPENASSETIO_NS(StringView) * err, Type *out, OPENASSETIO_NS(InfoDictionary_h) handle,
     const OPENASSETIO_NS(ConstStringView) key) {
-  const InfoDictionary &infoDictionary = toCpp(handle);
+  const InfoDictionary *infoDictionary = HandleConverter::toInstance(handle);
 
   // TODO(DF): @exception messages.
   try {
-    *out = std::get<Type>(infoDictionary.at({key.data, key.size}));
+    *out = std::get<Type>(infoDictionary->at({key.data, key.size}));
   } catch (const std::out_of_range &exc) {
     // Default exception message:
     // VS 2019: "invalid unordered_map<K, T> key"
@@ -66,42 +59,42 @@ get(OPENASSETIO_NS(StringView) * err, Type *out, OPENASSETIO_NS(InfoDictionary_h
 extern "C" {
 
 OPENASSETIO_NS(InfoDictionary_s) OPENASSETIO_NS(InfoDictionary_suite)() {
-  return {// dtor
-          [](OPENASSETIO_NS(InfoDictionary_h) handle) { delete &toCpp(handle); },
-          // getBool
-          [](OPENASSETIO_NS(StringView) * err, openassetio::Bool * out,
-             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
-            return get<openassetio::Bool>(err, out, handle, key);
-          },
-          // getInt
-          [](OPENASSETIO_NS(StringView) * err, openassetio::Int * out,
-             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
-            return get<openassetio::Int>(err, out, handle, key);
-          },
-          // getFloat
-          [](OPENASSETIO_NS(StringView) * err, openassetio::Float * out,
-             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
-            return get<openassetio::Float>(err, out, handle, key);
-          },
-          // getStr
-          [](OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
-             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
-            openassetio::Str str;
-            const OPENASSETIO_NS(ErrorCode) errorCode =
-                get<openassetio::Str>(err, &str, handle, key);
+  return {
+      // dtor
+      [](OPENASSETIO_NS(InfoDictionary_h) handle) { delete HandleConverter::toInstance(handle); },
+      // getBool
+      [](OPENASSETIO_NS(StringView) * err, openassetio::Bool * out,
+         OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+        return get<openassetio::Bool>(err, out, handle, key);
+      },
+      // getInt
+      [](OPENASSETIO_NS(StringView) * err, openassetio::Int * out,
+         OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+        return get<openassetio::Int>(err, out, handle, key);
+      },
+      // getFloat
+      [](OPENASSETIO_NS(StringView) * err, openassetio::Float * out,
+         OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+        return get<openassetio::Float>(err, out, handle, key);
+      },
+      // getStr
+      [](OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
+         OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+        openassetio::Str str;
+        const OPENASSETIO_NS(ErrorCode) errorCode = get<openassetio::Str>(err, &str, handle, key);
 
-            if (errorCode != OPENASSETIO_NS(ErrorCode_kOK)) {
-              return errorCode;
-            }
+        if (errorCode != OPENASSETIO_NS(ErrorCode_kOK)) {
+          return errorCode;
+        }
 
-            openassetio::assignStringView(out, str);
+        openassetio::assignStringView(out, str);
 
-            if (str.size() > out->capacity) {
-              openassetio::assignStringView(err, "Insufficient storage for return value");
-              return OPENASSETIO_NS(ErrorCode_kLengthError);
-            }
+        if (str.size() > out->capacity) {
+          openassetio::assignStringView(err, "Insufficient storage for return value");
+          return OPENASSETIO_NS(ErrorCode_kLengthError);
+        }
 
-            return OPENASSETIO_NS(ErrorCode_kOK);
-          }};
+        return OPENASSETIO_NS(ErrorCode_kOK);
+      }};
 }
 }  // extern "C"

--- a/src/openassetio-core-c/private/InfoDictionary.cpp
+++ b/src/openassetio-core-c/private/InfoDictionary.cpp
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <stdexcept>
+
+#include <openassetio/c/InfoDictionary.h>
+#include <openassetio/c/StringView.h>
+#include <openassetio/c/errors.h>
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/typedefs.hpp>
+
+#include "StringView.hpp"
+#include "errors.hpp"
+
+namespace {
+
+using openassetio::InfoDictionary;
+
+/**
+ * Convert a InfoDictionary opaque C handle back into the C++ type.
+ *
+ * @param handle InfoDictionary opaque C handle.
+ * @return Reference to InfoDictionary associated with handle.
+ */
+InfoDictionary &toCpp(OPENASSETIO_NS(InfoDictionary_h) handle) {
+  return *reinterpret_cast<InfoDictionary *>(handle);
+}
+
+/**
+ * Get a primitive value from a InfoDictionary, converting exceptions to
+ * error codes.
+ *
+ * @tparam Type Type of value to extract from variant.
+ * @param[out] err Storage for error message, if any.
+ * @param[out] out Storage for return value.
+ * @param handle Opaque handle to a InfoDictionary.
+ * @param key Key to query within InfoDictionary.
+ * @return Error code.
+ */
+template <class Type>
+OPENASSETIO_NS(ErrorCode)
+get(OPENASSETIO_NS(StringView) * err, Type *out, OPENASSETIO_NS(InfoDictionary_h) handle,
+    const OPENASSETIO_NS(ConstStringView) key) {
+  const InfoDictionary &infoDictionary = toCpp(handle);
+
+  // TODO(DF): @exception messages.
+  try {
+    *out = std::get<Type>(infoDictionary.at({key.data, key.size}));
+  } catch (const std::out_of_range &exc) {
+    // Default exception message:
+    // VS 2019: "invalid unordered_map<K, T> key"
+    // GCC 9: "_Map_base::at"
+    openassetio::assignStringView(err, "Invalid key");
+    return OPENASSETIO_NS(ErrorCode_kOutOfRange);
+  } catch (const std::bad_variant_access &exc) {
+    // Default exception message:
+    // VS 2019: "bad variant access"
+    // GCC 9: "Unexpected index"
+    openassetio::assignStringView(err, "Invalid value type");
+    return OPENASSETIO_NS(ErrorCode_kBadVariantAccess);
+  }
+
+  return OPENASSETIO_NS(ErrorCode_kOK);
+}
+}  // namespace
+
+extern "C" {
+
+OPENASSETIO_NS(InfoDictionary_s) OPENASSETIO_NS(InfoDictionary_suite)() {
+  return {// dtor
+          [](OPENASSETIO_NS(InfoDictionary_h) handle) { delete &toCpp(handle); },
+          // getBool
+          [](OPENASSETIO_NS(StringView) * err, openassetio::Bool * out,
+             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+            return get<openassetio::Bool>(err, out, handle, key);
+          },
+          // getInt
+          [](OPENASSETIO_NS(StringView) * err, openassetio::Int * out,
+             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+            return get<openassetio::Int>(err, out, handle, key);
+          },
+          // getFloat
+          [](OPENASSETIO_NS(StringView) * err, openassetio::Float * out,
+             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+            return get<openassetio::Float>(err, out, handle, key);
+          },
+          // getStr
+          [](OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
+             OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+            openassetio::Str str;
+            const OPENASSETIO_NS(ErrorCode) errorCode =
+                get<openassetio::Str>(err, &str, handle, key);
+
+            if (errorCode != OPENASSETIO_NS(ErrorCode_kOK)) {
+              return errorCode;
+            }
+
+            openassetio::assignStringView(out, str);
+
+            if (str.size() > out->capacity) {
+              openassetio::assignStringView(err, "Insufficient storage for return value");
+              return OPENASSETIO_NS(ErrorCode_kLengthError);
+            }
+
+            return OPENASSETIO_NS(ErrorCode_kOK);
+          }};
+}
+}  // extern "C"

--- a/src/openassetio-core-c/private/errors.hpp
+++ b/src/openassetio-core-c/private/errors.hpp
@@ -47,6 +47,30 @@ template <class Exception>
 void extractExceptionMessage(OPENASSETIO_NS(StringView) * err, const Exception &exc) {
   openassetio::assignStringView(err, exc.what());
 }
+
+/**
+ * Wrap a callable such that all exceptions are caught and converted to
+ * an error code.
+ *
+ * This is intended as a fallback for unhandled exceptions.
+ *
+ * @tparam Fn Type of callable to wrap.
+ * @param err Storage for error message, if any.
+ * @param fn Callable to wrap.
+ * @return Error code.
+ */
+template <typename Fn>
+auto catchUnknownExceptionAsCode(OPENASSETIO_NS(StringView) * err, Fn &&fn) {
+  try {
+    return fn();
+  } catch (std::exception &exc) {
+    extractExceptionMessage(err, exc);
+    return OPENASSETIO_NS(ErrorCode_kException);
+  } catch (...) {
+    assignStringView(err, "Unknown non-exception object thrown");
+    return OPENASSETIO_NS(ErrorCode_kUnknown);
+  }
+}
 }  // namespace errors
 }  // namespace OPENASSETIO_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core-c/private/errors.hpp
+++ b/src/openassetio-core-c/private/errors.hpp
@@ -21,8 +21,9 @@ namespace errors {
  * @param code Error code.
  * @param msg Error message to bundle in exception.
  */
-inline void throwIfError(const int code, [[maybe_unused]] const OPENASSETIO_NS(StringView) & msg) {
-  if (code != 0) {
+inline void throwIfError(const OPENASSETIO_NS(ErrorCode) code,
+                         [[maybe_unused]] const OPENASSETIO_NS(StringView) & msg) {
+  if (code != OPENASSETIO_NS(ErrorCode_kOK)) {
     Str errorMessageWithCode = std::to_string(code);
     errorMessageWithCode += ": ";
     errorMessageWithCode += std::string_view{msg.data, msg.size};

--- a/src/openassetio-core-c/private/handles.hpp
+++ b/src/openassetio-core-c/private/handles.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <openassetio/export.h>  // For OPENASSETIO_VERSION
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+/**
+ * Provides utilities for converting between C++ types and C handles.
+ */
+namespace handles {
+/**
+ * Convert between C++ types and C opaque handles for those types.
+ *
+ * @tparam Type C++ type.
+ * @tparam Handle Opaque handle type.
+ */
+template <class Type, class Handle>
+struct Converter {
+  /**
+   * Convert a pointer to a C++ instance to a handle.
+   *
+   * @param ptr Pointer to C++ instance.
+   * @return Opaque C handle.
+   */
+  static Handle toHandle(Type* ptr) { return reinterpret_cast<Handle>(ptr); }
+
+  /**
+   * Convert a handle back to the underlying C++ instance.
+   *
+   * @param handle Handle to unpack.
+   * @return Pointer to C++ instance.
+   */
+  static Type* toInstance(Handle handle) { return reinterpret_cast<Type*>(handle); }
+};
+}  // namespace handles
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core-c/private/managerAPI/CManagerInterface.cpp
+++ b/src/openassetio-core-c/private/managerAPI/CManagerInterface.cpp
@@ -32,7 +32,7 @@ Str CManagerInterface::identifier() const {
   OPENASSETIO_NS(StringView) out{kStringBufferSize, outBuffer, 0};
 
   // Execute corresponding suite function.
-  const int errorCode = suite_.identifier(&errorMessage, &out, handle_);
+  const OPENASSETIO_NS(ErrorCode) errorCode = suite_.identifier(&errorMessage, &out, handle_);
 
   // Convert error code/message to exception.
   errors::throwIfError(errorCode, errorMessage);
@@ -53,7 +53,7 @@ Str CManagerInterface::displayName() const {
   OPENASSETIO_NS(StringView) out{kStringBufferSize, outBuffer, 0};
 
   // Execute corresponding suite function.
-  const int errorCode = suite_.displayName(&errorMessage, &out, handle_);
+  const OPENASSETIO_NS(ErrorCode) errorCode = suite_.displayName(&errorMessage, &out, handle_);
 
   // Convert error code/message to exception.
   errors::throwIfError(errorCode, errorMessage);

--- a/src/openassetio-core/include/openassetio/InfoDictionary.hpp
+++ b/src/openassetio-core/include/openassetio/InfoDictionary.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <unordered_map>
+#include <variant>
+
+#include <openassetio/export.h>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+/// Types available as values in a InfoDictionary.
+using InfoDictionaryValue = std::variant<Bool, Int, Float, Str>;
+/**
+ * InfoDictionary type used for @needsref
+ * managerAPI::ManagerInterface::info "ManagerInterface::info".
+ */
+using InfoDictionary = std::unordered_map<Str, InfoDictionaryValue>;
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/specification/Specification.hpp
+++ b/src/openassetio-core/include/openassetio/specification/Specification.hpp
@@ -34,7 +34,7 @@ namespace specification {
  * to the consumer (host or manager, depending on the API method) to
  * decide how this should be handled.
  *
- * @todo Add SimpleMap trait property value type.
+ * @todo Add InfoDictionary trait property value type.
  *
  * @see trait::property
  *

--- a/src/openassetio-core/include/openassetio/trait/BlobTrait.hpp
+++ b/src/openassetio-core/include/openassetio/trait/BlobTrait.hpp
@@ -50,7 +50,7 @@ struct OPENASSETIO_CORE_EXPORT BlobTrait : TraitBase<BlobTrait> {
    * @exception `std::out_of_range` if this trait is not supported by
    * the wrapped specification.
    */
-  [[nodiscard]] TraitPropertyStatus getUrl(property::Str* out) const;
+  [[nodiscard]] TraitPropertyStatus getUrl(Str* out) const;
 
   /**
    * Set the URL property for this trait in the wrapped specification.
@@ -59,7 +59,7 @@ struct OPENASSETIO_CORE_EXPORT BlobTrait : TraitBase<BlobTrait> {
    * @exception `std::out_of_range` if this trait is not supported by
    * the wrapped specification.
    */
-  void setUrl(property::Str url);
+  void setUrl(Str url);
 
   /**
    * Get the mime type property for this trait from the wrapped
@@ -70,7 +70,7 @@ struct OPENASSETIO_CORE_EXPORT BlobTrait : TraitBase<BlobTrait> {
    * @exception `std::out_of_range` if this trait is not supported by
    * the wrapped specification.
    */
-  [[nodiscard]] TraitPropertyStatus getMimeType(property::Str* out) const;
+  [[nodiscard]] TraitPropertyStatus getMimeType(Str* out) const;
 
   /**
    * Set the mime type property for this trait in the wrapped
@@ -80,7 +80,7 @@ struct OPENASSETIO_CORE_EXPORT BlobTrait : TraitBase<BlobTrait> {
    * @exception `std::out_of_range` if this trait is not supported by
    * the wrapped specification.
    */
-  void setMimeType(property::Str mimeType);
+  void setMimeType(Str mimeType);
 };
 }  // namespace trait
 }  // namespace OPENASSETIO_VERSION

--- a/src/openassetio-core/include/openassetio/trait/property.hpp
+++ b/src/openassetio-core/include/openassetio/trait/property.hpp
@@ -25,15 +25,6 @@ namespace trait {
  */
 namespace property {
 
-/// Boolean value type for specification property dictionaries.
-using Bool = bool;
-/// Integer value type for specification property dictionaries.
-using Int = int;
-/// Real value type for specification property dictionaries.
-using Float = double;
-/// String value type for specification property dictionaries.
-using Str = openassetio::Str;
-
 /**
  * Property dictionary keys
  *

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -8,7 +8,39 @@
 
 namespace openassetio {
 inline namespace OPENASSETIO_VERSION {
-/// String type used throughout OpenAssetIO.
+/**
+ * @name Primitive Types
+ *
+ * These types are used throughout OpenAssetIO, especially within
+ * dictionary-like types such as @ref specification data or
+ * @needsref ManagerInterface::info.
+ *
+ * OpenAssetIO must be able to bridge disparate platforms, including
+ * serialization of data. It is therefore useful to ensure that our core
+ * primitive types are as predictable and portable as possible.
+ *
+ * The following type list aims to standardise on types that share a
+ * common binary layout across platforms.
+ *
+ * This also gives us a single point to change should we need to switch
+ * to a different primitive representation in future. Therefore all use
+ * of primitive types by OpenAssetIO hosts and plugins should use these
+ * typedefs where possible, to reduce potential find-and-replace pain
+ * later.
+ *
+ * @{
+ */
+/// Boolean value type.
+using Bool = bool;
+/// Integer value type.
+using Int = int64_t;
+/// Real value type.
+using Float = double;
+/// String value type.
 using Str = std::string;
+
+/**
+ * @}
+ */
 }  // namespace OPENASSETIO_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/trait/BlobTrait.cpp
+++ b/src/openassetio-core/trait/BlobTrait.cpp
@@ -16,19 +16,15 @@ const property::Key kUrl{"url"};
 const property::Key kMimeType{"mimeType"};
 }  // namespace
 
-TraitPropertyStatus BlobTrait::getUrl(property::Str* out) const {
-  return getTraitProperty(out, kId, kUrl);
-}
+TraitPropertyStatus BlobTrait::getUrl(Str* out) const { return getTraitProperty(out, kId, kUrl); }
 
-void BlobTrait::setUrl(property::Str url) {
-  specification()->setTraitProperty(kId, kUrl, std::move(url));
-}
+void BlobTrait::setUrl(Str url) { specification()->setTraitProperty(kId, kUrl, std::move(url)); }
 
-TraitPropertyStatus BlobTrait::getMimeType(property::Str* out) const {
+TraitPropertyStatus BlobTrait::getMimeType(Str* out) const {
   return getTraitProperty(out, kId, kMimeType);
 }
 
-void BlobTrait::setMimeType(property::Str mimeType) {
+void BlobTrait::setMimeType(Str mimeType) {
   specification()->setTraitProperty(kId, kMimeType, std::move(mimeType));
 }
 

--- a/src/openassetio-python/trait/BlobTraitBinding.cpp
+++ b/src/openassetio-python/trait/BlobTraitBinding.cpp
@@ -63,7 +63,6 @@ void registerBlobTrait(const py::module& mod) {
   using openassetio::trait::maybeProperty;
   namespace specification = openassetio::specification;
   namespace trait = openassetio::trait;
-  namespace property = openassetio::trait::property;
 
   py::class_<BlobTrait, Holder<BlobTrait>>(mod, "BlobTrait")
       .def(py::init<Holder<specification::Specification>>(), py::arg("specification"))
@@ -72,7 +71,7 @@ void registerBlobTrait(const py::module& mod) {
       .def(
           "getUrl",
           [](const BlobTrait& self, const bool raiseOnError) {
-            property::Str out;
+            openassetio::Str out;
             trait::TraitPropertyStatus status = self.getUrl(&out);
             return maybeProperty(raiseOnError, status, std::move(out));
           },
@@ -81,7 +80,7 @@ void registerBlobTrait(const py::module& mod) {
       .def(
           "getMimeType",
           [](const BlobTrait& self, const bool raiseOnError) {
-            property::Str out;
+            openassetio::Str out;
             trait::TraitPropertyStatus status = self.getMimeType(&out);
             return maybeProperty(raiseOnError, status, std::move(out));
           },

--- a/tests/openassetio-core-c/CMakeLists.txt
+++ b/tests/openassetio-core-c/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(openassetio-core-c-test-exe
     main.cpp
     private/errorsTest.cpp
     private/StringViewTest.cpp
+    private/InfoDictionaryTest.cpp
     private/managerAPI/CManagerInterfaceTest.cpp)
 
 target_link_libraries(

--- a/tests/openassetio-core-c/CMakeLists.txt
+++ b/tests/openassetio-core-c/CMakeLists.txt
@@ -17,6 +17,7 @@ install(
 target_sources(openassetio-core-c-test-exe
     PRIVATE
     main.cpp
+    private/handlesTest.cpp
     private/errorsTest.cpp
     private/StringViewTest.cpp
     private/InfoDictionaryTest.cpp

--- a/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
+++ b/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <openassetio/c/InfoDictionary.h>
+#include <openassetio/c/StringView.h>
+#include <openassetio/c/errors.h>
+#include <openassetio/c/namespace.h>
+
+#include <catch2/catch.hpp>
+
+#include <openassetio/InfoDictionary.hpp>
+#include <openassetio/typedefs.hpp>
+
+#include "StringViewReporting.hpp"
+
+SCENARIO("InfoDictionary deallocated via C API") {
+  GIVEN("a heap-allocated C++ InfoDictionary and its C handle and function suite") {
+    auto* infoDictionary = new openassetio::InfoDictionary{};
+
+    // Convert InfoDictionary to opaque handle.
+    auto* const infoDictionaryHandle =
+        reinterpret_cast<OPENASSETIO_NS(InfoDictionary_h)>(infoDictionary);
+
+    // InfoDictionary function pointer suite
+    const auto suite = OPENASSETIO_NS(InfoDictionary_suite)();
+
+    WHEN("suite dtor function is called") {
+      suite.dtor(infoDictionaryHandle);
+
+      THEN("InfoDictionary was deallocated") {
+        // Rely on ASan to detect.
+      }
+    }
+  }
+}
+
+/// Default storage capacity for StringView C strings.
+constexpr std::size_t kStrStorageCapacity = 500;
+
+/**
+ * Base fixture for tests, providing a pre-populated InfoDictionary and its
+ * C handle and function pointer suite.
+ */
+struct InfoDictionaryFixture {
+  static constexpr openassetio::Bool kBoolValue = true;
+  static constexpr openassetio::Int kIntValue = 123;
+  static constexpr openassetio::Float kFloatValue = 0.456;
+  inline static const openassetio::Str kStrValue = "string value";
+
+  openassetio::InfoDictionary infoDictionary_{
+      {"aBool", kBoolValue}, {"anInt", kIntValue}, {"aFloat", kFloatValue}, {"aStr", kStrValue}};
+
+  OPENASSETIO_NS(InfoDictionary_h)
+  infoDictionaryHandle_ = reinterpret_cast<OPENASSETIO_NS(InfoDictionary_h)>(&infoDictionary_);
+
+  OPENASSETIO_NS(InfoDictionary_s) suite_ = OPENASSETIO_NS(InfoDictionary_suite)();
+};
+
+/**
+ * Fixture for a specific suite function, specialised by return data
+ * type.
+ *
+ * @tparam Value Return (out-parameter) data type of suite function.
+ */
+template <typename Value>
+struct SuiteFnFixture;
+
+/// Specialisation for getBool.
+template <>
+struct SuiteFnFixture<openassetio::Bool> : InfoDictionaryFixture {
+  decltype(InfoDictionaryFixture::suite_.getBool) fn_ = InfoDictionaryFixture::suite_.getBool;
+  static constexpr openassetio::Bool kInitialValue = false;
+  static constexpr openassetio::Bool kExpectedValue = InfoDictionaryFixture::kBoolValue;
+  static constexpr openassetio::Bool kAlternativeValue = !InfoDictionaryFixture::kBoolValue;
+  inline static const openassetio::Str kKeyStr = "aBool";
+  inline static const openassetio::Str kWrongValueTypeKeyStr = "anInt";
+  openassetio::Bool actualValue_ = kInitialValue;
+};
+
+/// Specialisation for getInt.
+template <>
+struct SuiteFnFixture<openassetio::Int> : InfoDictionaryFixture {
+  decltype(InfoDictionaryFixture::suite_.getInt) fn_ = InfoDictionaryFixture::suite_.getInt;
+  static constexpr openassetio::Int kInitialValue = 0;
+  static constexpr openassetio::Int kExpectedValue = InfoDictionaryFixture::kIntValue;
+  static constexpr openassetio::Int kAlternativeValue = InfoDictionaryFixture::kIntValue + 1;
+  inline static const openassetio::Str kKeyStr = "anInt";
+  inline static const openassetio::Str kWrongValueTypeKeyStr = "aBool";
+  openassetio::Int actualValue_ = kInitialValue;
+};
+
+/// Specialisation for getFloat.
+template <>
+struct SuiteFnFixture<openassetio::Float> : InfoDictionaryFixture {
+  decltype(InfoDictionaryFixture::suite_.getFloat) fn_ = InfoDictionaryFixture::suite_.getFloat;
+  static constexpr openassetio::Float kInitialValue = 0.0;
+  static constexpr openassetio::Float kExpectedValue = InfoDictionaryFixture::kFloatValue;
+  static constexpr openassetio::Float kAlternativeValue = InfoDictionaryFixture::kFloatValue / 2;
+  inline static const openassetio::Str kKeyStr = "aFloat";
+  inline static const openassetio::Str kWrongValueTypeKeyStr = "anInt";
+  openassetio::Float actualValue_ = kInitialValue;
+};
+
+/// Specialisation for getStr.
+template <>
+struct SuiteFnFixture<openassetio::Str> : InfoDictionaryFixture {
+  decltype(InfoDictionaryFixture::suite_.getStr) fn_ = InfoDictionaryFixture::suite_.getStr;
+  openassetio::Str valueStorage_ = openassetio::Str(kStrStorageCapacity, '\0');
+  OPENASSETIO_NS(StringView) kInitialValue{valueStorage_.size(), valueStorage_.data(), 0};
+  inline static const openassetio::Str kExpectedValue = InfoDictionaryFixture::kStrValue;
+  inline static const openassetio::Str kAlternativeValue =
+      InfoDictionaryFixture::kStrValue + " alternative";
+  inline static const openassetio::Str kKeyStr = "aStr";
+  inline static const openassetio::Str kWrongValueTypeKeyStr = "anInt";
+  OPENASSETIO_NS(StringView) actualValue_ = kInitialValue;
+};
+
+TEMPLATE_TEST_CASE_METHOD(SuiteFnFixture, "InfoDictionary accessed via C API", "",
+                          openassetio::Bool, openassetio::Int, openassetio::Float,
+                          openassetio::Str) {
+  GIVEN("a populated C++ InfoDictionary and its C handle and suite function pointer") {
+    // Map constructed with some initial data.
+    auto& infoDictionary = SuiteFnFixture<TestType>::infoDictionary_;
+    // Opaque handle to map.
+    const auto& infoDictionaryHandle = SuiteFnFixture<TestType>::infoDictionaryHandle_;
+    // Suite function for type under test.
+    const auto& fn = SuiteFnFixture<TestType>::fn_;
+
+    // Storage for return (out-parameter) value.
+    auto& actualValue = SuiteFnFixture<TestType>::actualValue_;
+    // Initial value held in actualValue out-parameter before suite
+    // function is called.
+    const auto& initialValue = SuiteFnFixture<TestType>::kInitialValue;
+    // Value in map at construction.
+    const auto& expectedValue = SuiteFnFixture<TestType>::kExpectedValue;
+    // Valid value to set in map that is not equal to expectedValue.
+    const auto& alternativeValue = SuiteFnFixture<TestType>::kAlternativeValue;
+    // Key in map where a value of the current type under test can be
+    // found.
+    const auto& keyStr = SuiteFnFixture<TestType>::kKeyStr;
+    // Key in map where a value of a different type from that under test
+    // can be found.
+    const auto& wrongValueTypeKeyStr = SuiteFnFixture<TestType>::kWrongValueTypeKeyStr;
+    // Key that doesn't exist in the map.
+    const openassetio::Str nonExistentKeyStr = "nonExistent";
+
+    // Storage for error messages coming from suite functions.
+    openassetio::Str errStorage(kStrStorageCapacity, '\0');
+    OPENASSETIO_NS(StringView) actualErrorMsg{errStorage.size(), errStorage.data(), 0};
+
+    WHEN("existing value is retrieved through C API") {
+      OPENASSETIO_NS(ConstStringView) key{keyStr.data(), keyStr.size()};
+
+      OPENASSETIO_NS(ErrorCode)
+      actualErrorCode = fn(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+
+      THEN("value is retrieved successfully") {
+        CHECK(actualErrorCode == OPENASSETIO_NS(ErrorCode_kOK));
+        CHECK(actualValue == expectedValue);
+      }
+    }
+
+    WHEN("value is updated in C++ and retrieved through C API again") {
+      OPENASSETIO_NS(ConstStringView) key{keyStr.data(), keyStr.size()};
+      infoDictionary.at(keyStr) = alternativeValue;
+
+      OPENASSETIO_NS(ErrorCode)
+      actualErrorCode = fn(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+
+      THEN("updated value is retrieved successfully") {
+        CHECK(actualErrorCode == OPENASSETIO_NS(ErrorCode_kOK));
+        CHECK(actualValue == alternativeValue);
+      }
+    }
+
+    WHEN("attempting to retrieve a non-existent value through C API") {
+      OPENASSETIO_NS(ConstStringView) key{nonExistentKeyStr.data(), nonExistentKeyStr.size()};
+
+      OPENASSETIO_NS(ErrorCode)
+      actualErrorCode = fn(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+
+      THEN("error code and message is set and out-param is unmodified") {
+        CHECK(actualErrorCode == OPENASSETIO_NS(ErrorCode_kOutOfRange));
+        CHECK(actualErrorMsg == "Invalid key");
+        CHECK(actualValue == initialValue);
+      }
+    }
+
+    WHEN("attempting to retrieve an incorrect value type through C API") {
+      OPENASSETIO_NS(ConstStringView)
+      key{wrongValueTypeKeyStr.data(), wrongValueTypeKeyStr.size()};
+
+      OPENASSETIO_NS(ErrorCode)
+      actualErrorCode = fn(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+
+      THEN("error code and message is set and out-param is unmodified") {
+        CHECK(actualErrorCode == OPENASSETIO_NS(ErrorCode_kBadVariantAccess));
+        CHECK(actualErrorMsg == "Invalid value type");
+        CHECK(actualValue == initialValue);
+      }
+    }
+
+    AND_GIVEN("error message storage capacity is very low") {
+      OPENASSETIO_NS(StringView) lowCapacityErr{3, errStorage.data(), 0};
+
+      WHEN("attempting to retrieve a non-existent value through C API") {
+        OPENASSETIO_NS(ConstStringView) key{nonExistentKeyStr.data(), nonExistentKeyStr.size()};
+
+        fn(&lowCapacityErr, &actualValue, infoDictionaryHandle, key);
+
+        THEN("error message is truncated to fit storage capacity") {
+          CHECK(lowCapacityErr == "Inv");
+        }
+      }
+
+      WHEN("attempting to retrieve an incorrect value type through C API") {
+        OPENASSETIO_NS(ConstStringView)
+        key{wrongValueTypeKeyStr.data(), wrongValueTypeKeyStr.size()};
+
+        fn(&lowCapacityErr, &actualValue, infoDictionaryHandle, key);
+
+        THEN("error message is truncated to fit storage capacity") {
+          CHECK(lowCapacityErr == "Inv");
+        }
+      }
+    }
+  }
+}
+
+SCENARIO("InfoDictionary string return with insufficient buffer capacity") {
+  GIVEN("a populated C++ InfoDictionary and its C handle and suite") {
+    InfoDictionaryFixture fixture{};
+    // Opaque handle to map.
+    const auto& infoDictionaryHandle = fixture.infoDictionaryHandle_;
+    // C API function suite
+    const auto& suite = fixture.suite_;
+
+    // Storage for error messages coming from suite functions.
+    openassetio::Str errStorage(kStrStorageCapacity, '\0');
+    OPENASSETIO_NS(StringView) actualErrorMsg{errStorage.size(), errStorage.data(), 0};
+
+    AND_GIVEN(
+        "a StringView with insufficient storage capacity for string stored in InfoDictionary") {
+      constexpr std::size_t kReducedStrStorageCapacity = 5;
+      openassetio::Str valueStorage(kReducedStrStorageCapacity, '\0');
+      OPENASSETIO_NS(StringView) actualValue{valueStorage.size(), valueStorage.data(), 0};
+
+      WHEN("string is retrieved into insufficient-capacity StringView") {
+        openassetio::Str keyStr = "aStr";
+        OPENASSETIO_NS(ConstStringView) key{keyStr.data(), keyStr.size()};
+
+        OPENASSETIO_NS(ErrorCode)
+        actualErrorCode = suite.getStr(&actualErrorMsg, &actualValue, infoDictionaryHandle, key);
+
+        THEN("truncated string is stored and error code and message is set") {
+          CHECK(actualErrorCode == OPENASSETIO_NS(ErrorCode_kLengthError));
+          CHECK(actualValue.size == actualValue.capacity);
+          CHECK(actualValue == "strin");
+          CHECK(actualErrorMsg == "Insufficient storage for return value");
+        }
+      }
+    }
+  }
+}

--- a/tests/openassetio-core-c/private/errorsTest.cpp
+++ b/tests/openassetio-core-c/private/errorsTest.cpp
@@ -15,7 +15,7 @@ SCENARIO("throwIfError error code/message handling") {
   using openassetio::errors::throwIfError;
 
   GIVEN("an OK error code") {
-    const int code = OPENASSETIO_NS(kOK);
+    const OPENASSETIO_NS(ErrorCode) code = OPENASSETIO_NS(ErrorCode_kOK);
 
     WHEN("throwIfError is called") {
       THEN("no exception is thrown") { throwIfError(code, OPENASSETIO_NS(StringView){}); }
@@ -23,7 +23,7 @@ SCENARIO("throwIfError error code/message handling") {
   }
 
   GIVEN("an error code and message") {
-    const int code = 123;
+    const auto code = OPENASSETIO_NS(ErrorCode_kUnknown);
     openassetio::Str message = "some error";
 
     OPENASSETIO_NS(StringView)
@@ -36,7 +36,7 @@ SCENARIO("throwIfError error code/message handling") {
     WHEN("throwIfError is called") {
       THEN("expected exception is thrown") {
         REQUIRE_THROWS_MATCHES(throwIfError(code, cmessage), std::runtime_error,
-                               Catch::Message("123: some error"));
+                               Catch::Message("1: some error"));
       }
     }
   }

--- a/tests/openassetio-core-c/private/handlesTest.cpp
+++ b/tests/openassetio-core-c/private/handlesTest.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+
+#include <catch2/catch.hpp>
+
+// Private headers
+#include <handles.hpp>
+
+SCENARIO("Converting to/from C++ instances and C opaque handles") {
+  GIVEN("A C++ type") {
+    struct StubCppType {
+      std::string value_;
+    };
+
+    AND_GIVEN("a non-const instance of the C++ type") {
+      StubCppType expectedCppInstance{"some string"};
+
+      AND_GIVEN("a corresponding C handle type and a converter type") {
+        using StubCppTypeHandle = struct StubCppTypeUnusedOpaqueType*;
+
+        using Converter = openassetio::handles::Converter<StubCppType, StubCppTypeHandle>;
+
+        WHEN("the instance is converted to a C handle") {
+          StubCppTypeHandle handle = Converter::toHandle(&expectedCppInstance);
+
+          AND_WHEN("the handle is converted back to a C++ instance") {
+            StubCppType* actualCppInstance = Converter::toInstance(handle);
+
+            THEN("the instances are the same") {
+              CHECK(actualCppInstance == &expectedCppInstance);
+            }
+          }
+        }
+      }
+    }
+
+    AND_GIVEN("a const instance of the C++ type") {
+      const StubCppType expectedCppInstance{"some string"};
+
+      AND_GIVEN("a corresponding C handle type and a converter type") {
+        using StubCppTypeHandle = struct StubCppTypeUnusedOpaqueType const*;
+
+        using Converter = openassetio::handles::Converter<const StubCppType, StubCppTypeHandle>;
+
+        WHEN("the instance is converted to a C handle") {
+          StubCppTypeHandle handle = Converter::toHandle(&expectedCppInstance);
+
+          THEN("converting back to a C++ instance will give a pointer to const") {
+            STATIC_REQUIRE(
+                std::is_const_v<std::remove_pointer_t<decltype(Converter::toInstance(handle))>>);
+          }
+
+          AND_WHEN("the handle is converted back to a C++ instance") {
+            const StubCppType* actualCppInstance = Converter::toInstance(handle);
+
+            THEN("the instances are the same") {
+              CHECK(actualCppInstance == &expectedCppInstance);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/openassetio-core-c/private/managerAPI/CManagerInterfaceTest.cpp
+++ b/tests/openassetio-core-c/private/managerAPI/CManagerInterfaceTest.cpp
@@ -20,11 +20,13 @@ constexpr size_t kStringBufferSize = 500;
 struct MockCAPI {
   MAKE_MOCK1(dtor, void(OPENASSETIO_NS(managerAPI_ManagerInterface_h)));
 
-  MAKE_MOCK3(identifier, int(OPENASSETIO_NS(StringView) *, OPENASSETIO_NS(StringView) *,
-                             OPENASSETIO_NS(managerAPI_ManagerInterface_h)));
+  MAKE_MOCK3(identifier,
+             OPENASSETIO_NS(ErrorCode)(OPENASSETIO_NS(StringView) *, OPENASSETIO_NS(StringView) *,
+                                       OPENASSETIO_NS(managerAPI_ManagerInterface_h)));
 
-  MAKE_MOCK3(displayName, int(OPENASSETIO_NS(StringView) *, OPENASSETIO_NS(StringView) *,
-                              OPENASSETIO_NS(managerAPI_ManagerInterface_h)));
+  MAKE_MOCK3(displayName,
+             OPENASSETIO_NS(ErrorCode)(OPENASSETIO_NS(StringView) *, OPENASSETIO_NS(StringView) *,
+                                       OPENASSETIO_NS(managerAPI_ManagerInterface_h)));
 };
 
 /**
@@ -96,7 +98,7 @@ SCENARIO("A host calls CManagerInterface::identifier") {
           .LR_SIDE_EFFECT(strncpy(_2->data, expectedIdentifier.data(), expectedIdentifier.size()))
           .LR_SIDE_EFFECT(_2->size = expectedIdentifier.size())
           // Return OK code.
-          .RETURN(OPENASSETIO_NS(kOK));
+          .RETURN(OPENASSETIO_NS(ErrorCode_kOK));
 
       WHEN("the manager's identifier is queried") {
         const openassetio::Str actualIdentifier = cManagerInterface.identifier();
@@ -109,8 +111,8 @@ SCENARIO("A host calls CManagerInterface::identifier") {
 
     AND_GIVEN("the C suite's identifier() call fails") {
       const std::string_view expectedErrorMsg = "some error happened";
-      const int expectedErrorCode = 123;
-      const openassetio::Str expectedErrorCodeAndMsg = "123: some error happened";
+      const auto expectedErrorCode = OPENASSETIO_NS(ErrorCode_kUnknown);
+      const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
 
       using trompeloeil::_;
 
@@ -163,7 +165,7 @@ SCENARIO("A host calls CManagerInterface::displayName") {
               strncpy(_2->data, expectedDisplayName.data(), expectedDisplayName.size()))
           .LR_SIDE_EFFECT(_2->size = expectedDisplayName.size())
           // Return OK code.
-          .RETURN(OPENASSETIO_NS(kOK));
+          .RETURN(OPENASSETIO_NS(ErrorCode_kOK));
 
       WHEN("the manager's displayName is queried") {
         const openassetio::Str actualDisplayName = cManagerInterface.displayName();
@@ -176,8 +178,8 @@ SCENARIO("A host calls CManagerInterface::displayName") {
 
     AND_GIVEN("the C suite's displayName() call fails") {
       const std::string_view expectedErrorMsg = "some error happened";
-      const int expectedErrorCode = 123;
-      const openassetio::Str expectedErrorCodeAndMsg = "123: some error happened";
+      const auto expectedErrorCode = OPENASSETIO_NS(ErrorCode_kUnknown);
+      const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
 
       using trompeloeil::_;
 


### PR DESCRIPTION
Part of #290. 

~We may want to think of a better name than `InfoDictionary`.~

Future PRs will expand the C API to include:
* Creating a new `InfoDictionary`from the C API (currently only pre-existing C++ `InfoDictionary`s can be converted).
* Querying the value type of an entry.
* Iteration through entries.
* Writing (insert/update) entries.