### PR TITLE
[Core] Migrate `ManagerInterface` `info` method to C++

### DIFF
--- a/doc/src/Examples.dox
+++ b/doc/src/Examples.dox
@@ -109,9 +109,8 @@
  *
  * The API middleware provides assorted short-circuit validation
  * optimisations that can reduce the number of inter-language hops
- * required. See @ref
- * openassetio.managerAPI.ManagerInterface.ManagerInterface.info
- * "ManagerInterface.info" and the `kField_EntityReferencesMatchPrefix`
+ * required. See @fqref{managerAPI::ManagerInterface::info}
+ * "ManagerInterface::info" and the `kField_EntityReferencesMatchPrefix`
  * key.
  *
  * @code{.py}

--- a/python/openassetio/hostAPI/ManagerFactoryInterface.py
+++ b/python/openassetio/hostAPI/ManagerFactoryInterface.py
@@ -58,8 +58,8 @@ class ManagerFactoryInterface(object, metaclass=abc.ABCMeta):
             use.
             @li **identifier** It's identifier
             @li **info** The info dict from the Manager (see:
-            @ref openassetio.managerAPI.ManagerInterface.ManagerInterface.info
-            "ManagerInterface.info")
+            @fqref{managerAPI::ManagerInterface::info}
+            "ManagerInterface::info")
             @li **plugin** The plugin class that represents the Manager
             (see: @ref openassetio.pluginSystem.ManagerPlugin "ManagerPlugin")
         """

--- a/python/openassetio/managerAPI/ManagerInterface.py
+++ b/python/openassetio/managerAPI/ManagerInterface.py
@@ -148,7 +148,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
 
        @li @needsref identifier()
        @li @needsref displayName()
-       @li @ref info()
+       @li @needsref info()
        @li @ref updateTerminology()
        @li @ref getSettings()
        @li @ref setSettings()
@@ -199,40 +199,6 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
     # asset_management_system itself.
     #
     # @{
-
-    def info(self):
-        """
-        Returns other information that may be useful about this @ref
-        asset_management_system. This can contain arbitrary key/value
-        pairs. For example:
-
-            { 'version' : '1.1v3', 'server' : 'assets.openassetio.org' }
-
-        @note Keys should always be strings, and values must be
-        plain-old-data types (ie: str, int, float, bool).
-
-        There are certain optional keys that may be used by a host or
-        the API:
-
-          @li openassetio.constants.kField_SmallIcon (upto 32x32)
-          @li openassetio.constants.kField_Icon (any size)
-
-        Because it can often be expensive to bridge between languages,
-        info can also contain an additional field - a prefix that
-        identifies a string as a valid entity reference. If supplied,
-        this will be used by the API to optimize calls to
-        isEntityReference when bridging between C/Python etc.
-        If this isn't supplied, then isEntityReference will always be
-        called to determine if a string is an @ref entity_reference or
-        not. Note, not all invocations require this optimization, so
-        @ref isEntityReference should be implemented regardless.
-
-          @li openassetio.constants.kField_EntityReferencesMatchPrefix
-
-        @note Keys should always be strings, and values must be
-        plain-old-data types (ie: str, int, float, bool).
-        """
-        return {}
 
     def updateTerminology(self, stringDict, hostSession):
         """
@@ -305,7 +271,7 @@ class ManagerInterface(_openassetio.managerAPI.ManagerInterface):
 
          @li @needsref identifier()
          @li @needsref displayName()
-         @li @ref info()
+         @li @needsref info()
          @li @ref updateTerminology()
          @li @ref getSettings()
          @li @ref setSettings()

--- a/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
+++ b/python/openassetio/pluginSystem/PluginSystemManagerFactory.py
@@ -95,9 +95,9 @@ class PluginSystemManagerFactory(ManagerFactoryInterface):
           @li **name** The display name of the Manager suitable for UI
           use.
           @li **identifier** It's identifier
-          @li **info** The info dict from the Manager (see: @ref
-          openassetio.managerAPI.ManagerInterface.ManagerInterface.info
-          "ManagerInterface.info")
+          @li **info** The info dict from the Manager (see:
+          @fqref{managerAPI::ManagerInterface::info}
+          "ManagerInterface::info")
           @li **plugin** The plugin class that represents the Manager
           (see: @ref openassetio.pluginSystem.ManagerPlugin
           "ManagerPlugin")

