### PR TITLE
[Core] Allow lazy trait population

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,11 @@ ij_visual_guides = 72
 
 # ij_wrap_on_typing = false
 
+[{*.h,*.hpp,*.cpp}]
+indent_size = 2
+tab_width = 2
+ij_continuation_indent_size = 4
+
 [*.feature]
 indent_size = 2
 # ij_gherkin_keep_indents_on_empty_lines = false

--- a/python/openassetio/Trait.py
+++ b/python/openassetio/Trait.py
@@ -71,3 +71,22 @@ class Trait:
         trait, `False` otherwise.
         """
         return self._specification.hasTrait(self.kId)  # pylint: disable=no-member
+
+
+    def imbue(self):
+        """
+        Adds this trait to the held specification.
+
+        If the specifcation already has this trait, it is a no-op.
+        """
+        self._specification.addTrait(self.kId)  # pylint: disable=no-member
+
+
+    @classmethod
+    def imbueTo(cls, specification):
+        """
+        Adds this trait to the provided specification.
+
+        If the specifcation already has this trait, it is a no-op.
+        """
+        specification.addTrait(cls.kId)  # pylint: disable=no-member

--- a/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
+++ b/resources/examples/manager/BasicAssetLibrary/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
@@ -115,13 +115,13 @@ class BasicAssetLibraryInterface(ManagerInterface):
             try:
                 entity_info = bal.parse_entity_ref(ref)
                 entity = bal.entity(entity_info, self.__library)
-                # Filter the entity's traits to the ones requested by the host
-                result_traits = {trait_id for trait_id in entity.traits if trait_id in traitSet}
-                result = Specification(result_traits)
-                # Populate any values we have for the result traits
-                for trait in result_traits:
-                    for property_, value in entity.traits[trait].items():
-                        result.setTraitProperty(trait, property_, value)
+                result = Specification()
+                for trait in traitSet:
+                    trait_data = entity.traits.get(trait)
+                    if trait_data is not None:
+                        result.addTrait(trait)
+                        for property_, value in trait_data.items():
+                            result.setTraitProperty(trait, property_, value)
             except Exception as exc:  # pylint: disable=broad-except
                 exc_name = exc.__class__.__name__
                 result = EntityResolutionError(f"{exc_name}: {exc}", ref)

--- a/src/openassetio-core/include/openassetio/specification/Specification.hpp
+++ b/src/openassetio-core/include/openassetio/specification/Specification.hpp
@@ -107,6 +107,25 @@ class OPENASSETIO_CORE_EXPORT Specification {
   [[nodiscard]] bool hasTrait(const trait::TraitId& traitId) const;
 
   /**
+   * Add the specified trait to this specification.
+   *
+   * If the specification already has this trait, it is a no-op.
+   *
+   * @param traitId ID of the trait to add.
+   */
+  void addTrait(const trait::TraitId& traitId);
+
+  /**
+   * Add the specified traits to this specification.
+   *
+   * If the specification already has any of the supplied traits, they
+   * are skipped.
+   *
+   * @param traitIds IDs of the traits to add.
+   */
+  void addTraits(const TraitIds& traitIds);
+
+  /**
    * Get the value of a given trait property, if the property has
    * been set.
    *

--- a/src/openassetio-core/include/openassetio/specification/Specification.hpp
+++ b/src/openassetio-core/include/openassetio/specification/Specification.hpp
@@ -75,8 +75,13 @@ class OPENASSETIO_CORE_EXPORT Specification {
   using TraitIds = std::unordered_set<trait::TraitId>;
 
   /**
+   * Construct an empty specification, with no traits.
+   */
+  Specification();
+
+  /**
    * Construct such that this specification has the given set of
-   * trait IDs.
+   * traits.
    *
    * @param traitIds The consituent traits IDs.
    */

--- a/src/openassetio-core/include/openassetio/specification/Specification.hpp
+++ b/src/openassetio-core/include/openassetio/specification/Specification.hpp
@@ -143,11 +143,12 @@ class OPENASSETIO_CORE_EXPORT Specification {
   /**
    * Set the value of given trait property.
    *
+   * If the specification does not yet have this trait, it will be
+   * added by this call.
+   *
    * @param traitId ID of trait to update.
    * @param propertyKey Key of property to set.
    * @param propertyValue Value to set.
-   * @exception `std::out_of_range` if the specification does not have
-   * this trait.
    */
   void setTraitProperty(const trait::TraitId& traitId, const trait::property::Key& propertyKey,
                         trait::property::Value propertyValue);

--- a/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
+++ b/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
@@ -108,6 +108,24 @@ struct TraitBase {
    **/
   [[nodiscard]] bool isValid() const { return specification_->hasTrait(Derived::kId); }
 
+  /**
+   * Applies this trait to the specification.
+   *
+   * If the specification already has this trait, it is a no-op.
+   **/
+  void imbue() const { specification_->addTrait(Derived::kId); }
+
+  /**
+   * Applies this trait to the supplied specification.
+   *
+   * If the specification already has this trait, it is a no-op.
+   *
+   * @param specification The specification to apply the trait to.
+   **/
+  static void imbueTo(const SpecificationPtr& specification) {
+    specification->addTrait(Derived::kId);
+  }
+
  protected:
   /**
    * Get the underlying specification that this trait is wrapping.

--- a/src/openassetio-core/specification/Specification.cpp
+++ b/src/openassetio-core/specification/Specification.cpp
@@ -51,8 +51,8 @@ class Specification::Impl {
 
   void setTraitProperty(const trait::TraitId& traitId, const trait::property::Key& propertyKey,
                         trait::property::Value propertyValue) {
-    // Use `at` deliberately to trigger exception if trait doesn't exist
-    data_.at(traitId)[propertyKey] = std::move(propertyValue);
+    // Use subscript to ensure the trait is added if it is missing
+    data_[traitId][propertyKey] = std::move(propertyValue);
   }
 
   bool operator==(const Impl& other) const { return data_ == other.data_; }

--- a/src/openassetio-core/specification/Specification.cpp
+++ b/src/openassetio-core/specification/Specification.cpp
@@ -10,6 +10,9 @@ namespace specification {
 
 class Specification::Impl {
  public:
+
+  Impl() = default;
+
   explicit Impl(const TraitIds& traitIds) {
     // Initialise data dict with supported traits.
     for (const auto& traitId : traitIds) {
@@ -57,6 +60,8 @@ class Specification::Impl {
   using PropertiesByTrait = std::unordered_map<trait::TraitId, Properties>;
   PropertiesByTrait data_;
 };
+
+Specification::Specification() : impl_{std::make_unique<Impl>()} {}
 
 Specification::Specification(const TraitIds& traitIds) : impl_{std::make_unique<Impl>(traitIds)} {}
 

--- a/src/openassetio-core/specification/Specification.cpp
+++ b/src/openassetio-core/specification/Specification.cpp
@@ -10,15 +10,9 @@ namespace specification {
 
 class Specification::Impl {
  public:
-
   Impl() = default;
 
-  explicit Impl(const TraitIds& traitIds) {
-    // Initialise data dict with supported traits.
-    for (const auto& traitId : traitIds) {
-      data_[traitId];
-    }
-  }
+  explicit Impl(const TraitIds& traitIds) { addTraits(traitIds); }
   ~Impl() = default;
 
   TraitIds traitIds() const {
@@ -32,6 +26,14 @@ class Specification::Impl {
 
   bool hasTrait(const trait::TraitId& traitId) const {
     return static_cast<bool>(data_.count(traitId));
+  }
+
+  void addTrait(const trait::TraitId& traitId) { data_[traitId]; }
+
+  void addTraits(const TraitIds& traitIds) {
+    for (const auto& traitId : traitIds) {
+      data_[traitId];
+    }
   }
 
   bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
@@ -68,6 +70,10 @@ Specification::Specification(const TraitIds& traitIds) : impl_{std::make_unique<
 Specification::~Specification() = default;
 
 Specification::TraitIds Specification::traitIds() const { return impl_->traitIds(); }
+
+void Specification::addTrait(const trait::TraitId& traitId) { impl_->addTrait(traitId); }
+
+void Specification::addTraits(const TraitIds& traitIds) { impl_->addTraits(traitIds); }
 
 bool Specification::hasTrait(const trait::TraitId& traitId) const {
   return impl_->hasTrait(traitId);

--- a/src/openassetio-python/specification/SpecificationBinding.cpp
+++ b/src/openassetio-python/specification/SpecificationBinding.cpp
@@ -20,6 +20,8 @@ void registerSpecification(const py::module& mod) {
       .def(py::init<const Specification::TraitIds&>(), py::arg("traitIds"))
       .def("traitIds", &Specification::traitIds)
       .def("hasTrait", &Specification::hasTrait, py::arg("id"))
+      .def("addTrait", &Specification::addTrait)
+      .def("addTraits", &Specification::addTraits)
       .def("setTraitProperty", &Specification::setTraitProperty, py::arg("id"),
            py::arg("propertyKey"), py::arg("propertyValue").none(false))
       .def(

--- a/src/openassetio-python/specification/SpecificationBinding.cpp
+++ b/src/openassetio-python/specification/SpecificationBinding.cpp
@@ -16,6 +16,7 @@ void registerSpecification(const py::module& mod) {
   using MaybeValue = std::optional<property::Value>;
 
   py::class_<Specification, Holder<Specification>>(mod, "Specification")
+      .def(py::init())
       .def(py::init<const Specification::TraitIds&>(), py::arg("traitIds"))
       .def("traitIds", &Specification::traitIds)
       .def("hasTrait", &Specification::hasTrait, py::arg("id"))

--- a/tests/python/openassetio/test_specification.py
+++ b/tests/python/openassetio/test_specification.py
@@ -11,6 +11,8 @@ from openassetio import Specification
 
 
 class Test_Specification_traitIds:
+    ## TODO(TC): Asset that result is a set, and not a reference to
+    ## any internal structures.
     def test_when_has_no_traits_returns_empty_list(self):
         empty_specification = Specification()
         assert empty_specification.traitIds() == set()
@@ -19,6 +21,47 @@ class Test_Specification_traitIds:
         expected_ids = {"a", "b", "🐠🐟🐠🐟"}
         populated_specification = Specification(expected_ids)
         assert populated_specification.traitIds() == expected_ids
+
+
+class Test_Specification_addTrait:
+    def test_when_trait_is_new_then_added(self):
+        specification = Specification()
+        trait_name = "a 🐍"
+        specification.addTrait(trait_name)
+        assert specification.traitIds() == {trait_name}
+
+    def test_when_trait_is_new_then_existing_traits_are_unaffected(self, a_specification):
+        trait_set = set(a_specification.traitIds())
+        new_trait = "another trait"
+        a_specification.addTrait(new_trait)
+        trait_set.add(new_trait)
+        assert a_specification.traitIds() == trait_set
+
+    def test_when_trait_already_exists_then_is_noop(self, a_specification):
+        old_traits = a_specification.traitIds()
+        a_specification.addTrait(next(iter(a_specification.traitIds())))
+        assert a_specification.traitIds() == old_traits
+
+
+class Test_Specification_addTraits:
+    def test_when_traits_are_new_the_added(self):
+        specification = Specification()
+        trait_set = {"🐌", "🐞", "🐜"}
+        specification.addTraits(trait_set)
+        assert specification.traitIds() == trait_set
+
+    def test_when_traits_are_new_then_existing_traits_are_unaffected(self, a_specification):
+        trait_set = set(a_specification.traitIds())
+        new_traits = {"🐌", "🐞", "🐜"}
+        a_specification.addTraits(new_traits)
+        expected_traits = trait_set.union(new_traits)
+        assert a_specification.traitIds() == expected_traits
+
+    def test_when_trait_ids_already_exist_then_is_noop(self, a_specification):
+        traits = a_specification.traitIds()
+        old_traits = traits
+        a_specification.addTraits(traits)
+        assert a_specification.traitIds() == old_traits
 
 
 class Test_Specification_hasTrait:

--- a/tests/python/openassetio/test_specification.py
+++ b/tests/python/openassetio/test_specification.py
@@ -12,7 +12,7 @@ from openassetio import Specification
 
 class Test_Specification_traitIds:
     def test_when_has_no_traits_returns_empty_list(self):
-        empty_specification = Specification(set())
+        empty_specification = Specification()
         assert empty_specification.traitIds() == set()
 
     def test_when_has_traits_returns_expected_trait_ids(self):

--- a/tests/python/openassetio/test_specification.py
+++ b/tests/python/openassetio/test_specification.py
@@ -90,10 +90,13 @@ class Test_Specification_getsetTraitProperty:
     def test_when_key_is_not_found_then_get_returns_None(self, a_specification):
         assert a_specification.getTraitProperty("first_trait", "a string") is None
 
-    def test_when_trait_is_not_found_then_IndexError_raised(self, a_specification):
-        with pytest.raises(IndexError):
-            a_specification.setTraitProperty("unknown_trait", "a string", "string")
+    def test_when_trait_is_not_found_then_set_adds_trait(self, a_specification):
+        new_trait_id, a_property, a_value = "a_new_trait", "a string", "string"
+        a_specification.setTraitProperty(new_trait_id, a_property, a_value)
+        assert new_trait_id in a_specification.traitIds()
+        assert a_specification.getTraitProperty(new_trait_id, a_property) == a_value
 
+    def test_when_trait_is_not_found_then_get_raises_IndexError(self, a_specification):
         with pytest.raises(IndexError):
             _ = a_specification.getTraitProperty("unknown_trait", "a string")
 

--- a/tests/python/openassetio/test_trait.py
+++ b/tests/python/openassetio/test_trait.py
@@ -47,6 +47,31 @@ class Test_Trait_isValid:
         assert trait.isValid() is False
 
 
+class Test_Trait_imbue:
+    def test_when_specification_empty_then_adds_trait(self, a_custom_trait_class):
+        a_specification = Specification()
+        trait = a_custom_trait_class(a_specification)
+        trait.imbue()
+        assert trait.isValid()
+        assert trait.kId in a_specification.traitIds()
+
+    def test_when_specification_has_trait_then_is_noop(self, a_custom_trait_class):
+        a_specification = Specification({a_custom_trait_class.kId})
+        trait = a_custom_trait_class(a_specification)
+        trait.imbue()
+
+
+class Test_Trait_imbueTo:
+    def test_when_specification_empty_then_adds_trait(self, a_custom_trait_class):
+        a_specification = Specification()
+        a_custom_trait_class.imbueTo(a_specification)
+        assert a_custom_trait_class.kId in a_specification.traitIds()
+
+    def test_when_specification_has_trait_then_is_noop(self, a_custom_trait_class):
+        a_specification = Specification({a_custom_trait_class.kId})
+        a_custom_trait_class.imbueTo(a_specification)
+
+
 @pytest.fixture
 def a_custom_trait_class():
     class CustomTrait(Trait):


### PR DESCRIPTION
Closes #335.

Assorted tweaks to the `Specification` and `Trait` APIs to make it easier to implement common scenarios.

A couple of variations:
 - I left the constructor in that takes a list of traits, as it was used a lot in tests already, and we are building a framework, so its a potentially valid use case in a manager too.
 - Happy to change the static `imbueTo` if we can think of a better name to differentiate - having the same names in C++ and Python is generally important where we can.