### PR TITLE
[Core] Minimal Manager C++ implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,5 +33,9 @@ function-rgx = "(_|test_)?[a-z0-9]+([A-Z][a-z0-9]*)*"
 const-rgx = "k([A-Z0-9]+[a-z0-9]*)+_?([A-Z0-9]+[a-z0-9]*)*"
 class-const-rgx = "k([A-Z0-9]+[a-z0-9]*)+_?([A-Z0-9]+[a-z0-9]*)*"
 
+[tool.pylint.similarities]
+# Ignore imports when computing similarities.
+ignore-imports = true
+
 [tool.black]
 line-length = 99

--- a/python/openassetio/__init__.py
+++ b/python/openassetio/__init__.py
@@ -70,11 +70,11 @@ API documentation
 The documentation for OpenAssetIO can be found here:
    https://thefoundryvisionmongers.github.io/OpenAssetIO.
 """
-# TODO(DF): @pylint - re-enable once Python dev vs. install mess sorted.
-from ._openassetio import *  # pylint: disable=import-error
 # Temporarily hoist the C++ class into the top level name space,
 # until this is done in the module itself.
-Specification = specification.Specification  # pylint: disable=undefined-variable
+# TODO(DF): @pylint
+from ._openassetio import specification  # pylint: disable=import-error
+Specification = specification.Specification
 
 # pylint: disable=wrong-import-position
 from .Context import Context

--- a/python/openassetio/hostAPI/Manager.py
+++ b/python/openassetio/hostAPI/Manager.py
@@ -24,7 +24,7 @@ A single-class module, providing the Manager class.
 # implementations more complicated.
 # pylint: disable=too-many-public-methods
 
-from ..managerAPI.ManagerInterface import ManagerInterface
+from openassetio import _openassetio  # pylint: disable=no-name-in-module
 
 from .._core.debug import debugApiCall, Debuggable
 from .._core.audit import auditApiCall
@@ -33,7 +33,7 @@ from .._core.audit import auditApiCall
 __all__ = ['Manager']
 
 
-class Manager(Debuggable):
+class Manager(_openassetio.hostAPI.Manager, Debuggable):
     """
     The Manager is the Host facing representation of an @ref
     asset_management_system. The Manager class shouldn't be directly
@@ -41,7 +41,7 @@ class Manager(Debuggable):
     asset management system can be retrieved from an API @ref Session,
     using the @ref openassetio.hostAPI.Session.Session.currentManager
     "Session.currentManager" method, after configuring the session with