--- a/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
+++ b/src/openassetio-core-c/include/openassetio/c/InfoDictionary.h
@@ -28,10 +28,6 @@ extern "C" {
 /**
  * Opaque handle type representing a @fqref{InfoDictionary}
  * "InfoDictionary" instance.
- *
- * The ownership semantics of this handle are "owned by client", that
- * is, the caller of the C API is responsible for deallocating using
- * the C API `dtor` function once the InfoDictionary is no longer in use.
  */
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct OPENASSETIO_NS(InfoDictionary_t) * OPENASSETIO_NS(InfoDictionary_h);

--- a/src/openassetio-core-c/include/openassetio/c/managerAPI/ManagerInterface.h
+++ b/src/openassetio-core-c/include/openassetio/c/managerAPI/ManagerInterface.h
@@ -2,6 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
+#include "../InfoDictionary.h"
 #include "../StringView.h"
 #include "../errors.h"
 #include "../namespace.h"
@@ -99,6 +100,23 @@ typedef struct {
   OPENASSETIO_NS(ErrorCode)
   (*displayName)(OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
                  OPENASSETIO_NS(managerAPI_ManagerInterface_h) handle);
+
+  /**
+   * C equivalent of the
+   * @fqref{managerAPI::ManagerInterface::info} "info"
+   * member function.
+   *
+   * @param[out] err Storage for error message, if any.
+   * @param[out] out Handle to pre-existing dictionary that should be
+   * populated with entries.
+   * @param handle Opaque handle representing `ManagerInterface`
+   * instance.
+   * @return @fqcref{ErrorCode_kOK} "kOK" if no error occurred, an
+   * error code otherwise.
+   */
+  OPENASSETIO_NS(ErrorCode)
+  (*info)(OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(InfoDictionary_h) out,
+          OPENASSETIO_NS(managerAPI_ManagerInterface_h) handle);
 } OPENASSETIO_NS(managerAPI_ManagerInterface_s);
 
 /**

--- a/src/openassetio-core-c/private/managerAPI/CManagerInterface.cpp
+++ b/src/openassetio-core-c/private/managerAPI/CManagerInterface.cpp
@@ -6,6 +6,7 @@
 #include "CManagerInterface.hpp"
 
 #include "../errors.hpp"
+#include "../handles.hpp"
 
 namespace openassetio {
 inline namespace OPENASSETIO_VERSION {
@@ -59,6 +60,27 @@ Str CManagerInterface::displayName() const {
   errors::throwIfError(errorCode, errorMessage);
 
   return {out.data, out.size};
+}
+
+InfoDictionary CManagerInterface::info() const {
+  // Buffer for error message.
+  char errorMessageBuffer[kStringBufferSize];
+  // Error message.
+  OPENASSETIO_NS(StringView)
+  errorMessage{kStringBufferSize, errorMessageBuffer, 0};
+
+  // Return value.
+  InfoDictionary infoDict{};
+  auto *infoDictHandle =
+      handles::Converter<InfoDictionary, OPENASSETIO_NS(InfoDictionary_h)>::toHandle(&infoDict);
+
+  // Execute corresponding suite function.
+  const OPENASSETIO_NS(ErrorCode) errorCode = suite_.info(&errorMessage, infoDictHandle, handle_);
+
+  // Convert error code/message to exception.
+  errors::throwIfError(errorCode, errorMessage);
+
+  return infoDict;
 }
 }  // namespace managerAPI
 }  // namespace OPENASSETIO_VERSION

--- a/src/openassetio-core-c/private/managerAPI/CManagerInterface.hpp
+++ b/src/openassetio-core-c/private/managerAPI/CManagerInterface.hpp
@@ -38,6 +38,9 @@ class OPENASSETIO_CORE_C_EXPORT CManagerInterface : ManagerInterface {
   /// Wrap the C suite's `displayName` function.
   [[nodiscard]] Str displayName() const override;
 
+  /// Wrap the C suite's `info` function.
+  [[nodiscard]] InfoDictionary info() const override;
+
  private:
   /// Opaque handle representing a ManagerInterface for the C API.
   OPENASSETIO_NS(managerAPI_ManagerInterface_h) handle_;

--- a/src/openassetio-core/include/openassetio/InfoDictionary.hpp
+++ b/src/openassetio-core/include/openassetio/InfoDictionary.hpp
@@ -13,8 +13,8 @@ inline namespace OPENASSETIO_VERSION {
 /// Types available as values in a InfoDictionary.
 using InfoDictionaryValue = std::variant<Bool, Int, Float, Str>;
 /**
- * InfoDictionary type used for @needsref
- * managerAPI::ManagerInterface::info "ManagerInterface::info".
+ * Dictionary type used for @fqref{managerAPI::ManagerInterface::info}
+ * "ManagerInterface::info".
  */
 using InfoDictionary = std::unordered_map<Str, InfoDictionaryValue>;
 }  // namespace OPENASSETIO_VERSION

