### PR TITLE
[Core] C API InfoDictionary basic introspection

### DIFF
--- a/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
+++ b/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
@@ -89,6 +89,13 @@ typedef struct {
   void (*dtor)(OPENASSETIO_NS(InfoDictionary_h) handle);
 
   /**
+   * Retrieve the number of entries currently in the map.
+   *
+   * @param handle Opaque handle to InfoDictionary.
+   */
+  size_t (*size)(OPENASSETIO_NS(InfoDictionary_h) handle);  // noexcept
+
+  /**
    * Get the type of value stored in an entry.
    *
    * @param[out] error Storage for error message, if any.

--- a/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
+++ b/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
@@ -34,6 +34,30 @@ extern "C" {
 typedef struct OPENASSETIO_NS(InfoDictionary_t) * OPENASSETIO_NS(InfoDictionary_h);
 
 /**
+ * Enumeration of the available types in a @fqref{InfoDictionary}
+ * "InfoDictionary".
+ *
+ * The set of possible types is dictated by those specified in the
+ * definition of the @fqref{InfoDictionaryValue} "variant value type".
+ * In particular, this means the set of types is fixed and cannot be
+ * extended by hosts or plugins. This enum is therefore exhaustive.
+ *
+ * @see @fqcref{InfoDictionary_s::typeOf} "typeOf"
+ * @see @ref CppPrimitiveTypes "Primitive types"
+ */
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum {
+  /// Boolean value type
+  OPENASSETIO_NS(InfoDictionary_ValueType_kBool) = 1,
+  /// Integer value type
+  OPENASSETIO_NS(InfoDictionary_ValueType_kInt),
+  /// Floating point value type
+  OPENASSETIO_NS(InfoDictionary_ValueType_kFloat),
+  /// String value type
+  OPENASSETIO_NS(InfoDictionary_ValueType_kStr)
+} OPENASSETIO_NS(InfoDictionary_ValueType);
+
+/**
  * Function pointer suite for a @fqref{InfoDictionary} "InfoDictionary" C API.
  *
  * Instances of this suite are provided by the `InfoDictionary_suite`
@@ -63,6 +87,19 @@ typedef struct {
    * @param handle Opaque handle to InfoDictionary.
    */
   void (*dtor)(OPENASSETIO_NS(InfoDictionary_h) handle);
+
+  /**
+   * Get the type of value stored in an entry.
+   *
+   * @param[out] error Storage for error message, if any.
+   * @param[out] out Storage for retrieved type.
+   * @param handle Opaque handle to InfoDictionary.
+   * @param key Key of entry to query.
+   * @return Error code.
+   */
+  OPENASSETIO_NS(ErrorCode)
+  (*typeOf)(OPENASSETIO_NS(StringView) * error, OPENASSETIO_NS(InfoDictionary_ValueType) * out,
+            OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key);
 
   /**
    * @name Accessors
@@ -205,8 +242,8 @@ typedef struct {
 } OPENASSETIO_NS(InfoDictionary_s);
 
 /**
- * Get an instance of a @fqcref{InfoDictionary_s} "InfoDictionary suite" of C API
- * function pointers.
+ * Get an instance of a @fqcref{InfoDictionary_s} "InfoDictionary suite"
+ * of C API function pointers.
  *
  * @return Suite of function pointers.
  */

--- a/src/openassetio-core-c/private/InfoDictionary.cpp
+++ b/src/openassetio-core-c/private/InfoDictionary.cpp
@@ -134,6 +134,11 @@ OPENASSETIO_NS(InfoDictionary_s) OPENASSETIO_NS(InfoDictionary_suite)() {
       // dtor
       [](OPENASSETIO_NS(InfoDictionary_h) handle) { delete HandleConverter::toInstance(handle); },
 
+      // size
+      [](OPENASSETIO_NS(InfoDictionary_h) handle) {
+        return HandleConverter::toInstance(handle)->size();
+      },
+
       // typeOf
       [](OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(InfoDictionary_ValueType) * out,
          OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {

--- a/src/openassetio-core-c/private/InfoDictionary.cpp
+++ b/src/openassetio-core-c/private/InfoDictionary.cpp
@@ -19,6 +19,36 @@ namespace errors = openassetio::errors;
 using HandleConverter =
     openassetio::handles::Converter<InfoDictionary, OPENASSETIO_NS(InfoDictionary_h)>;
 
+// Helper for static_assert.
+template <class... T>
+[[maybe_unused]] constexpr bool kAlwaysFalse = false;
+
+/**
+ * Wrap a callable such that some common exceptions are caught and
+ * converted to an error code.
+ *
+ * @tparam Fn Type of callable to wrap.
+ * @param err Storage for error message, if any.
+ * @param fn Callable to wrap.
+ * @return Error code.
+ */
+template <typename Fn>
+OPENASSETIO_NS(ErrorCode)
+catchCommonExceptionAsCode(OPENASSETIO_NS(StringView) * err, Fn &&fn) {
+  // TODO(DF): @exception messages.
+  return errors::catchUnknownExceptionAsCode(err, [&] {
+    try {
+      return fn();
+    } catch (const std::out_of_range &exc) {
+      // Default exception message:
+      // VS 2019: "invalid unordered_map<K, T> key"
+      // GCC 9: "_Map_base::at"
+      openassetio::assignStringView(err, "Invalid key");
+      return OPENASSETIO_NS(ErrorCode_kOutOfRange);
+    }
+  });
+}
+
 /**
  * Get a primitive value from a InfoDictionary, converting exceptions to
  * error codes.
@@ -36,16 +66,10 @@ get(OPENASSETIO_NS(StringView) * err, Type *out, OPENASSETIO_NS(InfoDictionary_h
     const OPENASSETIO_NS(ConstStringView) key) {
   const InfoDictionary *infoDictionary = HandleConverter::toInstance(handle);
 
-  return errors::catchUnknownExceptionAsCode(err, [&] {
+  return catchCommonExceptionAsCode(err, [&] {
     // TODO(DF): @exception messages.
     try {
       *out = std::get<Type>(infoDictionary->at({key.data, key.size}));
-    } catch (const std::out_of_range &exc) {
-      // Default exception message:
-      // VS 2019: "invalid unordered_map<K, T> key"
-      // GCC 9: "_Map_base::at"
-      openassetio::assignStringView(err, "Invalid key");
-      return OPENASSETIO_NS(ErrorCode_kOutOfRange);
     } catch (const std::bad_variant_access &exc) {
       // Default exception message:
       // VS 2019: "bad variant access"
@@ -109,6 +133,33 @@ OPENASSETIO_NS(InfoDictionary_s) OPENASSETIO_NS(InfoDictionary_suite)() {
 
       // dtor
       [](OPENASSETIO_NS(InfoDictionary_h) handle) { delete HandleConverter::toInstance(handle); },
+
+      // typeOf
+      [](OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(InfoDictionary_ValueType) * out,
+         OPENASSETIO_NS(InfoDictionary_h) handle, const OPENASSETIO_NS(ConstStringView) key) {
+        return catchCommonExceptionAsCode(err, [&] {
+          const InfoDictionary *infoDictionary = HandleConverter::toInstance(handle);
+
+          std::visit(
+              [&out](auto &&value) {
+                using ValueType = std::decay_t<decltype(value)>;
+                if constexpr (std::is_same_v<ValueType, openassetio::Bool>) {
+                  *out = OPENASSETIO_NS(InfoDictionary_ValueType_kBool);
+                } else if constexpr (std::is_same_v<ValueType, openassetio::Int>) {
+                  *out = OPENASSETIO_NS(InfoDictionary_ValueType_kInt);
+                } else if constexpr (std::is_same_v<ValueType, openassetio::Float>) {
+                  *out = OPENASSETIO_NS(InfoDictionary_ValueType_kFloat);
+                } else if constexpr (std::is_same_v<ValueType, openassetio::Str>) {
+                  *out = OPENASSETIO_NS(InfoDictionary_ValueType_kStr);
+                } else {
+                  static_assert(kAlwaysFalse<ValueType>, "Unhandled variant type");
+                }
+              },
+              infoDictionary->at({key.data, key.size}));
+
+          return OPENASSETIO_NS(ErrorCode_kOK);
+        });
+      },
 
       // Through the magic of template type deduction...
       // getBool

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -9,6 +9,7 @@
 namespace openassetio {
 inline namespace OPENASSETIO_VERSION {
 /**
+ * @anchor CppPrimitiveTypes
  * @name Primitive Types
  *
  * These types are used throughout OpenAssetIO, especially within

--- a/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
+++ b/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
@@ -114,6 +114,102 @@ struct InfoDictionaryFixture {
 };
 
 /**
+ * Fixture for `typeOf` function, specialised by entry data type.
+ *
+ * @tparam Value Type of entry in InfoDictionary.
+ */
+template <typename Value>
+struct SuiteTypeOfFixture;
+
+template <>
+struct SuiteTypeOfFixture<openassetio::Bool> : InfoDictionaryFixture {
+  inline static const openassetio::Str kKeyStr = kBoolKey;
+  static constexpr OPENASSETIO_NS(InfoDictionary_ValueType)
+      kExpectedValueType = OPENASSETIO_NS(InfoDictionary_ValueType_kBool);
+};
+
+template <>
+struct SuiteTypeOfFixture<openassetio::Int> : InfoDictionaryFixture {
+  inline static const openassetio::Str kKeyStr = kIntKey;
+  static constexpr OPENASSETIO_NS(InfoDictionary_ValueType)
+      kExpectedValueType = OPENASSETIO_NS(InfoDictionary_ValueType_kInt);
+};
+
+template <>
+struct SuiteTypeOfFixture<openassetio::Float> : InfoDictionaryFixture {
+  inline static const openassetio::Str kKeyStr = kFloatKey;
+  static constexpr OPENASSETIO_NS(InfoDictionary_ValueType)
+      kExpectedValueType = OPENASSETIO_NS(InfoDictionary_ValueType_kFloat);
+};
+
+template <>
+struct SuiteTypeOfFixture<openassetio::Str> : InfoDictionaryFixture {
+  inline static const openassetio::Str kKeyStr = kStrKey;
+  static constexpr OPENASSETIO_NS(InfoDictionary_ValueType)
+      kExpectedValueType = OPENASSETIO_NS(InfoDictionary_ValueType_kStr);
+};
+
+TEMPLATE_TEST_CASE_METHOD(SuiteTypeOfFixture,
+                          "Retrieving the type of an entry in a InfoDictionary via C API", "",
+                          openassetio::Bool, openassetio::Int, openassetio::Float,
+                          openassetio::Str) {
+  GIVEN("a populated C++ InfoDictionary and its C handle and suite") {
+    using Fixture = SuiteTypeOfFixture<TestType>;
+    const auto& suite = Fixture::suite_;
+    const auto& infoDictionaryHandle = Fixture::infoDictionaryHandle_;
+    const auto& keyStr = Fixture::kKeyStr;
+    const auto& expectedValueType = Fixture::kExpectedValueType;
+
+    // Storage for error messages coming from suite functions.
+    openassetio::Str errStorage(kStrStorageCapacity, '\0');
+    OPENASSETIO_NS(StringView) actualErrorMsg{errStorage.size(), errStorage.data(), 0};
+
+    WHEN("the type of an entry is queried") {
+      OPENASSETIO_NS(ConstStringView) key{keyStr.data(), keyStr.size()};
+      OPENASSETIO_NS(InfoDictionary_ValueType) actualValueType;
+
+      OPENASSETIO_NS(ErrorCode)
+      actualErrorCode = suite.typeOf(&actualErrorMsg, &actualValueType, infoDictionaryHandle, key);
+
+      THEN("returned type matches expected type") {
+        CHECK(actualErrorCode == OPENASSETIO_NS(ErrorCode_kOK));
+        CHECK(actualValueType == expectedValueType);
+      }
+    }
+  }
+}
+
+SCENARIO("Attempting to retrieve the type of a non-existent InfoDictionary entry via C API") {
+  GIVEN("a populated C++ InfoDictionary and its C handle and suite") {
+    InfoDictionaryFixture fixture{};
+    const auto& suite = fixture.suite_;
+    const auto& infoDictionaryHandle = fixture.infoDictionaryHandle_;
+
+    WHEN("the type of a non-existent entry is queried") {
+      // Key to non-existent entry.
+      const auto& nonExistentKey = InfoDictionaryFixture::kNonExistentKeyStr;
+      OPENASSETIO_NS(ConstStringView) key{nonExistentKey.data(), nonExistentKey.size()};
+      // Storage for error message.
+      openassetio::Str errStorage(kStrStorageCapacity, '\0');
+      OPENASSETIO_NS(StringView) actualErrorMsg{errStorage.size(), errStorage.data(), 0};
+      // Initial value of storage for return value.
+      const OPENASSETIO_NS(InfoDictionary_ValueType) initialValueType{};
+      // Storage for return value.
+      OPENASSETIO_NS(InfoDictionary_ValueType) actualValueType = initialValueType;
+
+      OPENASSETIO_NS(ErrorCode)
+      actualErrorCode = suite.typeOf(&actualErrorMsg, &actualValueType, infoDictionaryHandle, key);
+
+      THEN("error code and message is set") {
+        CHECK(actualErrorCode == OPENASSETIO_NS(ErrorCode_kOutOfRange));
+        CHECK(actualErrorMsg == "Invalid key");
+        CHECK(actualValueType == initialValueType);
+      }
+    }
+  }
+}
+
+/**
  * Fixture for a specific suite accessor function, specialised by return
  * data type.
  *

--- a/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
+++ b/tests/openassetio-core-c/private/InfoDictionaryTest.cpp
@@ -209,6 +209,42 @@ SCENARIO("Attempting to retrieve the type of a non-existent InfoDictionary entry
   }
 }
 
+SCENARIO("Retrieve the number of entries in a InfoDictionary via C API") {
+  GIVEN("a populated C++ InfoDictionary and its C handle and suite") {
+    InfoDictionaryFixture fixture{};
+    const auto& suite = fixture.suite_;
+    auto& infoDictionary = fixture.infoDictionary_;
+    const auto& infoDictionaryHandle = fixture.infoDictionaryHandle_;
+
+    const auto& nonExistentKey = InfoDictionaryFixture::kNonExistentKeyStr;
+
+    WHEN("the size of the map is queried") {
+      const std::size_t actualSize = suite.size(infoDictionaryHandle);
+
+      THEN("size is as expected") {
+        const std::size_t expectedSize = infoDictionary.size();
+        CHECK(actualSize == expectedSize);
+      }
+
+      AND_WHEN("an entry is added to the InfoDictionary") {
+        constexpr openassetio::Int kNewValue{123};
+        infoDictionary[nonExistentKey] = kNewValue;
+
+        AND_WHEN("the size of the map is queried") {
+          const std::size_t actualUpdatedSize = suite.size(infoDictionaryHandle);
+
+          THEN("size is as expected") {
+            const std::size_t expectedUpdatedSize = infoDictionary.size();
+
+            CHECK(actualUpdatedSize == actualSize + 1);
+            CHECK(actualUpdatedSize == expectedUpdatedSize);
+          }
+        }
+      }
+    }
+  }
+}
+
 /**
  * Fixture for a specific suite accessor function, specialised by return
  * data type.


### PR DESCRIPTION
Part of https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/290. 

Add introspection functions allowing 
* The number of entries currently in the container.
* The type of an existing entry to be queried, so that the correct accessor function can be chosen.