### PR TITLE
[Build] Allow python venv build without tests

### DIFF
--- a/.github/workflows/build-instructions.yml
+++ b/.github/workflows/build-instructions.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         docker run -v `pwd`:/src aswf/ci-base:2022.2 bash -c '
           cd /src && \
-          cmake -S . -B build && cmake --build build && cmake --install build'
+          cmake -S . -B build && cmake --build build --target openassetio-python-py-install'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,16 +201,20 @@ include(ThirdParty)
 
 
 #-----------------------------------------------------------------------
+# Add a top-level install target, useful for tests and deploument to
+# ensure the project is installed. The special `install` target is
+# unavailable as a target dependency if the Unix Makefile generator
+# (default on Linux) is used, so we must shell out the install.
+
+add_custom_target(openassetio-install
+    COMMAND "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target install)
+
+
+#-----------------------------------------------------------------------
 # Enable ctest testing
 
 if (OPENASSETIO_ENABLE_TESTS)
     enable_testing()
-    # Add a top-level install target, useful for tests to ensure the
-    # project is installed. The special `install` target is unavailable
-    # as a target dependency if the Unix Makefile generator (default on
-    # Linux) is used, so we must shell out the install.
-    add_custom_target(openassetio-install
-        COMMAND "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target install)
 endif ()
 
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ via a container, from the repository root run
 ```shell
 docker run -v `pwd`:/src aswf/ci-base:2022.2 bash -c '
   cd /src && \
-  cmake -S . -B build && cmake --build build && cmake --install build'
+  cmake -S . -B build && \
+  cmake --build build --target openassetio-python-py-install'
 ```
 
 #### Other build methods

--- a/src/openassetio-python/CMakeLists.txt
+++ b/src/openassetio-python/CMakeLists.txt
@@ -78,9 +78,9 @@ if (UNIX)
 endif ()
 
 #-----------------------------------------------------------------------
-# Create convenience targets for testing
+# Create deployment targets
 
-if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
+if (Python_Interpreter_FOUND)
 
     # set up values that differ between Windows and Unixes
     if(WIN32)
@@ -100,29 +100,18 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
         COMMAND
         ${venv_python_dir}/python -m pip install --upgrade pip
     )
-    # Target to wrap the venv command so it can be executed in isolation.
+
+    # Convenience target to wrap the empty venv command so it can be
+    # executed in isolation.
     add_custom_target(
         openassetio-python-venv
         DEPENDS "${installed_pip}"
     )
 
-    # One-time step to download test-specific dependencies
-    # so we don't always need an online connection for running ctest
+    # One-time step to download project-specific dependencies
+    # so we don't always need an online connection to install
     set(deps_dir "${CMAKE_BINARY_DIR}/dependencies")
     set(python_deps_dir "${deps_dir}/python")
-    set(test_deps_dir "${python_deps_dir}/tests")
-    set(test_deps_downloaded "${deps_dir}/testDepsDwnld.out")
-    add_custom_command(
-        OUTPUT "${test_deps_downloaded}"
-        COMMAND
-        "${installed_pip}" "download" "--destination-directory" "${test_deps_dir}"
-            "-r" "${PROJECT_SOURCE_DIR}/tests/python/requirements.txt"
-        COMMAND
-        cmake -E touch "${test_deps_downloaded}"
-        DEPENDS "${installed_pip}" "${PROJECT_SOURCE_DIR}/tests/python/requirements.txt"
-    )
-
-    # One-time step to download project-specific dependencies
     set(project_deps_dir "${python_deps_dir}/project")
     set(project_deps_downloaded "${deps_dir}/projDepsDwnld.out")
     add_custom_command(
@@ -134,17 +123,6 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
         COMMAND
         cmake -E touch "${project_deps_downloaded}"
         DEPENDS "${installed_pip}"
-    )
-
-    # Command to install test-specific dependencies (e.g. pytest).
-    add_custom_command(
-        OUTPUT
-        "${venv_python_dir}/pytest"
-        COMMAND
-        "${installed_pip}" "install" "--no-index"
-            "--find-links" "${test_deps_dir}"
-            "-r" "${PROJECT_SOURCE_DIR}/tests/python/requirements.txt"
-        DEPENDS "${test_deps_downloaded}"
     )
 
     # Target to install the pure Python component of the project.
@@ -159,54 +137,85 @@ if (OPENASSETIO_ENABLE_TESTS AND Python_Interpreter_FOUND)
     # Ensure pre-requisite C++ component has been installed first.
     add_dependencies(openassetio-python-py-install openassetio-install)
 
-    # Add ASan-specific environment variables to prepend to the `pytest`
-    # invocation.
-    if (OPENASSETIO_ENABLE_SANITIZER_ADDRESS AND IS_GCC_OR_CLANG)
-        # ASan will error out if libasan is not the first library to be
-        # linked (so it can override `malloc`). Since our executable
-        # (`python` in this case) doesn't link libasan we must add it to
-        # `LD_PRELOAD`. But first we have to find libasan on the system:
-        execute_process(
-            # TODO(DF): This is probably wrong for OSX (clang).
-            COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libasan.so
-            OUTPUT_VARIABLE asan_path
-            OUTPUT_STRIP_TRAILING_WHITESPACE
+    if (OPENASSETIO_ENABLE_TESTS)
+        # One-time step to download test-specific dependencies
+        # so we don't always need an online connection for running ctest
+        set(test_deps_dir "${python_deps_dir}/tests")
+        set(test_deps_downloaded "${deps_dir}/testDepsDwnld.out")
+        add_custom_command(
+            OUTPUT "${test_deps_downloaded}"
+            COMMAND
+            "${installed_pip}" "download" "--destination-directory" "${test_deps_dir}"
+                "-r" "${PROJECT_SOURCE_DIR}/tests/python/requirements.txt"
+            COMMAND
+            cmake -E touch "${test_deps_downloaded}"
+            DEPENDS "${installed_pip}" "${PROJECT_SOURCE_DIR}/tests/python/requirements.txt"
         )
-        # ASan can hang on exceptions when `dlopen`ed libraries are
-        # involved (i.e. Python extension modules)
-        # See: https://bugs.llvm.org/show_bug.cgi?id=39641
-        # or: https://github.com/llvm/llvm-project/issues/38989
-        # and: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91325#c5
-        # The latter link indicates this bug is fixed in GCC 10.1, but
-        # we're stuck with 9.3 (CY21/22) for now.
-        # To work around this we must LD_PRELOAD our core lib.
-        set(openassetio_path
-            ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:openassetio-core>)
-        # In addition to `LD_PRELOAD`ing we must override Python's
-        # memory allocator to use the C (or rather, ASan's) `malloc`
-        # rather than the optimized `pymalloc`, so that ASan can
-        # properly count memory (de)allocations.
-        set(pytest_env PYTHONMALLOC=malloc LD_PRELOAD=${asan_path}:${openassetio_path})
+
+        # Add ASan-specific environment variables to prepend to the `pytest`
+        # invocation.
+        if (OPENASSETIO_ENABLE_SANITIZER_ADDRESS AND IS_GCC_OR_CLANG)
+            # ASan will error out if libasan is not the first library to be
+            # linked (so it can override `malloc`). Since our executable
+            # (`python` in this case) doesn't link libasan we must add it to
+            # `LD_PRELOAD`. But first we have to find libasan on the system:
+            execute_process(
+                # TODO(DF): This is probably wrong for OSX (clang).
+                COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libasan.so
+                OUTPUT_VARIABLE asan_path
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+            # ASan can hang on exceptions when `dlopen`ed libraries are
+            # involved (i.e. Python extension modules)
+            # See: https://bugs.llvm.org/show_bug.cgi?id=39641
+            # or: https://github.com/llvm/llvm-project/issues/38989
+            # and: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91325#c5
+            # The latter link indicates this bug is fixed in GCC 10.1, but
+            # we're stuck with 9.3 (CY21/22) for now.
+            # To work around this we must LD_PRELOAD our core lib.
+            set(openassetio_path
+                ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:openassetio-core>)
+            # In addition to `LD_PRELOAD`ing we must override Python's
+            # memory allocator to use the C (or rather, ASan's) `malloc`
+            # rather than the optimized `pymalloc`, so that ASan can
+            # properly count memory (de)allocations.
+            set(pytest_env PYTHONMALLOC=malloc LD_PRELOAD=${asan_path}:${openassetio_path})
+
+        endif ()
+
+
+        # Command to install test-specific dependencies (e.g. pytest).
+        add_custom_command(
+            OUTPUT
+            "${venv_python_dir}/pytest"
+            COMMAND
+            "${installed_pip}" "install" "--no-index"
+                "--find-links" "${test_deps_dir}"
+                "-r" "${PROJECT_SOURCE_DIR}/tests/python/requirements.txt"
+            DEPENDS "${test_deps_downloaded}"
+        )
+
+
+        # Target to run pytest in the install directory, ensuring the lib has
+        # been built and installed first. Add `-s` to ensure no output is
+        # captured, which is needed to show sanitizer errors (and is useful
+        # for debugging regardless).
+        add_custom_target(
+            openassetio-python-pytest
+            COMMAND ${pytest_env} "${venv_python_dir}/pytest" -s tests/python resources
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+            DEPENDS "${venv_python_dir}/pytest"
+            USES_TERMINAL
+        )
+        add_dependencies(openassetio-python-pytest openassetio-python-py-install)
+
+        # Add a CTest target.
+        add_test(
+            NAME openassetio-python
+            COMMAND
+            ${CMAKE_COMMAND} --build "${PROJECT_BINARY_DIR}" --target openassetio-python-pytest
+        )
+
     endif ()
-
-    # Target to run pytest in the install directory, ensuring the lib has
-    # been built and installed first. Add `-s` to ensure no output is
-    # captured, which is needed to show sanitizer errors (and is useful
-    # for debugging regardless).
-    add_custom_target(
-        openassetio-python-pytest
-        COMMAND ${pytest_env} "${venv_python_dir}/pytest" -s tests/python resources
-        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-        DEPENDS "${venv_python_dir}/pytest"
-        USES_TERMINAL
-    )
-    add_dependencies(openassetio-python-pytest openassetio-python-py-install)
-
-    # Add a CTest target.
-    add_test(
-        NAME openassetio-python
-        COMMAND
-        ${CMAKE_COMMAND} --build "${PROJECT_BINARY_DIR}" --target openassetio-python-pytest
-    )
 
 endif ()


### PR DESCRIPTION
As tests require extra build-time dependencies (Catch2, Trompeloeil), it limits the use of some off-the-shelf build environments such as the ASWF docker containers. Moving the venv build outside of the test-only target set allows these environments to be used to produce a working deployment without the test dependencies.

For consumers of OpenAssetIO, this is helpful, as they are most likely using a sanctioned tag/release and so don't need to test the API itself.

This will also facilitate interim CI for the `otio-openassetio` plugin.