--- a/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <openassetio/export.h>
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/typedefs.hpp>
 
 namespace openassetio {
@@ -193,6 +194,35 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @return Manager's display name.
    */
   [[nodiscard]] virtual Str displayName() const = 0;
+
+  /**
+   * Returns other information that may be useful about this @ref
+   * asset_management_system. This can contain arbitrary key/value
+   * pairs. For example:
+   *
+   *     { 'version' : '1.1v3', 'server' : 'assets.openassetio.org' }
+   *
+   * There are certain optional keys that may be used by a host or
+   * the API:
+   *
+   *   @li openassetio.constants.kField_SmallIcon (upto 32x32)
+   *   @li openassetio.constants.kField_Icon (any size)
+   *
+   * Because it can often be expensive to bridge between languages,
+   * info can also contain an additional field - a prefix that
+   * identifies a string as a valid entity reference. If supplied,
+   * this will be used by the API to optimize calls to
+   * isEntityReference when bridging between C/Python etc.
+   * If this isn't supplied, then isEntityReference will always be
+   * called to determine if a string is an @ref entity_reference or
+   * not. Note, not all invocations require this optimization, so
+   * @needsref isEntityReference should be implemented regardless.
+   *
+   *   @li openassetio.constants.kField_EntityReferencesMatchPrefix
+   *
+   * @return Map of info string key to primitive value.
+   */
+  [[nodiscard]] virtual InfoDictionary info() const;
 
   /**
    * @}

--- a/src/openassetio-core/managerAPI/ManagerInterface.cpp
+++ b/src/openassetio-core/managerAPI/ManagerInterface.cpp
@@ -9,6 +9,8 @@ namespace managerAPI {
 
 ManagerInterface::ManagerInterface() = default;
 
+InfoDictionary ManagerInterface::info() const { return {}; }
+
 }  // namespace managerAPI
 }  // namespace OPENASSETIO_VERSION
 }  // namespace openassetio

--- a/src/openassetio-python/managerAPI/ManagerInterfaceBinding.cpp
+++ b/src/openassetio-python/managerAPI/ManagerInterfaceBinding.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <pybind11/stl.h>
 
+#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/managerAPI/ManagerInterface.hpp>
 #include <openassetio/typedefs.hpp>
 
@@ -24,6 +26,10 @@ struct PyManagerInterface : ManagerInterface {
   [[nodiscard]] Str displayName() const override {
     PYBIND11_OVERRIDE_PURE(Str, ManagerInterface, displayName, /* no args */);
   }
+
+  [[nodiscard]] InfoDictionary info() const override {
+    PYBIND11_OVERRIDE(InfoDictionary, ManagerInterface, info, /* no args */);
+  }
 };
 
 }  // namespace managerAPI
@@ -38,5 +44,6 @@ void registerManagerInterface(const py::module& mod) {
                                                                              "ManagerInterface")
       .def(py::init())
       .def("identifier", &ManagerInterface::identifier)
-      .def("displayName", &ManagerInterface::displayName);
+      .def("displayName", &ManagerInterface::displayName)
+      .def("info", &ManagerInterface::info);
 }

--- a/tests/openassetio-core-c/private/managerAPI/CManagerInterfaceTest.cpp
+++ b/tests/openassetio-core-c/private/managerAPI/CManagerInterfaceTest.cpp
@@ -7,6 +7,7 @@
 #include <catch2/trompeloeil.hpp>
 
 // private headers
+#include <handles.hpp>
 #include <managerAPI/CManagerInterface.hpp>
 
 namespace {
@@ -29,6 +30,9 @@ struct MockCAPI {
                                        OPENASSETIO_NS(managerAPI_ManagerInterface_h)));
 };
 