-    the appropriate manager @ref identifier.
+    the appropriate manager @needsref identifier.
 
     @code
     session = openassetio.hostAPI.Session(
@@ -73,13 +73,9 @@ class Manager(Debuggable):
         @param hostSession openassetio.managerAPI.HostSession the host
         session the manager is part of.
         """
-        super(Manager, self).__init__()
 
-        if not isinstance(interfaceInstance, ManagerInterface):
-            raise ValueError(
-                ("A manager can only be instantiated with a " +
-                 "instance of the ManagerInterface or a derived class (%s)")
-                % type(interfaceInstance))
+        _openassetio.hostAPI.Manager .__init__(self, interfaceInstance)
+        Debuggable.__init__(self)
 
         self.__impl = interfaceInstance
         self.__hostSession = hostSession
@@ -104,63 +100,6 @@ class Manager(Debuggable):
     # initialize has been called.
     #
     # @{
-
-    @debugApiCall
-    @auditApiCall("Manager methods")
-    def identifier(self):
-        """
-        Returns an identifier to uniquely identify the Manager. This
-        identifier is used with the Session class to select which
-        Manager to initialize, and so can be used as in preferences
-        etc... to persist the chosen Manager. The identifier will use
-        only alpha-numeric characters and '.', '_' or '-'. They
-        generally follow the 'reverse-DNS' style, for example:
-
-            "org.openassetio.manager.test"
-
-        @return `str`
-        """
-        return self.__impl.identifier()
-
-    @debugApiCall
-    @auditApiCall("Manager methods")
-    def displayName(self):
-        """
-        Returns a human readable name to be used to reference this
-        specific asset manager in user-facing displays.
-        For example:
-
-            "OpenAssetIO Test Manager"
-
-        @return `str`
-        """
-        return self.__impl.displayName()
-
-    @debugApiCall
-    @auditApiCall("Manager methods")
-    def info(self):
-        """
-        Returns other information that may be useful about this @ref
-        asset_management_system.  This can contain arbitrary key/value
-        pairs.For example:
-
-            { 'version' : '1.1v3', 'server' : 'assets.openassetio.org' }
-
-        There is no requirement to use any of the information in the
-        info dict, but it may be useful for optimisations or display
-        customisation.
-
-        There are certain well-known keys that may be set by the
-        Manager. They include things such as:
-
-          @li openassetio.constants.kField_SmallIcon (upto 32x32)
-          @li openassetio.constants.kField_Icon (any size)
-          @li openassetio.constants.kField_EntityReferencesMatchPrefix
-
-        Keys will always be str, and Values will be int, bool, float or
-        str.
-        """
-        return self.__impl.info()
 
     @debugApiCall
     @auditApiCall("Manager methods")

--- a/src/openassetio-core/CMakeLists.txt
+++ b/src/openassetio-core/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 target_sources(
     openassetio-core
     PRIVATE
+    hostAPI/Manager.cpp
     managerAPI/ManagerInterface.cpp
     specification/Specification.cpp
 )

--- a/src/openassetio-core/hostAPI/Manager.cpp
+++ b/src/openassetio-core/hostAPI/Manager.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <openassetio/hostAPI/Manager.hpp>
+#include <openassetio/managerAPI/ManagerInterface.hpp>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+namespace hostAPI {
+
+Manager::Manager(managerAPI::ManagerInterfacePtr managerInterface)
+    : managerInterface_{std::move(managerInterface)} {}
+
+Str Manager::identifier() const { return managerInterface_->identifier(); }
+Str Manager::displayName() const { return managerInterface_->displayName(); }
+InfoDictionary Manager::info() const { return managerInterface_->info(); }
+
+}  // namespace hostAPI
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostAPI/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostAPI/Manager.hpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <openassetio/export.h>
+#include <openassetio/managerAPI/ManagerInterface.hpp>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_VERSION {
+/**
+ This namespace contains code relevant to anyone wanting to add support
+ for a host application.
+
+ If you are a asset management system developer, see @ref managerAPI.
+*/
+namespace hostAPI {
+/**
+ * The Manager is the Host facing representation of an @ref
+ * asset_management_system. The Manager class shouldn't be directly
+ * constructed by the host.  An instance of the class for any given
+ * asset management system can be retrieved from an API @needsref
+ * Session, using the @ref
+ * openassetio.hostAPI.Session.Session.currentManager
+ * "Session.currentManager" method, after configuring the session with
+ * the appropriate manager @ref identifier.
+ *
+ * @code
+ * session = openassetio.hostAPI.Session(
+ *     hostImpl, consoleLogger, pluginFactory)
+ * session.useManager("org.openassetio.test")
+ * manager = session.currentManager()
+ * @endcode
+ *
+ * A Manager instance is the single point of interaction with an asset
+ * management system. It provides methods to uniquely identify the
+ * underlying implementation, querying and resolving @ref
+ * entity_reference "entity references" and publishing new data.
+ *
+ * The Manager API is threadsafe and can be called from multiple
+ * threads concurrently.
+ */
+class OPENASSETIO_CORE_EXPORT Manager {
+ public:
+  explicit Manager(managerAPI::ManagerInterfacePtr managerInterface);
+
+  /**
+   * @name Asset Management System Information
+   *
+   * These functions provide general information about the @ref
+   * asset_management_system itself. These can all be called before
+   * @needsref initialize has been called.
+   *
+   * @{
+   */
+
+  /**
+   * Returns an identifier to uniquely identify the Manager.
+   *
+   * This identifier is used with the Session class to select which
+   * Manager to initialize, and so can be used as in preferences etc...
+   * to persist the chosen Manager. The identifier will use only
+   * alpha-numeric characters and '.', '_' or '-'. They generally follow
+   * the 'reverse-DNS' style, for example:
+   *
+   *     "org.openassetio.manager.test"
+   */
+  [[nodiscard]] Str identifier() const;
+
+  /**
+   * Returns a human readable name to be used to reference this
+   * specific asset manager in user-facing displays.
+   * For example:
+   *
+   *     "OpenAssetIO Test Manager"
+   */
+  [[nodiscard]] Str displayName() const;
+
+  /**
+   * Returns other information that may be useful about this @ref
+   * asset_management_system.  This can contain arbitrary key/value
+   * pairs.For example:
+   *
+   *     { 'version' : '1.1v3', 'server' : 'assets.openassetio.org' }
+   *
+   * There is no requirement to use any of the information in the
+   * info dict, but it may be useful for optimisations or display
+   * customisation.
+   *
+   * There are certain well-known keys that may be set by the
+   * Manager. They include things such as
+   * openassetio.constants.kField_EntityReferencesMatchPrefix.
+   */
+  [[nodiscard]] InfoDictionary info() const;
+
+  /**
+   * @}
+   */
+
+ private:
+  managerAPI::ManagerInterfacePtr managerInterface_;
+};
+
+}  // namespace hostAPI
+}  // namespace OPENASSETIO_VERSION
+}  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerAPI/ManagerInterface.hpp
@@ -229,6 +229,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    */
 };
 
+using ManagerInterfacePtr = SharedPtr<ManagerInterface>;
 }  // namespace managerAPI
 }  // namespace OPENASSETIO_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/typedefs.hpp
+++ b/src/openassetio-core/include/openassetio/typedefs.hpp
@@ -2,6 +2,7 @@
 // Copyright 2013-2022 The Foundry Visionmongers Ltd
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include <openassetio/export.h>
@@ -43,5 +44,8 @@ using Str = std::string;
 /**
  * @}
  */
+
+template <class T>
+using SharedPtr = std::shared_ptr<T>;
 }  // namespace OPENASSETIO_VERSION
 }  // namespace openassetio

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(
     openassetio-python
     PRIVATE
     _openassetio.cpp
+    hostAPI/ManagerBinding.cpp
     managerAPI/ManagerInterfaceBinding.cpp
     specification/SpecificationBinding.cpp
 )

--- a/src/openassetio-python/_openassetio.cpp
+++ b/src/openassetio-python/_openassetio.cpp
@@ -6,9 +6,19 @@
 PYBIND11_MODULE(_openassetio, mod) {
   namespace py = pybind11;
 
+  // Note: the `register` functions here should be called in dependency
+  // order. E.g. `Manager` depends on `ManagerInterface`, so
+  // `registerManagerInterface` should be called first. This is so
+  // pybind11 will properly report type names in its docstring/error
+  // output.
+
   py::module managerAPI = mod.def_submodule("managerAPI");
 
   registerManagerInterface(managerAPI);
+
+  py::module hostAPI = mod.def_submodule("hostAPI");
+
+  registerManager(hostAPI);
 
   py::module specification = mod.def_submodule("specification");
 

--- a/src/openassetio-python/_openassetio.hpp
+++ b/src/openassetio-python/_openassetio.hpp
@@ -9,6 +9,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include <openassetio/typedefs.hpp>
+
 /// Concise pybind alias.
 namespace py = pybind11;
 
@@ -20,10 +22,13 @@ namespace py = pybind11;
  * smart pointer saves many object lifetime headaches.
  */
 template <class T>
-using Holder = std::shared_ptr<T>;
+using Holder = openassetio::SharedPtr<T>;
 
 /// Register the ManagerInterface class with Python.
 void registerManagerInterface(const py::module& mod);
+
+/// Register the Manager class with Python.
+void registerManager(const py::module& mod);
 
 /// Register the base specification class with Python.
 void registerSpecification(const py::module& mod);

--- a/src/openassetio-python/hostAPI/ManagerBinding.cpp
+++ b/src/openassetio-python/hostAPI/ManagerBinding.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2022 The Foundry Visionmongers Ltd
+#include <pybind11/stl.h>
+
+#include <openassetio/hostAPI/Manager.hpp>
+
+#include "../_openassetio.hpp"
+
+void registerManager(const py::module& mod) {
+  using openassetio::hostAPI::Manager;
+  using openassetio::managerAPI::ManagerInterfacePtr;
+
+  // Manager wrapper is cheap and has no independent shared state, so
+  // no need for a `shared_ptr` holder.
+  py::class_<Manager>(mod, "Manager")
+      .def(py::init<ManagerInterfacePtr>(), py::arg("managerInterface").none(false))
+      .def("identifier", &Manager::identifier)
+      .def("displayName", &Manager::displayName)
+      .def("info", &Manager::info);
+}

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -292,6 +292,26 @@ class Test_Manager_identifier:
         method.assert_called_once_with()
 
 
+class Test_Manager_displayName:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface):
+
+        method = mock_manager_interface.displayName
+        assert manager.displayName() == method.return_value
+        method.assert_called_once_with()
+
+
+class Test_Manager_info:
+
+    def test_wraps_the_corresponding_method_of_the_held_interface(
+            self, manager, mock_manager_interface):
+
+        method = mock_manager_interface.info
+        assert manager.info() == method.return_value
+        method.assert_called_once_with()
+
+
 class Test_Manager_updateTerminology:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -119,8 +119,7 @@ class ValidatingMockManagerInterface(ManagerInterface):
     def thawState(self, token, hostSession):
         return mock.DEFAULT
 
-    @staticmethod
-    def identifier():
+    def identifier(self):
         return mock.DEFAULT
 
     def displayName(self):

--- a/tests/python/openassetio/hostAPI/test_manager.py
+++ b/tests/python/openassetio/hostAPI/test_manager.py
@@ -21,205 +21,16 @@ Tests that cover the openassetio.hostAPI.Manager wrapper class.
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
-import inspect
 from unittest import mock
 
 import pytest
 
 from openassetio import Context, Specification
 from openassetio.hostAPI import Manager
-from openassetio.managerAPI import HostSession, ManagerInterface
+from openassetio.managerAPI import HostSession
 
 
 ## @todo Remove comments regarding Entity methods when splitting them from core API
-
-
-class ValidatingMockManagerInterface(ManagerInterface):
-    """
-    `ManagerInterface` implementation that asserts parameter types.
-
-    Using this (wrapped in a mock) then allows us to update the API
-    test-first, i.e. provide a failing test that gives a starting point
-    for TDD.
-
-    @see mock_manager_interface
-    """
-
-    # pylint: disable=too-many-public-methods,too-many-arguments
-
-    def info(self):
-        return mock.DEFAULT
-
-    def updateTerminology(self, stringDict, hostSession):
-        return mock.DEFAULT
-
-    def getSettings(self, hostSession):
-        return mock.DEFAULT
-
-    def setSettings(self, settings, hostSession):
-        return mock.DEFAULT
-
-    def prefetch(self, entityRefs, context, hostSession):
-        return mock.DEFAULT
-
-    def flushCaches(self, hostSession):
-        return mock.DEFAULT
-
-    def defaultEntityReference(self, traitSets, context, hostSession):
-        self.__assertIsIterableOf(traitSets, set)
-        for traitSet in traitSets:
-            self.__assertIsIterableOf(traitSet, str)
-        self.__assertCallingContext(context, hostSession)
-        return mock.DEFAULT
-
-    def entityVersion(self, entityRefs, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
-        self.__assertCallingContext(context, hostSession)
-        return mock.DEFAULT
-
-    def entityVersions(
-            self, entityRefs, context, hostSession, includeMetaVersions=False, maxNumVersions=-1):
-        self.__assertIsIterableOf(entityRefs, str)
-        self.__assertCallingContext(context, hostSession)
-        assert isinstance(includeMetaVersions, bool)
-        assert isinstance(maxNumVersions, int)
-        return mock.DEFAULT
-
-    def finalizedEntityVersion(self, entityRefs, context, hostSession, overrideVersionName=None):
-        self.__assertIsIterableOf(entityRefs, str)
-        self.__assertCallingContext(context, hostSession)
-        assert isinstance(overrideVersionName, str) or overrideVersionName is None
-        return mock.DEFAULT
-
-    def setRelatedReferences(
-            self, entityRef, relationshipSpec, relatedRefs, context, hostSession, append=True):
-        return mock.DEFAULT
-
-    def preflight(self, targetEntityRefs, traitSet, context, hostSession):
-        self.__assertIsIterableOf(targetEntityRefs, str)
-        self.__assertIsIterableOf(traitSet, str)
-        self.__assertCallingContext(context, hostSession)
-        return mock.DEFAULT
-
-    def createState(self, hostSession, parentState=None):
-        return mock.DEFAULT
-
-    def startTransaction(self, state, hostSession):
-        return mock.DEFAULT
-
-    def finishTransaction(self, state, hostSession):
-        return mock.DEFAULT
-
-    def cancelTransaction(self, state, hostSession):
-        return mock.DEFAULT
-
-    def freezeState(self, state, hostSession):
-        return mock.DEFAULT
-
-    def thawState(self, token, hostSession):
-        return mock.DEFAULT
-
-    def identifier(self):
-        return mock.DEFAULT
-
-    def displayName(self):
-        return mock.DEFAULT
-
-    def initialize(self, hostSession):
-        return mock.DEFAULT
-
-    def managementPolicy(self, traitSets, context, hostSession):
-        self.__assertIsIterableOf(traitSets, set)
-        for traitSet in traitSets:
-            self.__assertIsIterableOf(traitSet, str)
-        self.__assertCallingContext(context, hostSession)
-
-        return mock.DEFAULT
-
-    def isEntityReference(self, tokens, hostSession):
-        self.__assertIsIterableOf(tokens, str)
-        assert isinstance(hostSession, HostSession)
-        return mock.DEFAULT
-
-    def entityExists(self, entityRefs, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
-        self.__assertCallingContext(context, hostSession)
-        return mock.DEFAULT
-
-    def resolve(self, entityRefs, traitSet, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
-        self.__assertIsIterableOf(traitSet, str)
-        self.__assertCallingContext(context, hostSession)
-        return mock.DEFAULT
-
-    def entityName(self, entityRefs, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
-        self.__assertCallingContext(context, hostSession)
-        return mock.DEFAULT
-
-    def entityDisplayName(self, entityRefs, context, hostSession):
-        self.__assertIsIterableOf(entityRefs, str)
-        self.__assertCallingContext(context, hostSession)
-        return mock.DEFAULT
-
-    def getRelatedReferences(
-            self, entityRefs, relationshipSpecs, context, hostSession, resultTraitSet=None):
-        self.__assertIsIterableOf(entityRefs, str)
-        self.__assertIsIterableOf(relationshipSpecs, Specification)
-        self.__assertCallingContext(context, hostSession)
-        if resultTraitSet is not None:
-            assert isinstance(resultTraitSet, set)
-            self.__assertIsIterableOf(resultTraitSet, str)
-        return mock.DEFAULT
-
-    def register(self, targetEntityRefs, entitySpecs, context, hostSession):
-        self.__assertIsIterableOf(targetEntityRefs, str)
-        self.__assertIsIterableOf(entitySpecs, Specification)
-        self.__assertCallingContext(context, hostSession)
-        assert len(targetEntityRefs) == len(entitySpecs)
-        return mock.DEFAULT
-
-    @staticmethod
-    def __assertIsIterableOf(iterable, expectedElemType):
-        # We want to assert that `iterable` is any reasonable container.
-        # Unfortunately there doesn't seem to be a catch-all for this.
-        # E.g. if we expect a collection containing str elements, then a
-        # str itself fits this criteria since we could iterate over it
-        # and each element (character) would be a str. So just be
-        # explicit on the types that we accept.
-        assert isinstance(iterable, (list, tuple, set))
-        for elem in iterable:
-            assert isinstance(elem, expectedElemType)
-
-    @staticmethod
-    def __assertCallingContext(context, hostSession):
-        assert isinstance(context, Context)
-        assert isinstance(hostSession, HostSession)
-
-
-@pytest.fixture
-def mock_manager_interface():
-    """
-    Fixture for a mock `ManagerInterface` that asserts parameter types.
-
-    Return a mock `autospec`ed to the `ManagerInterface`, with each
-    mocked method set up to `side_effect` to the corresponding
-    method in `ValidatingMockManagerInterface`.
-
-    This then means method parameter types will be `assert`ed, whilst
-    still providing full `MagicMock` functionality.
-    """
-    interface = ValidatingMockManagerInterface()
-    mockInterface = mock.create_autospec(spec=interface, spec_set=True)
-    # Set the `side_effect` of each mocked method to call through to
-    # the concrete instance.
-    methods = inspect.getmembers(interface, predicate=inspect.ismethod)
-    for name, method in methods:
-        if not name.startswith("__"):  # Ignore private/magic methods.
-            getattr(mockInterface, name).side_effect = method
-
-    return mockInterface
-
 
 @pytest.fixture
 def host_session():
@@ -281,15 +92,46 @@ class Test_Manager_init:
         a_manager = Manager(mock_manager_interface, host_session)
         assert a_manager._interface() is mock_manager_interface
 
+    def test_when_constructed_with_ManagerInterface_as_None_then_raises_TypeError(
+            self, host_session):
+        with pytest.raises(TypeError) as err:
+            Manager(None, host_session)
+
+        assert str(err.value) == (
+            '__init__(): incompatible constructor arguments. The following argument types '
+            'are supported:\n'
+            '    1. openassetio._openassetio.hostAPI.Manager(managerInterface: '
+            'openassetio._openassetio.managerAPI.ManagerInterface)\n'
+            '\n'
+            'Invoked with: None')
+
 
 class Test_Manager_identifier:
 
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface):
+        expected = "stub.manager"
+        mock_manager_interface.mock.identifier.return_value = expected
 
-        method = mock_manager_interface.identifier
-        assert manager.identifier() == method.return_value
-        method.assert_called_once_with()
+        actual = manager.identifier()
+
+        assert actual == expected
+
+    def test_when_interface_provides_wrong_type_then_raises_RuntimeError(
+            self, manager, mock_manager_interface):
+
+        mock_manager_interface.mock.identifier.return_value = 123
+
+        with pytest.raises(RuntimeError) as err:
+            manager.identifier()
+
+        # Pybind error messages vary between release and debug mode:
+        # "Unable to cast Python instance of type <class 'int'> to C++
+        # type 'std::string'"
+        # vs.
+        # "Unable to cast Python instance to C++ type (compile in debug
+        # mode for details)"
+        assert str(err.value).startswith("Unable to cast Python instance")
 
 
 class Test_Manager_displayName:
@@ -297,9 +139,23 @@ class Test_Manager_displayName:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface):
 
-        method = mock_manager_interface.displayName
-        assert manager.displayName() == method.return_value
-        method.assert_called_once_with()
+        expected = "stub.manager"
+        mock_manager_interface.mock.displayName.return_value = expected
+
+        actual = manager.displayName()
+
+        assert actual == expected
+
+    def test_when_interface_provides_wrong_type_then_raises_RuntimeError(
+            self, manager, mock_manager_interface):
+
+        mock_manager_interface.mock.displayName.return_value = 123
+
+        with pytest.raises(RuntimeError) as err:
+            manager.displayName()
+
+        # Note: pybind error messages vary between release and debug mode.
+        assert str(err.value).startswith("Unable to cast Python instance")
 
 
 class Test_Manager_info:
@@ -307,9 +163,23 @@ class Test_Manager_info:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface):
 
-        method = mock_manager_interface.info
-        assert manager.info() == method.return_value
-        method.assert_called_once_with()
+        expected = {"an int": 123}
+        mock_manager_interface.mock.info.return_value = expected
+
+        actual = manager.info()
+
+        assert actual == expected
+
+    def test_when_interface_provides_wrong_type_then_raises_RuntimeError(
+            self, manager, mock_manager_interface):
+
+        mock_manager_interface.mock.info.return_value = {123: 123}
+
+        with pytest.raises(RuntimeError) as err:
+            manager.info()
+
+        # Note: pybind error messages vary between release and debug mode.
+        assert str(err.value).startswith("Unable to cast Python instance")
 
 
 class Test_Manager_updateTerminology:
@@ -317,7 +187,7 @@ class Test_Manager_updateTerminology:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session):
 
-        method = mock_manager_interface.updateTerminology
+        method = mock_manager_interface.mock.updateTerminology
         a_dict = {"k", "v"}
         assert manager.updateTerminology(a_dict) is a_dict
         method.assert_called_once_with(a_dict, host_session)
@@ -328,7 +198,7 @@ class Test_Manager_getSettings:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session):
 
-        method = mock_manager_interface.getSettings
+        method = mock_manager_interface.mock.getSettings
         assert manager.getSettings() == method.return_value
         method.assert_called_once_with(host_session)
 
@@ -338,7 +208,7 @@ class Test_Manager_setSettings:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session):
 
-        method = mock_manager_interface.setSettings
+        method = mock_manager_interface.mock.setSettings
         a_dict = {"k", "v"}
         assert manager.setSettings(a_dict) == method.return_value
         method.assert_called_once_with(a_dict, host_session)
@@ -349,7 +219,7 @@ class Test_Manager_initialize:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session):
 
-        method = mock_manager_interface.initialize
+        method = mock_manager_interface.mock.initialize
         assert manager.initialize() == method.return_value
         method.assert_called_once_with(host_session)
 
@@ -359,7 +229,7 @@ class Test_Manager_prefetch:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.prefetch
+        method = mock_manager_interface.mock.prefetch
         assert manager.prefetch(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
@@ -369,7 +239,7 @@ class Test_Manager_flushCaches:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session):
 
-        method = mock_manager_interface.flushCaches
+        method = mock_manager_interface.mock.flushCaches
         assert manager.flushCaches() == method.return_value
         method.assert_called_once_with(host_session)
 
@@ -379,7 +249,7 @@ class Test_Manager_isEntityReference:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs):
 
-        method = mock_manager_interface.isEntityReference
+        method = mock_manager_interface.mock.isEntityReference
         assert manager.isEntityReference(some_refs) == method.return_value
         method.assert_called_once_with(some_refs, host_session)
 
@@ -389,7 +259,7 @@ class Test_Manager_entityExists:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.entityExists
+        method = mock_manager_interface.mock.entityExists
         assert manager.entityExists(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
@@ -400,7 +270,7 @@ class Test_Manager_defaultEntityReference:
             self, manager, mock_manager_interface, host_session, a_context,
             some_entity_trait_sets):
 
-        method = mock_manager_interface.defaultEntityReference
+        method = mock_manager_interface.mock.defaultEntityReference
         assert manager.defaultEntityReference(some_entity_trait_sets, a_context) \
                 == method.return_value
         method.assert_called_once_with(some_entity_trait_sets, a_context, host_session)
@@ -411,7 +281,7 @@ class Test_Manager_entityName:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.entityName
+        method = mock_manager_interface.mock.entityName
         assert manager.entityName(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
@@ -421,7 +291,7 @@ class Test_Manager_entityDisplayNamer:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.entityDisplayName
+        method = mock_manager_interface.mock.entityDisplayName
         assert manager.entityDisplayName(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
@@ -431,7 +301,7 @@ class Test_Manager_entityVersion:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.entityVersion
+        method = mock_manager_interface.mock.entityVersion
         assert manager.entityVersion(some_refs, a_context) == method.return_value
         method.assert_called_once_with(some_refs, a_context, host_session)
 
@@ -441,7 +311,7 @@ class Test_Manager_entityVersions:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.entityVersions
+        method = mock_manager_interface.mock.entityVersions
 
         assert manager.entityVersions(some_refs, a_context) == method.return_value
         method.assert_called_once_with(
@@ -470,14 +340,14 @@ class Test_Manager_finalizedEntityVersion:
     def test_wraps_the_corresponding_method_of_the_held_interface(
             self, manager, mock_manager_interface, host_session, some_refs, a_context):
 
-        method = mock_manager_interface.finalizedEntityVersion
+        method = mock_manager_interface.mock.finalizedEntityVersion
         assert manager.finalizedEntityVersion(some_refs, a_context) == method.return_value
         method.assert_called_once_with(
             some_refs, a_context, host_session, overrideVersionName=None)
         method.reset_mock()
 
         a_version_name = "aVersion"
-        method = mock_manager_interface.finalizedEntityVersion
+        method = mock_manager_interface.mock.finalizedEntityVersion
         assert manager.finalizedEntityVersion(
             some_refs, a_context, overrideVersionName=a_version_name) == method.return_value
         method.assert_called_once_with(
@@ -492,7 +362,7 @@ class Test_Manager_getRelatedReferences:
 
         # pylint: disable=too-many-locals
 
-        method = mock_manager_interface.getRelatedReferences
+        method = mock_manager_interface.mock.getRelatedReferences
 
         one_ref = a_ref
         two_refs = [a_ref, a_ref]
@@ -538,7 +408,7 @@ class Test_Manager_resolve:
             self, manager, mock_manager_interface, host_session, some_refs, an_entity_trait_set,
             a_context):
 
-        method = mock_manager_interface.resolve
+        method = mock_manager_interface.mock.resolve
         assert manager.resolve(some_refs, an_entity_trait_set, a_context) \
                 == method.return_value
         method.assert_called_once_with(some_refs, an_entity_trait_set, a_context, host_session)
@@ -550,7 +420,7 @@ class Test_Manager_managentPolicy:
             self, manager, mock_manager_interface, host_session, some_entity_trait_sets,
             a_context):
 
-        method = mock_manager_interface.managementPolicy
+        method = mock_manager_interface.mock.managementPolicy
         assert manager.managementPolicy(some_entity_trait_sets, a_context) == method.return_value
         method.assert_called_once_with(some_entity_trait_sets, a_context, host_session)
 
@@ -561,7 +431,7 @@ class Test_Manager_preflight:
             self, manager, mock_manager_interface, host_session, some_refs, an_entity_trait_set,
             a_context):
 
-        method = mock_manager_interface.preflight
+        method = mock_manager_interface.mock.preflight
         assert manager.preflight(some_refs, an_entity_trait_set, a_context) \
                 == method.return_value
         method.assert_called_once_with(some_refs, an_entity_trait_set, a_context, host_session)
@@ -576,7 +446,7 @@ class Test_Manager_register:
         specifications = [a_specification for _ in some_refs]
         mutated_refs = [f"{r}-registered" for r in some_refs]
 
-        register_method = mock_manager_interface.register
+        register_method = mock_manager_interface.mock.register
         register_method.return_value = mutated_refs
 
         assert manager.register(some_refs, specifications, a_context) \

--- a/tests/python/openassetio/hostAPI/test_terminology.py
+++ b/tests/python/openassetio/hostAPI/test_terminology.py
@@ -27,7 +27,6 @@ import pytest
 
 import openassetio.hostAPI.terminology as tgy
 from openassetio.hostAPI import Manager, Session
-from openassetio.managerAPI import ManagerInterface
 
 
 all_terminology_keys = (
@@ -76,9 +75,9 @@ class MockTerminologyManager(Manager):
 
 
 @pytest.fixture
-def mock_manager():
+def mock_manager(mock_manager_interface):
     return MockTerminologyManager(
-        mock.create_autospec(ManagerInterface), mock.create_autospec(Session))
+        mock_manager_interface, mock.create_autospec(Session))
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #345. Migrate `Manager`'s `identifier`, `displayName` and `info` methods from Python to C++ and add Python bindings. Wrangle tests to work with the enhanced type checking caused by this.