+using HandleConverter =
+    openassetio::handles::Converter<MockCAPI, OPENASSETIO_NS(managerAPI_ManagerInterface_h)>;
+
 /**
  * Get a ManagerInterface C API function pointer suite that assumes the
  * provided `handle` is a `MockCAPI` instance.
@@ -36,19 +40,19 @@ struct MockCAPI {
 OPENASSETIO_NS(managerAPI_ManagerInterface_s) getSuite() {
   return {// dtor
           [](OPENASSETIO_NS(managerAPI_ManagerInterface_h) h) {
-            auto *api = reinterpret_cast<MockCAPI *>(h);
+            auto *api = HandleConverter::toInstance(h);
             api->dtor(h);
           },
           // identifier
           [](OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
              OPENASSETIO_NS(managerAPI_ManagerInterface_h) h) {
-            auto *api = reinterpret_cast<MockCAPI *>(h);
+            auto *api = HandleConverter::toInstance(h);
             return api->identifier(err, out, h);
           },
           // displayName
           [](OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(StringView) * out,
              OPENASSETIO_NS(managerAPI_ManagerInterface_h) h) {
-            auto *api = reinterpret_cast<MockCAPI *>(h);
+            auto *api = HandleConverter::toInstance(h);
             return api->displayName(err, out, h);
           }};
 }
@@ -58,7 +62,7 @@ SCENARIO("A CManagerInterface is destroyed") {
   GIVEN("An opaque handle and function suite") {
     MockCAPI capi;
 
-    auto *handle = reinterpret_cast<OPENASSETIO_NS(managerAPI_ManagerInterface_h)>(&capi);
+    auto *handle = HandleConverter::toHandle(&capi);
     auto const suite = getSuite();
 
     THEN("CManagerInterface's destructor calls the suite's dtor") {
@@ -73,7 +77,7 @@ SCENARIO("A host calls CManagerInterface::identifier") {
   GIVEN("A CManagerInterface wrapping an opaque handle and function suite") {
     MockCAPI capi;
 
-    auto *handle = reinterpret_cast<OPENASSETIO_NS(managerAPI_ManagerInterface_h)>(&capi);
+    auto *handle = HandleConverter::toHandle(&capi);
     auto const suite = getSuite();
 
     // Expect the destructor to be called, i.e. when cManagerInterface
@@ -141,7 +145,7 @@ SCENARIO("A host calls CManagerInterface::displayName") {
   GIVEN("A CManagerInterface wrapping an opaque handle and function suite") {
     MockCAPI capi;
 
-    auto *handle = reinterpret_cast<OPENASSETIO_NS(managerAPI_ManagerInterface_h)>(&capi);
+    auto *handle = HandleConverter::toHandle(&capi);
     auto const suite = getSuite();
 
     // Expect the destructor to be called, i.e. when cManagerInterface

--- a/tests/openassetio-core-c/private/managerAPI/CManagerInterfaceTest.cpp
+++ b/tests/openassetio-core-c/private/managerAPI/CManagerInterfaceTest.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <openassetio/c/InfoDictionary.h>
 #include <openassetio/c/errors.h>
 #include <openassetio/c/namespace.h>
 
@@ -28,6 +29,10 @@ struct MockCAPI {
   MAKE_MOCK3(displayName,
              OPENASSETIO_NS(ErrorCode)(OPENASSETIO_NS(StringView) *, OPENASSETIO_NS(StringView) *,
                                        OPENASSETIO_NS(managerAPI_ManagerInterface_h)));
+
+  MAKE_MOCK3(info, OPENASSETIO_NS(ErrorCode)(OPENASSETIO_NS(StringView) *,
+                                             OPENASSETIO_NS(InfoDictionary_h),
+                                             OPENASSETIO_NS(managerAPI_ManagerInterface_h)));
 };
 
 using HandleConverter =
@@ -54,6 +59,12 @@ OPENASSETIO_NS(managerAPI_ManagerInterface_s) getSuite() {
              OPENASSETIO_NS(managerAPI_ManagerInterface_h) h) {
             auto *api = HandleConverter::toInstance(h);
             return api->displayName(err, out, h);
+          },
+          // info
+          [](OPENASSETIO_NS(StringView) * err, OPENASSETIO_NS(InfoDictionary_h) out,
+             OPENASSETIO_NS(managerAPI_ManagerInterface_h) h) {
+            auto *api = HandleConverter::toInstance(h);
+            return api->info(err, out, h);
           }};
 }
 }  // namespace
@@ -201,6 +212,74 @@ SCENARIO("A host calls CManagerInterface::displayName") {
       WHEN("the manager's displayName is queried") {
         THEN("an exception is thrown with expected error message") {
           REQUIRE_THROWS_MATCHES(cManagerInterface.displayName(), std::runtime_error,
+                                 Catch::Message(expectedErrorCodeAndMsg));
+        }
+      }
+    }
+  }
+}
+
+SCENARIO("A host calls CManagerInterface::info") {
+  GIVEN("A CManagerInterface wrapping an opaque handle and function suite") {
+    MockCAPI capi;
+
+    auto *handle = HandleConverter::toHandle(&capi);
+    auto const suite = getSuite();
+
+    // Expect the destructor to be called, i.e. when cManagerInterface
+    // goes out of scope.
+    REQUIRE_CALL(capi, dtor(handle));
+
+    openassetio::managerAPI::CManagerInterface cManagerInterface{handle, suite};
+
+    AND_GIVEN("the C suite's info() call succeeds") {
+      const openassetio::Str expectedInfoKey = "info key";
+      const openassetio::Float expectedInfoValue = 123.456;
+
+      using trompeloeil::_;
+
+      using InfoDictHandleConverter =
+          openassetio::handles::Converter<openassetio::InfoDictionary,
+                                          OPENASSETIO_NS(InfoDictionary_h)>;
+
+      REQUIRE_CALL(capi, info(_, _, handle))
+          // Update out-parameter.
+          .LR_SIDE_EFFECT(InfoDictHandleConverter::toInstance(_2)->insert(
+              {expectedInfoKey, expectedInfoValue}))
+          // Return OK code.
+          .RETURN(OPENASSETIO_NS(ErrorCode_kOK));
+
+      WHEN("the manager's info is queried") {
+        const openassetio::InfoDictionary infoDict = cManagerInterface.info();
+
+        THEN("the returned info contains the expected entry") {
+          const auto actualInfoValue = std::get<openassetio::Float>(infoDict.at(expectedInfoKey));
+          CHECK(actualInfoValue == expectedInfoValue);
+        }
+      }
+    }
+
+    AND_GIVEN("the C suite's info() call fails") {
+      const std::string_view expectedErrorMsg = "some error happened";
+      const auto expectedErrorCode = OPENASSETIO_NS(ErrorCode_kUnknown);
+      const openassetio::Str expectedErrorCodeAndMsg = "1: some error happened";
+
+      using trompeloeil::_;
+
+      // Check that `info` is called properly and update error
+      // message out-parameter.
+      REQUIRE_CALL(capi, info(_, _, handle))
+          // Ensure max size is reasonable.
+          .LR_WITH(_1->capacity == kStringBufferSize)
+          // Update StringView error message out-parameter.
+          .LR_SIDE_EFFECT(strncpy(_1->data, expectedErrorMsg.data(), expectedErrorMsg.size()))
+          .LR_SIDE_EFFECT(_1->size = expectedErrorMsg.size())
+          // Return OK code.
+          .RETURN(expectedErrorCode);
+
+      WHEN("the manager's info is queried") {
+        THEN("an exception is thrown with expected error message") {
+          REQUIRE_THROWS_MATCHES(cManagerInterface.info(), std::runtime_error,
                                  Catch::Message(expectedErrorCodeAndMsg));
         }
       }

--- a/tests/python/openassetio/managerAPI/test_managerinterface.py
+++ b/tests/python/openassetio/managerAPI/test_managerinterface.py
@@ -50,6 +50,20 @@ class Test_ManagerInterface_displayName:
         assert manager_interface.displayName() == "Stub Manager"
 
 
+class Test_ManagerInterface_info:
+    def test_when_not_overridden_then_returns_empty_dict(self):
+        info = ManagerInterface().info()
+
+        assert isinstance(info, dict)
+        assert info == {}
+
+    def test_when_overridden_then_returns_expected_dict(self, manager_interface):
+        info = manager_interface.info()
+
+        assert isinstance(info, dict)
+        assert info == {"stub": "info"}
+
+
 class Test_ManagerInterface_defaultEntityReference:
     def test_when_given_single_trait_set_then_returns_single_empty_ref(self, manager_interface):
         refs = manager_interface.defaultEntityReference([()], Mock(), Mock())
@@ -102,6 +116,9 @@ class StubManagerInterface(ManagerInterface):
 
     def displayName(self):
         return "Stub Manager"
+
+    def info(self):
+        return {"stub": "info"}
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #290. Migrate `info` method from Python to C++ with Python binding, and add its C API.